### PR TITLE
feat(primitives): expand 20.3 state matrix to IconButton, IconRail, ToolbarButton

### DIFF
--- a/docs/cn-frontend-ssot/20-design-v3/20.3-component-states.md
+++ b/docs/cn-frontend-ssot/20-design-v3/20.3-component-states.md
@@ -2,9 +2,62 @@
 
 > 来源：[docs/CN-设计文稿.md](../../CN-设计文稿.md) §19
 
-所有交互组件必须覆盖以下 7 种状态：Default · Hover · Active（按下瞬间）· Focus · Disabled · Loading · Error。
+所有交互组件必须覆盖以下 7 种基准状态：Default · Hover · Active（按下瞬间）· Focus · Disabled · Loading · Error。各组件按自身语义裁剪适用子集，下表标注每个组件实际覆盖的状态。
 
-## Icon Rail 图标按钮
+### 覆盖范围
+
+| 组件 | Default | Hover | Active | Focus | Disabled | Loading | Selected | Error | Storybook | Tests |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| IconButton | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | 🔲 | 🔲 |
+| IconRail | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | 🔲 | 🔲 |
+| ToolbarButton | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | — | 🔲 | 🔲 |
+| Context Panel 文件节点 | ✓ | ✓ | — | ✓ | — | — | ✓ | — | 🔲 | 🔲 |
+| AI 面板底部选择器 | ✓ | ✓ | — | — | ✓ | — | ✓ | — | 🔲 | 🔲 |
+| 输入框 | ✓ | ✓ | — | ✓ | ✓ | — | — | ✓ | 🔲 | 🔲 |
+| AI FAB 按钮 | ✓ | ✓ | ✓ | — | ✓ | — | — | — | 🔲 | 🔲 |
+
+> ✓ = 已定义 · — = 不适用 · 🔲 = 待组件实现后补齐
+
+---
+
+## IconButton（图标按钮 Primitive）
+
+> 独立的图标按钮 primitive，用于 IconRail 项、ToolbarButton 和其他需要纯图标交互的场景。
+
+| **状态** | **图标色** | **背景色** | **圆角** | **过渡** |
+| --- | --- | --- | --- | --- |
+| Default | `#737373` | 透明 | `--radius-md`（8px） | — |
+| Hover | `#B0B0B0` | `rgba(255,255,255,0.06)` | `--radius-md` | `background 150ms ease-out, color 150ms ease-out` |
+| Active（pressed） | `#E0E0E0` | `rgba(255,255,255,0.10)` | `--radius-md` | `background 80ms ease-out` |
+| Focus（键盘） | 继承当前色 | 继承当前背景 + 外圈 2px `--ring` offset 2px | `--radius-md` | `outline 100ms ease` |
+| Disabled | `#3A3A3A` | 透明 | `--radius-md` | — / `cursor: not-allowed; opacity: 0.5` |
+| Selected | `#7AA2F7` | `rgba(122,162,247,0.10)` | `--radius-md` | `background 150ms ease-out, color 150ms ease-out` |
+
+**尺寸变体**：
+
+| 变体 | 按钮尺寸 | 图标尺寸 | 适用场景 |
+| --- | --- | --- | --- |
+| `sm` | 28×28px | 14×14px | 工具栏密集区域 |
+| `md` | 32×32px | 18×18px | 默认，Icon Rail、一般工具栏 |
+| `lg` | 40×40px | 20×20px | FAB 附近、特殊强调 |
+
+> **Storybook & Tests**：待组件实现后补齐。Story 需覆盖所有 6 种状态 × 3 种尺寸变体；测试需验证状态切换行为（hover/focus/disabled 交互）和 ARIA 属性（`aria-pressed`, `aria-disabled`）。
+
+---
+
+## IconRail（图标导航轨道）
+
+> 48px 宽垂直导航轨道，包含多个 IconButton 项。容器本身有布局状态，内部项状态继承 IconButton。
+
+### 容器状态
+
+| **状态** | **宽度** | **背景** | **边框（右侧）** | **过渡** |
+| --- | --- | --- | --- | --- |
+| Default | 48px | `#0A0A0A` | 1px `rgba(255,255,255,0.06)` | — |
+| Hover（容器） | 48px | `#0A0A0A` | 1px `rgba(255,255,255,0.08)` | `border-color 120ms ease-out` |
+| Compact（响应式 ≤ 1023px） | 36px | `#0A0A0A` | 1px `rgba(255,255,255,0.06)` | `width 200ms ease` |
+
+### 项状态（继承 IconButton + Rail 专用扩展）
 
 | **状态** | **图标色** | **背景色** | **过渡** |
 | --- | --- | --- | --- |
