### PR TITLE
feat(ci): extend design-token-gate to cover stories and raw color utilities

### DIFF
--- a/scripts/eslint-rules/__tests__/no-raw-tailwind-tokens-shadow.test.cjs
+++ b/scripts/eslint-rules/__tests__/no-raw-tailwind-tokens-shadow.test.cjs
@@ -5,10 +5,10 @@ const { RuleTester } = require("eslint");
 const rule = require("../no-raw-tailwind-tokens.cjs");
 
 const tester = new RuleTester({
-  parserOptions: {
+  languageOptions: {
     ecmaVersion: 2022,
     sourceType: "module",
-    ecmaFeatures: { jsx: true },
+    parserOptions: { ecmaFeatures: { jsx: true } },
   },
 });
 

--- a/scripts/eslint-rules/__tests__/no-raw-tailwind-tokens.test.cjs
+++ b/scripts/eslint-rules/__tests__/no-raw-tailwind-tokens.test.cjs
@@ -1,0 +1,246 @@
+// @ts-nocheck — ESLint RuleTester is JS-only
+/**
+ * Comprehensive tests for creonow/no-raw-tailwind-tokens
+ *
+ * Covers:
+ *   - Shaded color utilities (bg-red-600, text-gray-300)
+ *   - Named raw color utilities (text-white, bg-black)
+ *   - Modifier prefixes (hover:text-white, focus:bg-black)
+ *   - Allowlist mechanism (opt-out for intentional exceptions)
+ *   - Stories file code (rule should apply equally)
+ *   - Shadow @theme exports (should NOT flag)
+ */
+const { RuleTester } = require("eslint");
+const rule = require("../no-raw-tailwind-tokens.cjs");
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+// ── Shaded color utilities (existing behavior) ─────────────────────
+tester.run("no-raw-tailwind-tokens — shaded colors", rule, {
+  valid: [
+    // Semantic token usage
+    { code: `const cls = "text-foreground";` },
+    { code: `const cls = "bg-surface";` },
+    { code: `const cls = "border-muted";` },
+    // CSS variable reference
+    { code: `const cls = "shadow-[var(--shadow-card)]";` },
+    // @theme-exported shadow utilities
+    { code: `const cls = "shadow-xs";` },
+    { code: `const cls = "shadow-sm";` },
+    { code: `const cls = "shadow-lg";` },
+    { code: `const cls = "shadow-xl";` },
+    { code: `const cls = "shadow-2xl";` },
+    { code: `const cls = "hover:shadow-lg";` },
+    // Non-color utilities
+    { code: `const cls = "text-lg";` },
+    { code: `const cls = "text-sm";` },
+    { code: `const cls = "bg-gradient-to-r";` },
+  ],
+  invalid: [
+    {
+      code: `const cls = "bg-red-600";`,
+      errors: [{ messageId: "rawColor" }],
+    },
+    {
+      code: `const cls = "text-gray-300";`,
+      errors: [{ messageId: "rawColor" }],
+    },
+    {
+      code: `const cls = "hover:bg-red-600";`,
+      errors: [{ messageId: "rawColor" }],
+    },
+    {
+      code: `const cls = "border-blue-500";`,
+      errors: [{ messageId: "rawColor" }],
+    },
+    {
+      code: `const cls = \`shadow-red-500/20\`;`,
+      errors: [{ messageId: "rawColor" }],
+    },
+  ],
+});
+
+// ── Named raw color utilities (new behavior) ───────────────────────
+tester.run("no-raw-tailwind-tokens — named raw colors", rule, {
+  valid: [
+    // Semantic tokens that happen to contain "white"/"black" as a substring
+    // but are NOT the raw utility pattern
+    { code: `const cls = "whitespace-nowrap";` },
+    { code: `const cls = "blackout-overlay";` },
+    // bg-transparent / text-transparent are CSS keywords, not design colors
+    { code: `const cls = "bg-transparent";` },
+    { code: `const cls = "text-transparent";` },
+    { code: `const cls = "border-transparent";` },
+    // "current" color
+    { code: `const cls = "text-current";` },
+    { code: `const cls = "border-current";` },
+    // "inherit"
+    { code: `const cls = "text-inherit";` },
+  ],
+  invalid: [
+    {
+      code: `const cls = "text-white";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "text-black";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "bg-white";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "bg-black";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "border-white";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "border-black";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "ring-white";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "ring-black";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    // With modifier prefixes
+    {
+      code: `const cls = "hover:text-white";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "focus:bg-black";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    // With opacity suffix
+    {
+      code: `const cls = "bg-black/50";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    {
+      code: `const cls = "text-white/80";`,
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    // In template literals
+    {
+      code: "const cls = `bg-white ${x}`;",
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+  ],
+});
+
+// ── Allowlist mechanism ────────────────────────────────────────────
+tester.run("no-raw-tailwind-tokens — allowlist", rule, {
+  valid: [
+    // Allowlisted named colors should pass
+    {
+      code: `const cls = "text-white";`,
+      options: [{ allowlist: ["text-white"] }],
+    },
+    {
+      code: `const cls = "bg-black";`,
+      options: [{ allowlist: ["bg-black"] }],
+    },
+    // Allowlisted shaded colors should pass
+    {
+      code: `const cls = "bg-red-600";`,
+      options: [{ allowlist: ["bg-red-600"] }],
+    },
+    // Allowlist with modifier — the base value is matched
+    {
+      code: `const cls = "hover:text-white";`,
+      options: [{ allowlist: ["text-white"] }],
+    },
+  ],
+  invalid: [
+    // Non-allowlisted value still flags
+    {
+      code: `const cls = "text-white bg-black";`,
+      options: [{ allowlist: ["text-white"] }],
+      errors: [{ messageId: "rawNamedColor" }],
+    },
+    // Allowlist doesn't apply to different patterns
+    {
+      code: `const cls = "bg-red-600";`,
+      options: [{ allowlist: ["text-white"] }],
+      errors: [{ messageId: "rawColor" }],
+    },
+  ],
+});
+
+// ── Stories file code (rule applies equally) ───────────────────────
+tester.run("no-raw-tailwind-tokens — stories coverage", rule, {
+  valid: [
+    // Story with semantic tokens — fine
+    {
+      code: `
+        export const Default = {
+          render: () => <div className="bg-surface text-foreground">Story</div>,
+        };
+      `,
+    },
+  ],
+  invalid: [
+    // Story with raw shaded color
+    {
+      code: `
+        export const Default = {
+          render: () => <div className="bg-red-500">Story</div>,
+        };
+      `,
+      errors: [{ messageId: "rawColor" }],
+    },
+    // Story with raw named color
+    {
+      code: `
+        export const Default = {
+          render: () => <div className="text-white bg-black">Story</div>,
+        };
+      `,
+      errors: [
+        { messageId: "rawNamedColor" },
+        { messageId: "rawNamedColor" },
+      ],
+    },
+  ],
+});
+
+// ── Violation type in error message ────────────────────────────────
+tester.run("no-raw-tailwind-tokens — error messages include violation type", rule, {
+  valid: [],
+  invalid: [
+    {
+      code: `const cls = "bg-red-600";`,
+      errors: [
+        {
+          messageId: "rawColor",
+          data: { value: "bg-red-600" },
+        },
+      ],
+    },
+    {
+      code: `const cls = "text-white";`,
+      errors: [
+        {
+          messageId: "rawNamedColor",
+          data: { value: "text-white" },
+        },
+      ],
+    },
+  ],
+});
+
+console.log("✅ no-raw-tailwind-tokens: all tests passed");

--- a/scripts/eslint-rules/no-raw-tailwind-tokens.cjs
+++ b/scripts/eslint-rules/no-raw-tailwind-tokens.cjs
@@ -1,19 +1,27 @@
 /**
  * Custom ESLint rule: no-raw-tailwind-tokens
  *
- * Forbids raw Tailwind color values (e.g., bg-red-600, text-gray-300)
- * in ANY string literal or template literal. This covers all usage patterns:
- *   - className="bg-red-600"           (direct JSX attribute)
- *   - className={`shadow-lg ${x}`}     (template literal)
- *   - ["shadow-2xl", ...].join(" ")    (array → join)
- *   - cn("hover:bg-red-600", ...)      (clsx/cn helper)
- *   - { color: "text-blue-400" }       (object property value)
+ * Forbids raw Tailwind color values in ANY string literal or template literal.
  *
- * Note: shadow-xs/sm/md/lg/xl/2xl are exported via @theme and map to
- * our design tokens. They are no longer flagged.
+ * Two categories of violations:
  *
- * The regex patterns are specific enough (e.g., bg-red-600) that false
- * positives on non-Tailwind strings are essentially impossible.
+ * 1. **Shaded color utilities** (rawColor):
+ *    bg-red-600, text-gray-300, border-blue-500, ring-emerald-200, etc.
+ *    Also with modifiers (hover:bg-red-600) and opacity (bg-red-600/50).
+ *
+ * 2. **Named raw color utilities** (rawNamedColor):
+ *    text-white, text-black, bg-white, bg-black, border-white, etc.
+ *    These bypass the design token system by using CSS named colors directly.
+ *
+ * Allowed exceptions:
+ *   - shadow-xs/sm/md/lg/xl/2xl — exported via @theme, map to design tokens
+ *   - bg-transparent, text-transparent — CSS keyword, not a design color
+ *   - text-current, border-current — CSS keyword
+ *   - text-inherit — CSS keyword
+ *   - Explicit allowlist via rule options
+ *
+ * Coverage: applies to all .ts/.tsx files including *.stories.tsx.
+ * The lint-ratchet runner uses `--ext .ts,.tsx` which includes stories.
  *
  * @see docs/references/design-ui-architecture.md
  */
@@ -28,17 +36,53 @@ const rule = {
     },
     messages: {
       rawColor:
-        "Avoid raw Tailwind color '{{value}}'. Use a semantic Design Token instead. See docs/references/design-ui-architecture.md.",
+        "[shaded-color] Avoid raw Tailwind color '{{value}}'. Use a semantic Design Token instead. See docs/references/design-ui-architecture.md.",
+      rawNamedColor:
+        "[named-color] Avoid raw Tailwind color '{{value}}'. Use a semantic Design Token (e.g. text-foreground, bg-surface) instead. See docs/references/design-ui-architecture.md.",
     },
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowlist: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Explicit list of raw color utilities to allow (e.g. ['text-white'] for a known exception). The base utility without modifier prefix is matched.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {
-    // Matches: bg-red-600, text-gray-300, border-blue-500, ring-emerald-200, etc.
-    // Also matches modifier prefixes: hover:bg-red-600, focus:text-gray-300
-    // Also matches opacity suffixes: shadow-red-500/20, bg-red-600/50
+    const options = context.options[0] || {};
+    const allowlist = new Set(options.allowlist || []);
+
+    // ── Pattern 1: Shaded color utilities ──────────────────────────
+    // Matches: bg-red-600, text-gray-300, border-blue-500, etc.
+    // Also matches modifier prefixes: hover:bg-red-600
+    // Also matches opacity suffixes: shadow-red-500/20
     const RAW_COLOR_RE =
-      /\b(?:[\w-]*:)?(?:bg|text|border|ring|shadow|outline|fill|stroke|from|via|to|divide|placeholder|accent|caret|decoration)-(?:red|blue|green|yellow|purple|pink|indigo|violet|cyan|teal|emerald|lime|amber|orange|fuchsia|rose|sky|slate|gray|zinc|neutral|stone|warm)-\d{1,3}(?:\/\d{1,3})?\b/g;
+      /\b(?:([\w-]*):)?(?:bg|text|border|ring|shadow|outline|fill|stroke|from|via|to|divide|placeholder|accent|caret|decoration)-(?:red|blue|green|yellow|purple|pink|indigo|violet|cyan|teal|emerald|lime|amber|orange|fuchsia|rose|sky|slate|gray|zinc|neutral|stone|warm)-\d{1,3}(?:\/\d{1,3})?\b/g;
+
+    // ── Pattern 2: Named raw color utilities ───────────────────────
+    // Matches: text-white, bg-black, border-white, ring-black, etc.
+    // Does NOT match: bg-transparent, text-current, text-inherit (CSS keywords)
+    // Does NOT match: whitespace-nowrap (not a color utility prefix)
+    const RAW_NAMED_COLOR_RE =
+      /\b(?:([\w-]*):)?(bg|text|border|ring|shadow|outline|fill|stroke|from|via|to|divide|placeholder|accent|caret|decoration)-(white|black)(?:\/(\d{1,3}))?\b/g;
+
+    /**
+     * Strip modifier prefix to get the base utility for allowlist matching.
+     * "hover:text-white" → "text-white"
+     */
+    function stripModifier(matched) {
+      const colonIdx = matched.lastIndexOf(":");
+      if (colonIdx === -1) return matched;
+      return matched.slice(colonIdx + 1);
+    }
 
     /**
      * Check a string value for raw Tailwind tokens.
@@ -46,12 +90,27 @@ const rule = {
      * @param {string} value
      */
     function checkValue(node, value) {
+      // Check shaded colors (bg-red-600 etc.)
       let match;
       RAW_COLOR_RE.lastIndex = 0;
       while ((match = RAW_COLOR_RE.exec(value)) !== null) {
+        const base = stripModifier(match[0]);
+        if (allowlist.has(base)) continue;
         context.report({
           node,
           messageId: "rawColor",
+          data: { value: match[0] },
+        });
+      }
+
+      // Check named colors (text-white, bg-black etc.)
+      RAW_NAMED_COLOR_RE.lastIndex = 0;
+      while ((match = RAW_NAMED_COLOR_RE.exec(value)) !== null) {
+        const base = stripModifier(match[0]);
+        if (allowlist.has(base)) continue;
+        context.report({
+          node,
+          messageId: "rawNamedColor",
           data: { value: match[0] },
         });
       }
@@ -64,8 +123,6 @@ const rule = {
      */
     function isInsideComment(node) {
       const parent = node.parent;
-      // Skip string literals that are the expression of an ExpressionStatement
-      // at the Program/top level (often stray doc strings that got parsed).
       return (
         parent &&
         parent.type === "ExpressionStatement" &&


### PR DESCRIPTION
## Summary

扩展 `no-raw-tailwind-tokens` ESLint 规则，覆盖此前的两个盲区：

1. **Named raw color utilities**：拦截 `text-white`、`text-black`、`bg-white`、`bg-black` 等绕过 Design Token 的命名色值
2. **Stories 文件覆盖**：确认 lint-ratchet 的 `--ext .ts,.tsx` 已覆盖 `*.stories.tsx`

## Changes

### Rule Enhancement (`scripts/eslint-rules/no-raw-tailwind-tokens.cjs`)

- **新增 `RAW_NAMED_COLOR_RE` 正则**：匹配 `{prefix}-white` / `{prefix}-black`（含修饰符前缀、透明度后缀）
- **新增 `rawNamedColor` messageId**：错误输出带 `[named-color]` 前缀，原有的带 `[shaded-color]`，文件行号由 ESLint 引擎自动提供
- **新增 `allowlist` schema option**：通过 `options: [{ allowlist: ['text-white'] }]` 显式豁免特定用法，而非静默放行
- **`stripModifier` 辅助函数**：`hover:text-white` → `text-white`，用于 allowlist 匹配

### Tests (`scripts/eslint-rules/__tests__/no-raw-tailwind-tokens.test.cjs`)

- 5 个测试组：shaded colors / named raw colors / allowlist / stories coverage / error messages
- 覆盖 valid + invalid 用例，包括模板字面量、修饰符前缀、透明度后缀、JSX stories 代码

### Bug Fix

- 修复 `no-raw-tailwind-tokens-shadow.test.cjs` 使用 eslintrc format 导致 ESLint 9 报错的问题

## Verification

```
✅ no-raw-tailwind-tokens: all tests passed
✅ no-raw-tailwind-tokens (shadow — @theme allowed): all tests passed
```

## Rollback

还原 `scripts/eslint-rules/no-raw-tailwind-tokens.cjs` 到前一版本即可回退。allowlist 为 opt-in，不影响现有行为。

Closes #5