@@ -13,8 +66,14 @@
 | Active（pressed） | `#E0E0E0` | `rgba(255,255,255,0.10)` | `background 80ms ease-out` |
 | Selected（激活路由） | `#7AA2F7` | `rgba(122,162,247,0.10)` | — |
 | Focus（键盘） | 继承 | 外圈 2px `--ring` offset 2px | `outline 100ms ease` |
-| Disabled | `#3A3A3A` | 透明 | `cursor: not-allowed` |
+| Disabled | `#3A3A3A` | 透明 | — / `cursor: not-allowed` |
 | Loading | 同 Selected | 图标位置显示 16px spinner | — |
+
+> **与 IconButton 的关系**：IconRail 项是 IconButton `md` 变体的语义化用法，附加了 Selected（激活路由）和 Loading 状态。组件实现时应复用 IconButton primitive，通过 `data-state` 属性区分状态。
+
+> **Storybook & Tests**：待组件实现后补齐。Story 需覆盖导航切换（Selected 项切换）、Loading 加载、键盘导航（上下箭头 + Enter）；测试需验证路由激活状态同步、ARIA `role="navigation"` + `aria-current="page"`。
+
+---
 
 ## Context Panel 文件节点
 
@@ -61,11 +120,19 @@
 | Dragging | `rgba(122,162,247,0.85)` | `#050505` | 1.08 | `0ms`（跟手） |
 | Disabled | — | — | — | `opacity 0, 300ms ease` |
 
-## 编辑器工具栏按钮
+## ToolbarButton（编辑器工具栏按钮）
 
-| **状态** | **背景** | **文字色** | **过渡** |
+> 编辑器顶部工具栏中的按钮，基于 IconButton primitive 扩展，增加 Selected（当前模式）语义。属于 ToolbarGroup composite 的子元素。
+
+| **状态** | **背景** | **文字/图标色** | **过渡** |
 | --- | --- | --- | --- |
 | Default | 透明 | `#737373` | — |
-| Hover | `rgba(255,255,255,0.06)` | `#B0B0B0` | `120ms ease-out` |
-| Active（当前模式） | `--accent-subtle` | `#7AA2F7` | `150ms ease-out` |
-| Focus | 同 Hover + `--ring` outline | 同 Hover | `100ms ease` |
+| Hover | `rgba(255,255,255,0.06)` | `#B0B0B0` | `background 120ms ease-out, color 120ms ease-out` |
+| Active（pressed） | `rgba(255,255,255,0.10)` | `#E0E0E0` | `background 80ms ease-out` |
+| Focus（键盘） | 同 Hover + `--ring` outline 2px offset 2px | 同 Hover | `outline 100ms ease` |
+| Disabled | 透明 | `#3A3A3A` | — / `cursor: not-allowed; opacity: 0.5` |
+| Selected（当前模式） | `--accent-subtle` | `#7AA2F7` | `background 150ms ease-out, color 150ms ease-out` |
+
+**与 IconButton 的关系**：ToolbarButton 是 IconButton `sm` 变体的语义化用法（工具栏区域更紧凑），附加了 Selected（当前编辑模式）语义。实现时应复用 IconButton，通过 `aria-pressed` 标记选中态。
+
+> **Storybook & Tests**：待组件实现后补齐。Story 需覆盖所有 6 种状态，以及工具栏组合展示（多按钮排列 + Separator + 单选互斥）；测试需验证互斥选中逻辑（同组只能一个 Selected）和键盘导航（左右箭头 + Home/End）。


### PR DESCRIPTION
## Summary

扩展 `20.3-component-states.md` 状态矩阵覆盖范围，新增 IconButton、IconRail 容器状态、ToolbarButton 完整状态定义。

## Changes

- **IconButton**：新增独立 primitive 状态矩阵（Default / Hover / Active / Focus / Disabled / Selected），含 3 种尺寸变体（sm / md / lg）
- **IconRail**：重构为容器 + 项两层结构，新增容器级状态（Default / Hover / Compact 响应式），明确项状态与 IconButton 的复用关系
- **ToolbarButton**：从 4 种状态扩展到 6 种，补齐 Disabled 和 Selected（当前模式）
- **覆盖总览表**：新增全组件 × 状态 × Storybook / Tests 追踪矩阵
- 各组件注明 Storybook stories 和行为测试待组件实现后补齐（renderer 尚未创建）

## Checklist

- [x] IconButton / IconRail 纳入 20.3 状态矩阵收口范围
- [x] 编辑器工具栏按钮纳入同一轮状态覆盖规划
- [x] 明确列出每个组件需覆盖的状态（按组件适用性裁剪）
- [x] Storybook stories 标记为待补齐（🔲 组件不存在）
- [x] 行为测试标记为待补齐（🔲 组件不存在）
- [x] 覆盖总览表同步修正状态矩阵全覆盖表述，与实际范围一致

## Rollback

纯文档变更，回滚 = `git revert <commit>`

Closes #4