### PR TITLE
feat(p2): WritingOrchestrator × ToolUseHandler agentic loop 主缝接线

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
@@ -13,6 +13,7 @@ vi.mock("../../services/skills/skillExecutor", () => ({
 }));
 
 vi.mock("../../services/skills/orchestrator", () => ({
+  AGENTIC_MAX_ROUNDS: 5,
   createWritingOrchestrator: vi.fn(() => ({
     execute: orchestratorExecuteSpy,
     abort: vi.fn(),

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -9,6 +9,7 @@ import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
 } from "@shared/types/ai";
 import type { Logger } from "../logging/logger";
@@ -39,7 +40,8 @@ import {
   createWritingOrchestrator,
   type WritingEvent,
 } from "../services/skills/orchestrator";
-import { createWritingToolRegistry } from "../services/skills/writingTooling";
+import { createWritingToolRegistry, createAgenticToolRegistry } from "../services/skills/writingTooling";
+import { createToolUseHandler } from "../services/skills/toolUseHandler";
 import { estimateTokens } from "../services/context/tokenEstimation";
 import { createDocumentService } from "../services/documents/documentService";
 import { editorSchema } from "../services/editor/prosemirrorSchema";
@@ -597,6 +599,42 @@ function emitOrchestratorChunk(args: {
     sender: args.sender,
     event,
   });
+}
+
+/** P2: Emit a tool-use event to the renderer via SKILL_TOOL_USE_CHANNEL */
+function emitOrchestratorToolUse(args: {
+  ctx: AiIpcContext;
+  sender: Electron.WebContents;
+  executionId: string;
+  runId: string;
+  event: WritingEvent;
+}): void {
+  const { event } = args;
+  if (
+    event.type !== "tool-use-started" &&
+    event.type !== "tool-use-completed" &&
+    event.type !== "tool-use-failed"
+  ) {
+    return;
+  }
+  const base = {
+    executionId: args.executionId,
+    runId: args.runId,
+    ts: nowTs(),
+  };
+  const payload =
+    event.type === "tool-use-started"
+      ? { ...base, type: "tool-use-started" as const, round: Number(event.round), toolNames: (event.toolNames as string[]) ?? [] }
+      : event.type === "tool-use-completed"
+      ? { ...base, type: "tool-use-completed" as const, round: Number(event.round), results: (event.results as Array<{ toolName: string; success: boolean; durationMs: number }>) ?? [], hasNextRound: Boolean(event.hasNextRound) }
+      : { ...base, type: "tool-use-failed" as const, round: Number(event.round), error: (event.error as { code: string; message: string; retryable: boolean }) };
+  try {
+    args.sender.send(SKILL_TOOL_USE_CHANNEL, payload);
+  } catch (error) {
+    args.ctx.deps.logger.error("ai_tool_use_send_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 function emitOrchestratorDone(args: {
@@ -1315,6 +1353,24 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
             db: deps.db,
             logger: deps.logger,
           }),
+    // P2: Agentic tool-use handler backed by read-only tools only
+    toolUseHandler: createToolUseHandler(
+      deps.db === null
+        ? createAgenticToolRegistry({
+            db: {} as Database.Database,
+            logger: deps.logger,
+          })
+        : createAgenticToolRegistry({
+            db: deps.db,
+            logger: deps.logger,
+          }),
+      {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      },
+    ),
     permissionGate,
     postWritingHooks: [
       {
@@ -1657,6 +1713,22 @@ async function drainPreviewUntilPause(args: {
       continue;
     }
 
+    // P2: Forward tool-use events to renderer
+    if (
+      event.type === "tool-use-started" ||
+      event.type === "tool-use-completed" ||
+      event.type === "tool-use-failed"
+    ) {
+      emitOrchestratorToolUse({
+        ctx: args.ctx,
+        sender: args.sender,
+        executionId: args.executionId,
+        runId: args.runId,
+        event,
+      });
+      continue;
+    }
+
     if (event.type === "permission-denied") {
       emitOrchestratorDone({
         ctx: args.ctx,
@@ -1912,6 +1984,8 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
         modelId: normalizedPayload.model,
         ...(normalizedPayload.selection ? { selection: normalizedPayload.selection } : {}),
         ...(cursorPosition === undefined ? {} : { cursorPosition }),
+        // P2: enable agentic loop for the 'continue' skill
+        agenticLoop: leafSkillId(normalizedPayload.skillId) === "continue",
       });
 
       rememberRunInRegistry(ctx, {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -38,9 +38,11 @@ import { createDbNotReadyError } from "./dbError";
 import type { ProjectSessionBindingRegistry } from "./projectSessionBinding";
 import {
   createWritingOrchestrator,
+  AGENTIC_MAX_ROUNDS,
   type WritingEvent,
 } from "../services/skills/orchestrator";
 import { createWritingToolRegistry, createAgenticToolRegistry } from "../services/skills/writingTooling";
+import { createToolRegistry } from "../services/skills/toolRegistry";
 import { createToolUseHandler } from "../services/skills/toolUseHandler";
 import { estimateTokens } from "../services/context/tokenEstimation";
 import { createDocumentService } from "../services/documents/documentService";
@@ -1345,10 +1347,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
     },
     toolRegistry:
       deps.db === null
-        ? createWritingToolRegistry({
-            db: {} as Database.Database,
-            logger: deps.logger,
-          })
+        ? createToolRegistry()
         : createWritingToolRegistry({
             db: deps.db,
             logger: deps.logger,
@@ -1356,16 +1355,13 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
     // P2: Agentic tool-use handler backed by read-only tools only
     toolUseHandler: createToolUseHandler(
       deps.db === null
-        ? createAgenticToolRegistry({
-            db: {} as Database.Database,
-            logger: deps.logger,
-          })
+        ? createToolRegistry()
         : createAgenticToolRegistry({
             db: deps.db,
             logger: deps.logger,
           }),
       {
-        maxToolRounds: 5,
+        maxToolRounds: AGENTIC_MAX_ROUNDS,
         toolTimeoutMs: 10_000,
         maxConcurrentTools: 4,
         agenticLoop: true,
@@ -1426,13 +1422,15 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       }
       return prepared.data;
     },
-    generateText: async ({ request, signal, emitChunk }) => {
+    generateText: async ({ request, signal, emitChunk, messages }) => {
       let outputText = "";
       let usage = {
         promptTokens: 0,
         completionTokens: 0,
         totalTokens: 0,
       };
+      let capturedFinishReason: "stop" | "tool_use" | undefined;
+      let capturedToolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> | undefined;
       let sawStreamChunk = false;
       let streamTerminalSeen = false;
       let settleStreamCompletion: (() => void) | null = null;
@@ -1441,6 +1439,96 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         settleStreamCompletion = resolve;
         rejectStreamCompletion = reject;
       });
+
+      const onDoneEvent = (event: { type: "done"; outputText: string; terminal: string; error?: { message?: string; code?: string }; result?: { metadata: { promptTokens: number; completionTokens: number } }; finishReason?: "stop" | "tool_use"; toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }> }) => {
+        if (!sawStreamChunk && event.outputText.length > 0) {
+          outputText = event.outputText;
+          emitChunk(event.outputText, estimateTokens(event.outputText));
+          sawStreamChunk = true;
+        } else {
+          outputText = event.outputText;
+        }
+        usage = {
+          promptTokens: event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request)),
+          completionTokens:
+            event.result?.metadata.completionTokens ?? estimateTokens(event.outputText),
+          totalTokens:
+            (event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request))) +
+            (event.result?.metadata.completionTokens ?? estimateTokens(event.outputText)),
+        };
+        // F1: capture finishReason and toolCalls from the done event
+        if (event.finishReason !== undefined) {
+          capturedFinishReason = event.finishReason;
+        }
+        if (event.toolCalls !== undefined) {
+          capturedToolCalls = event.toolCalls;
+        }
+        streamTerminalSeen = true;
+        if (event.terminal === "completed") {
+          settleStreamCompletion?.();
+        } else {
+          rejectStreamCompletion?.(
+            Object.assign(
+              new Error(
+                event.error?.message ??
+                  (event.terminal === "cancelled"
+                    ? "AI request canceled"
+                    : "AI stream failed"),
+              ),
+              {
+                code: event.error?.code ?? "AI_SERVICE_ERROR",
+                terminal: event.terminal,
+              },
+            ),
+          );
+        }
+      };
+
+      // F2: when messages is provided (agentic loop rounds 2+), call aiService directly
+      // bypassing skillExecutor so that the accumulated tool-result messages are forwarded
+      if (messages && messages.length > 0) {
+        const res = await aiService.runSkill({
+          skillId: request.skillId,
+          input: messages[messages.length - 1]?.content ?? "",
+          mode: "ask",
+          model: request.modelId ?? "default",
+          context: {
+            projectId: request.projectId,
+            documentId: request.documentId,
+          },
+          stream: true,
+          ts: nowTs(),
+          overrideMessages: messages,
+          emitEvent: (event) => {
+            if (signal.aborted) return;
+            if (event.type === "chunk") {
+              sawStreamChunk = true;
+              outputText += event.chunk;
+              const accumulatedTokens = estimateTokens(outputText);
+              emitChunk(event.chunk, accumulatedTokens);
+              return;
+            }
+            if (event.type === "done") {
+              onDoneEvent(event as Parameters<typeof onDoneEvent>[0]);
+            }
+          },
+        });
+        if (!res.ok) throw res.error;
+        if (!streamTerminalSeen) await streamCompletion;
+        if (!sawStreamChunk && (res.data.outputText?.length ?? 0) > 0) {
+          const finalOutput = res.data.outputText ?? "";
+          outputText = finalOutput;
+          emitChunk(finalOutput, estimateTokens(finalOutput));
+        }
+        return {
+          fullText: outputText || res.data.outputText || "",
+          usage,
+          finishReason: capturedFinishReason,
+          toolCalls: capturedToolCalls,
+        };
+      }
+
+      // First call: use skillExecutor for full context assembly
       const res = await skillExecutor.execute({
         skillId: request.skillId,
         hasSelection: Boolean(request.selection),
@@ -1468,40 +1556,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
             return;
           }
           if (event.type === "done") {
-            if (!sawStreamChunk && event.outputText.length > 0) {
-              outputText = event.outputText;
-              emitChunk(event.outputText, estimateTokens(event.outputText));
-              sawStreamChunk = true;
-            } else {
-              outputText = event.outputText;
-            }
-            usage = {
-              promptTokens: event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request)),
-              completionTokens:
-                event.result?.metadata.completionTokens ?? estimateTokens(event.outputText),
-              totalTokens:
-                (event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request))) +
-                (event.result?.metadata.completionTokens ?? estimateTokens(event.outputText)),
-            };
-            streamTerminalSeen = true;
-            if (event.terminal === "completed") {
-              settleStreamCompletion?.();
-            } else {
-              rejectStreamCompletion?.(
-                Object.assign(
-                  new Error(
-                    event.error?.message ??
-                      (event.terminal === "cancelled"
-                        ? "AI request canceled"
-                        : "AI stream failed"),
-                  ),
-                  {
-                    code: event.error?.code ?? "AI_SERVICE_ERROR",
-                    terminal: event.terminal,
-                  },
-                ),
-              );
-            }
+            onDoneEvent(event as Parameters<typeof onDoneEvent>[0]);
           }
         },
       });
@@ -1519,6 +1574,8 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       return {
         fullText: outputText || res.data.outputText || "",
         usage,
+        finishReason: capturedFinishReason,
+        toolCalls: capturedToolCalls,
       };
     },
   });

--- a/apps/desktop/main/src/services/ai/__tests__/aiService-override-messages-tool.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiService-override-messages-tool.test.ts
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+
+import type { AiStreamDoneEvent, AiStreamEvent } from "@shared/types/ai";
+import { describe, it } from "vitest";
+import type { Logger } from "../../../logging/logger";
+import { createAiService } from "../aiService";
+
+function nopLogger(): Logger {
+  return { logPath: "<test>", info: () => {}, error: () => {} };
+}
+
+type CapturedBody = {
+  stream?: boolean;
+  system?: string;
+  messages?: unknown[];
+};
+
+function makeDoneWaiter() {
+  let expectedExecId: string | null = null;
+  let buffered: AiStreamDoneEvent | null = null;
+  let resolve: (e: AiStreamDoneEvent) => void = () => undefined;
+  const promise = new Promise<AiStreamDoneEvent>((r) => {
+    resolve = r;
+  });
+  const maybeResolve = () => {
+    if (expectedExecId && buffered && buffered.executionId === expectedExecId) {
+      resolve(buffered);
+    }
+  };
+  return {
+    promise,
+    setExecutionId(id: string) {
+      expectedExecId = id;
+      maybeResolve();
+    },
+    onEvent(ev: AiStreamEvent) {
+      if (ev.type !== "done") {
+        return;
+      }
+      buffered = ev;
+      maybeResolve();
+    },
+  };
+}
+
+describe("aiService overrideMessages tool history", () => {
+  it("保留 OpenAI tool message 的 tool_call_id", async () => {
+    const captured: CapturedBody[] = [];
+    const originalFetch = globalThis.fetch;
+
+    try {
+      globalThis.fetch = (async (_url, init) => {
+        const body = JSON.parse(
+          typeof init?.body === "string" ? init.body : "{}",
+        ) as CapturedBody;
+        captured.push(body);
+        if (body.stream) {
+          return new Response(
+            `data: ${JSON.stringify({ choices: [{ delta: { content: "ok" } }] })}\n\n` +
+              "data: [DONE]\n\n",
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch;
+
+      const svc = createAiService({
+        logger: nopLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "openai",
+          CREONOW_AI_BASE_URL: "https://api.openai.com",
+          CREONOW_AI_API_KEY: "sk-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      const waiter = makeDoneWaiter();
+      const res = await svc.runSkill({
+        skillId: "builtin:polish",
+        input: "continue",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: true,
+        ts: Date.now(),
+        emitEvent: waiter.onEvent,
+        overrideMessages: [
+          { role: "system", content: "You are a writing assistant." },
+          { role: "user", content: "Please do X." },
+          { role: "assistant", content: "I will call a tool." },
+          { role: "tool", content: '{"result":"done"}', toolCallId: "call_abc123" },
+          { role: "user", content: "continue" },
+        ],
+      });
+
+      assert.equal(res.ok, true, `runSkill failed: ${JSON.stringify(!res.ok && res)}`);
+      if (res.ok) {
+        waiter.setExecutionId(res.data.executionId);
+      }
+      await waiter.promise;
+
+      const msgs = captured[0]?.messages as
+        | Array<{ role?: string; tool_call_id?: string; content?: string }>
+        | undefined;
+      assert.ok(Array.isArray(msgs), "OpenAI request must include messages array");
+
+      const toolMsg = msgs?.find((m) => m.role === "tool");
+      assert.ok(toolMsg, "tool message must be present in OpenAI request");
+      assert.equal(toolMsg?.tool_call_id, "call_abc123");
+      assert.equal(toolMsg?.content, '{"result":"done"}');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("保留多个 OpenAI tool message 的各自 tool_call_id", async () => {
+    const captured: CapturedBody[] = [];
+    const originalFetch = globalThis.fetch;
+
+    try {
+      globalThis.fetch = (async (_url, init) => {
+        const body = JSON.parse(
+          typeof init?.body === "string" ? init.body : "{}",
+        ) as CapturedBody;
+        captured.push(body);
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch;
+
+      const svc = createAiService({
+        logger: nopLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "openai",
+          CREONOW_AI_BASE_URL: "https://api.openai.com",
+          CREONOW_AI_API_KEY: "sk-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      await svc.runSkill({
+        skillId: "builtin:polish",
+        input: "go",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: false,
+        ts: Date.now(),
+        emitEvent: () => {},
+        overrideMessages: [
+          { role: "user", content: "call two tools" },
+          { role: "assistant", content: "ok" },
+          { role: "tool", content: "result-1", toolCallId: "call_t1" },
+          { role: "tool", content: "result-2", toolCallId: "call_t2" },
+          { role: "user", content: "go" },
+        ],
+      });
+
+      const msgs = (captured[0]?.messages ?? []) as Array<{
+        role?: string;
+        tool_call_id?: string;
+      }>;
+      const toolMsgs = msgs.filter((m) => m.role === "tool");
+      assert.equal(toolMsgs.length, 2);
+      assert.equal(toolMsgs[0]?.tool_call_id, "call_t1");
+      assert.equal(toolMsgs[1]?.tool_call_id, "call_t2");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("将 Anthropic tool history 转成 tool_result block", async () => {
+    const captured: CapturedBody[] = [];
+    const originalFetch = globalThis.fetch;
+
+    try {
+      globalThis.fetch = (async (_url, init) => {
+        const body = JSON.parse(
+          typeof init?.body === "string" ? init.body : "{}",
+        ) as CapturedBody;
+        captured.push(body);
+        if (body.stream) {
+          return new Response(
+            "event: content_block_delta\n" +
+              `data: ${JSON.stringify({ delta: { text: "ok" } })}\n\n` +
+              "event: message_stop\ndata: {}\n\n",
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({ content: [{ text: "ok" }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch;
+
+      const svc = createAiService({
+        logger: nopLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "anthropic",
+          CREONOW_AI_BASE_URL: "https://api.anthropic.com",
+          CREONOW_AI_API_KEY: "sk-ant-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      const waiter = makeDoneWaiter();
+      const res = await svc.runSkill({
+        skillId: "builtin:polish",
+        input: "continue",
+        mode: "ask",
+        model: "claude-3-5-sonnet",
+        stream: true,
+        ts: Date.now(),
+        emitEvent: waiter.onEvent,
+        overrideMessages: [
+          { role: "user", content: "call a tool please" },
+          { role: "assistant", content: "Calling the tool." },
+          { role: "tool", content: '{"text":"fetched content"}', toolCallId: "toolu_xyz" },
+          { role: "user", content: "continue" },
+        ],
+      });
+
+      assert.equal(res.ok, true, `runSkill failed: ${JSON.stringify(!res.ok && res)}`);
+      if (res.ok) {
+        waiter.setExecutionId(res.data.executionId);
+      }
+      await waiter.promise;
+
+      const msgs = (captured[0]?.messages ?? []) as Array<{
+        role?: string;
+        content?: string | Array<{ type?: string; tool_use_id?: string; content?: string }>;
+      }>;
+      const toolResultMsg = msgs.find(
+        (m) =>
+          m.role === "user" &&
+          Array.isArray(m.content) &&
+          m.content.some((b) => b.type === "tool_result"),
+      );
+      assert.ok(toolResultMsg, "Anthropic request must contain tool_result block");
+      const blocks = toolResultMsg?.content as Array<{
+        type?: string;
+        tool_use_id?: string;
+        content?: string;
+      }>;
+      const toolResultBlock = blocks.find((b) => b.type === "tool_result");
+      assert.ok(toolResultBlock);
+      assert.equal(toolResultBlock?.tool_use_id, "toolu_xyz");
+      assert.equal(toolResultBlock?.content, '{"text":"fetched content"}');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("将连续 Anthropic tool history 分组到同一条 user message", async () => {
+    const captured: CapturedBody[] = [];
+    const originalFetch = globalThis.fetch;
+
+    try {
+      globalThis.fetch = (async (_url, init) => {
+        const body = JSON.parse(
+          typeof init?.body === "string" ? init.body : "{}",
+        ) as CapturedBody;
+        captured.push(body);
+        return new Response(
+          JSON.stringify({ content: [{ text: "ok" }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch;
+
+      const svc = createAiService({
+        logger: nopLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "anthropic",
+          CREONOW_AI_BASE_URL: "https://api.anthropic.com",
+          CREONOW_AI_API_KEY: "sk-ant-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      await svc.runSkill({
+        skillId: "builtin:polish",
+        input: "go",
+        mode: "ask",
+        model: "claude-3-5-sonnet",
+        stream: false,
+        ts: Date.now(),
+        emitEvent: () => {},
+        overrideMessages: [
+          { role: "user", content: "q" },
+          { role: "assistant", content: "calling two" },
+          { role: "tool", content: "r1", toolCallId: "t1" },
+          { role: "tool", content: "r2", toolCallId: "t2" },
+          { role: "user", content: "go" },
+        ],
+      });
+
+      const msgs = (captured[0]?.messages ?? []) as Array<{
+        role?: string;
+        content?: string | Array<{ type?: string; tool_use_id?: string }>;
+      }>;
+      const toolResultMsgs = msgs.filter(
+        (m) =>
+          m.role === "user" &&
+          Array.isArray(m.content) &&
+          m.content.some((b) => b.type === "tool_result"),
+      );
+      assert.equal(toolResultMsgs.length, 1);
+      const blocks = toolResultMsgs[0]?.content as Array<{ type?: string }>;
+      assert.equal(blocks.filter((b) => b.type === "tool_result").length, 2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("缺失 toolCallId 时不崩溃，并回退为空字符串", async () => {
+    const captured: CapturedBody[] = [];
+    const originalFetch = globalThis.fetch;
+
+    try {
+      globalThis.fetch = (async (_url, init) => {
+        const body = JSON.parse(
+          typeof init?.body === "string" ? init.body : "{}",
+        ) as CapturedBody;
+        captured.push(body);
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch;
+
+      const svc = createAiService({
+        logger: nopLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "openai",
+          CREONOW_AI_BASE_URL: "https://api.openai.com",
+          CREONOW_AI_API_KEY: "sk-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      const res = await svc.runSkill({
+        skillId: "builtin:polish",
+        input: "go",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: false,
+        ts: Date.now(),
+        emitEvent: () => {},
+        overrideMessages: [
+          { role: "user", content: "q" },
+          { role: "tool", content: "result" },
+          { role: "user", content: "go" },
+        ],
+      });
+
+      assert.equal(res.ok, true);
+      const toolMsg = ((captured[0]?.messages ?? []) as Array<{
+        role?: string;
+        tool_call_id?: string;
+      }>).find((m) => m.role === "tool");
+      assert.ok(toolMsg);
+      assert.equal(toolMsg?.tool_call_id, "");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -74,6 +74,8 @@ export type AiService = {
     stream: boolean;
     ts: number;
     emitEvent: (event: AiStreamEvent) => void;
+    /** P2: when provided, bypass internal message building and use these messages directly */
+    overrideMessages?: Array<{ role: string; content: string }>;
   }) => Promise<
     ServiceResult<{
       executionId: string;
@@ -123,6 +125,10 @@ type RunEntry = {
   pendingChunkBuffer: string;
   pendingChunkCount: number;
   emitEvent: (event: AiStreamEvent) => void;
+  /** P2: finish reason captured from the AI provider streaming response */
+  finishReason?: "stop" | "tool_use";
+  /** P2: tool calls captured from the AI provider streaming response */
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
 };
 
 const PROVIDER_HALF_OPEN_AFTER_MS = 15 * 60 * 1000;
@@ -555,6 +561,8 @@ function createAiEmitHelpers(deps: AiServiceDeps, state: AiInternalState) {
       terminal: args.terminal,
       outputText: entry.outputText,
       ...(args.error ? { error: args.error } : {}),
+      ...(entry.finishReason !== undefined ? { finishReason: entry.finishReason } : {}),
+      ...(entry.toolCalls !== undefined ? { toolCalls: entry.toolCalls } : {}),
       ts: args.ts ?? Date.now(),
     });
   }
@@ -1071,6 +1079,8 @@ function createAiStreamHelpers(
     }
 
     let sawDone = false;
+    // P2: accumulators for tool call streaming (OpenAI tool_calls delta format)
+    const toolCallAccumulator = new Map<number, { id: string; name: string; argumentsRaw: string }>();
     try {
       for await (const msg of readSse({ body: res.body })) {
         if (args.entry.terminal !== null) {
@@ -1099,6 +1109,44 @@ function createAiStreamHelpers(
           );
           continue;
         }
+
+        // P2: capture finish_reason and tool_calls from OpenAI streaming chunks
+        const parsedObj = typeof parsed === "object" && parsed !== null ? parsed as JsonObject : null;
+        if (parsedObj) {
+          const choices = Array.isArray(parsedObj.choices) ? parsedObj.choices : [];
+          const firstChoice = choices.length > 0 && typeof choices[0] === "object" && choices[0] !== null
+            ? choices[0] as JsonObject
+            : null;
+          if (firstChoice) {
+            // Capture finish_reason
+            if (typeof firstChoice.finish_reason === "string" && firstChoice.finish_reason !== null) {
+              args.entry.finishReason = firstChoice.finish_reason === "tool_calls" ? "tool_use" : "stop";
+            }
+            // Accumulate tool_calls from delta
+            const delta = typeof firstChoice.delta === "object" && firstChoice.delta !== null
+              ? firstChoice.delta as JsonObject
+              : null;
+            if (delta && Array.isArray(delta.tool_calls)) {
+              for (const tcDelta of delta.tool_calls) {
+                if (typeof tcDelta !== "object" || tcDelta === null) continue;
+                const tc = tcDelta as JsonObject;
+                const idx = typeof tc.index === "number" ? tc.index : -1;
+                if (idx < 0) continue;
+                if (!toolCallAccumulator.has(idx)) {
+                  toolCallAccumulator.set(idx, { id: "", name: "", argumentsRaw: "" });
+                }
+                const acc = toolCallAccumulator.get(idx)!;
+                if (typeof tc.id === "string") acc.id = tc.id;
+                const fn = typeof tc.function === "object" && tc.function !== null ? tc.function as JsonObject : null;
+                if (fn) {
+                  if (typeof fn.name === "string") acc.name = fn.name;
+                  if (typeof fn.arguments === "string") acc.argumentsRaw += fn.arguments;
+                }
+              }
+            }
+          }
+        }
+
         const delta = extractOpenAiDelta(parsed);
         if (typeof delta !== "string" || delta.length === 0) {
           continue;
@@ -1115,6 +1163,24 @@ function createAiStreamHelpers(
         retryable: true,
         message: error instanceof Error ? error.message : String(error),
       });
+    }
+
+    // P2: finalise accumulated tool calls
+    if (toolCallAccumulator.size > 0) {
+      const toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> = [];
+      for (const [, acc] of toolCallAccumulator) {
+        let parsedArgs: Record<string, unknown> = {};
+        try {
+          const rawParsed = JSON.parse(acc.argumentsRaw);
+          if (typeof rawParsed === "object" && rawParsed !== null) {
+            parsedArgs = rawParsed as Record<string, unknown>;
+          }
+        } catch {
+          // Malformed arguments — leave as empty object
+        }
+        toolCalls.push({ id: acc.id, name: acc.name, arguments: parsedArgs });
+      }
+      args.entry.toolCalls = toolCalls;
     }
 
     if (args.entry.controller.signal.aborted) {
@@ -1184,6 +1250,8 @@ function createAiStreamHelpers(
     }
 
     let sawMessageStop = false;
+    // P2: accumulators for Anthropic tool_use streaming (content_block_start/delta format)
+    const anthropicToolBlocks = new Map<number, { id: string; name: string; inputRaw: string }>();
     try {
       for await (const msg of readSse({ body: res.body })) {
         if (args.entry.terminal !== null) {
@@ -1193,6 +1261,41 @@ function createAiStreamHelpers(
         if (msg.event === "message_stop") {
           sawMessageStop = true;
           break;
+        }
+
+        // P2: capture stop_reason from message_delta events
+        if (msg.event === "message_delta") {
+          try {
+            const parsed = JSON.parse(msg.data) as JsonObject;
+            const delta = typeof parsed.delta === "object" && parsed.delta !== null ? parsed.delta as JsonObject : null;
+            if (delta && typeof delta.stop_reason === "string") {
+              args.entry.finishReason = delta.stop_reason === "tool_use" ? "tool_use" : "stop";
+            }
+          } catch {
+            // ignore parse failures
+          }
+          continue;
+        }
+
+        // P2: capture tool_use content block starts
+        if (msg.event === "content_block_start") {
+          try {
+            const parsed = JSON.parse(msg.data) as JsonObject;
+            const idx = typeof parsed.index === "number" ? parsed.index : -1;
+            const block = typeof parsed.content_block === "object" && parsed.content_block !== null
+              ? parsed.content_block as JsonObject
+              : null;
+            if (block && block.type === "tool_use" && idx >= 0) {
+              anthropicToolBlocks.set(idx, {
+                id: typeof block.id === "string" ? block.id : "",
+                name: typeof block.name === "string" ? block.name : "",
+                inputRaw: "",
+              });
+            }
+          } catch {
+            // ignore parse failures
+          }
+          continue;
         }
 
         if (msg.event !== "content_block_delta") {
@@ -1217,6 +1320,22 @@ function createAiStreamHelpers(
           );
           continue;
         }
+
+        // P2: accumulate input_json_delta for tool_use blocks
+        const parsedObj = typeof parsed === "object" && parsed !== null ? parsed as JsonObject : null;
+        if (parsedObj) {
+          const blockIdx = typeof parsedObj.index === "number" ? parsedObj.index : -1;
+          const blockDelta = typeof parsedObj.delta === "object" && parsedObj.delta !== null
+            ? parsedObj.delta as JsonObject
+            : null;
+          if (blockDelta && blockDelta.type === "input_json_delta" && typeof blockDelta.partial_json === "string" && blockIdx >= 0) {
+            const acc = anthropicToolBlocks.get(blockIdx);
+            if (acc) {
+              acc.inputRaw += blockDelta.partial_json;
+            }
+          }
+        }
+
         const delta = extractAnthropicDelta(parsed);
         if (typeof delta !== "string" || delta.length === 0) {
           continue;
@@ -1233,6 +1352,24 @@ function createAiStreamHelpers(
         retryable: true,
         message: error instanceof Error ? error.message : String(error),
       });
+    }
+
+    // P2: finalise accumulated Anthropic tool blocks
+    if (anthropicToolBlocks.size > 0) {
+      const toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> = [];
+      for (const [, acc] of anthropicToolBlocks) {
+        let parsedInput: Record<string, unknown> = {};
+        try {
+          const rawParsed = JSON.parse(acc.inputRaw);
+          if (typeof rawParsed === "object" && rawParsed !== null) {
+            parsedInput = rawParsed as Record<string, unknown>;
+          }
+        } catch {
+          // Malformed input — leave as empty object
+        }
+        toolCalls.push({ id: acc.id, name: acc.name, arguments: parsedInput });
+      }
+      args.entry.toolCalls = toolCalls;
     }
 
     if (args.entry.controller.signal.aborted) {
@@ -1658,13 +1795,29 @@ function createAiRunSkillOp(
       role: message.role,
       content: message.content,
     }));
-    const runtimeMessages = buildRuntimeMessages({
-      systemPrompt: args.systemPrompt,
-      mode: args.mode,
-      system: args.system,
-      input: args.input,
-      history,
-    });
+    // P2: when overrideMessages is provided, use them directly bypassing internal message assembly
+    const runtimeMessages: RuntimeMessages = args.overrideMessages && args.overrideMessages.length > 0
+      ? (() => {
+          const openAiMessages: LLMMessage[] = args.overrideMessages!.map((m) => ({
+            role: m.role as "system" | "user" | "assistant",
+            content: m.content,
+          }));
+          const systemText = openAiMessages
+            .filter((m) => m.role === "system")
+            .map((m) => m.content)
+            .join("\n");
+          const anthropicMessages: RuntimeMessages["anthropicMessages"] = openAiMessages
+            .filter((m) => m.role === "user" || m.role === "assistant")
+            .map((m) => ({ role: m.role as "user" | "assistant", content: m.content }));
+          return { systemText, openAiMessages, anthropicMessages };
+        })()
+      : buildRuntimeMessages({
+          systemPrompt: args.systemPrompt,
+          mode: args.mode,
+          system: args.system,
+          input: args.input,
+          history,
+        });
     const promptTokens = estimateTokenCount(args.input);
     const projectedTokens = promptTokens + DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE;
     const hasExplicitEnvTimeout =

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -75,7 +75,7 @@ export type AiService = {
     ts: number;
     emitEvent: (event: AiStreamEvent) => void;
     /** P2: when provided, bypass internal message building and use these messages directly */
-    overrideMessages?: Array<{ role: string; content: string }>;
+    overrideMessages?: Array<{ role: string; content: string; toolCallId?: string }>;
   }) => Promise<
     ServiceResult<{
       executionId: string;
@@ -137,10 +137,26 @@ const STREAM_CHUNK_MAX_BATCH_COUNT = 4;
 const STREAM_COMPLETION_SETTLE_MS = 20;
 const SSE_PARSE_RAW_MAX_LEN = 200;
 
+/** OpenAI tool-result message shape (role="tool" requires tool_call_id). */
+type OpenAiToolMessage = { role: "tool"; content: string; tool_call_id: string };
+
+/** Anthropic tool-result content block (wrapped in a user message). */
+type AnthropicToolResultBlock = {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+};
+
 type RuntimeMessages = {
   systemText: string;
-  openAiMessages: LLMMessage[];
-  anthropicMessages: Array<{ role: "user" | "assistant"; content: string }>;
+  /** May include tool-result messages for agentic-loop rounds. */
+  openAiMessages: Array<LLMMessage | OpenAiToolMessage>;
+  /** Anthropic messages; tool results are represented as user messages with
+   * content blocks instead of plain strings. */
+  anthropicMessages: Array<{
+    role: "user" | "assistant";
+    content: string | AnthropicToolResultBlock[];
+  }>;
 };
 
 /**
@@ -1798,17 +1814,51 @@ function createAiRunSkillOp(
     // P2: when overrideMessages is provided, use them directly bypassing internal message assembly
     const runtimeMessages: RuntimeMessages = args.overrideMessages && args.overrideMessages.length > 0
       ? (() => {
-          const openAiMessages: LLMMessage[] = args.overrideMessages!.map((m) => ({
-            role: m.role as "system" | "user" | "assistant",
-            content: m.content,
-          }));
+          // OpenAI: preserve role="tool" messages with their tool_call_id
+          const openAiMessages: RuntimeMessages["openAiMessages"] = args.overrideMessages!.map((m) => {
+            if (m.role === "tool") {
+              return {
+                role: "tool" as const,
+                content: m.content,
+                tool_call_id: m.toolCallId ?? "",
+              };
+            }
+            return {
+              role: m.role as "system" | "user" | "assistant",
+              content: m.content,
+            };
+          });
           const systemText = openAiMessages
             .filter((m) => m.role === "system")
-            .map((m) => m.content)
+            .map((m) => (m as LLMMessage).content)
             .join("\n");
-          const anthropicMessages: RuntimeMessages["anthropicMessages"] = openAiMessages
-            .filter((m) => m.role === "user" || m.role === "assistant")
-            .map((m) => ({ role: m.role as "user" | "assistant", content: m.content }));
+          // Anthropic: group consecutive tool messages into user messages with
+          // tool_result content blocks; skip system messages (sent separately).
+          const anthropicMessages: RuntimeMessages["anthropicMessages"] = [];
+          let pendingToolResults: AnthropicToolResultBlock[] = [];
+          const flushToolResults = (): void => {
+            if (pendingToolResults.length > 0) {
+              anthropicMessages.push({ role: "user", content: [...pendingToolResults] });
+              pendingToolResults = [];
+            }
+          };
+          for (const m of args.overrideMessages!) {
+            if (m.role === "system") {
+              flushToolResults();
+              continue;
+            }
+            if (m.role === "tool") {
+              pendingToolResults.push({
+                type: "tool_result",
+                tool_use_id: m.toolCallId ?? "",
+                content: m.content,
+              });
+            } else if (m.role === "user" || m.role === "assistant") {
+              flushToolResults();
+              anthropicMessages.push({ role: m.role, content: m.content });
+            }
+          }
+          flushToolResults();
           return { systemText, openAiMessages, anthropicMessages };
         })()
       : buildRuntimeMessages({

--- a/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
@@ -1,0 +1,705 @@
+/**
+ * WritingOrchestrator P2 Agentic Loop 集成测试
+ *
+ * Spec: openspec/specs/skill-system/spec.md — P2: Agentic Loop（Tool-Use 循环）
+ *
+ * 覆盖：
+ * - Happy path：continue 技能 → tool_use → kgTool → stop → ai-done
+ * - All-failed：所有 tool call 失败 → TOOL_USE_ALL_FAILED → 继续到 ai-done
+ * - Max-rounds 熔断：超过 maxToolRounds → TOOL_USE_MAX_ROUNDS_EXCEEDED
+ * - 只读边界：documentWrite / versionSnapshot 不在 agentic registry
+ * - 非 agentic skill 忽略 tool_use（polish skill 时工具调用被丢弃）
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type {
+  WritingRequest,
+  WritingEvent,
+} from "../orchestrator";
+import { createWritingOrchestrator } from "../orchestrator";
+import { createToolRegistry, buildTool, type ToolRegistry } from "../toolRegistry";
+import type { ToolCallInfo } from "../../ai/streaming";
+import { createToolUseHandler, type ToolUseHandler } from "../toolUseHandler";
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+async function collectEvents(gen: AsyncGenerator<WritingEvent>): Promise<WritingEvent[]> {
+  const events: WritingEvent[] = [];
+  for await (const e of gen) {
+    events.push(e);
+  }
+  return events;
+}
+
+function eventTypes(events: WritingEvent[]): string[] {
+  return events.map((e) => e.type);
+}
+
+function makeRequest(overrides: Partial<WritingRequest> = {}): WritingRequest {
+  return {
+    requestId: "req-agentic-001",
+    skillId: "continue",
+    input: { precedingText: "夜幕降临，街灯次第亮起。" },
+    documentId: "doc-001",
+    projectId: "proj-001",
+    agenticLoop: true,
+    ...overrides,
+  };
+}
+
+function createMockPermissionGate(autoGrant = true) {
+  return {
+    evaluate: vi.fn().mockResolvedValue({ level: "auto-allow", granted: true }),
+    requestPermission: vi.fn().mockResolvedValue(autoGrant),
+    releasePendingPermission: vi.fn(),
+  };
+}
+
+/** Build a read-only agentic tool registry (kgTool, memTool, docTool – no write tools) */
+function createReadOnlyAgenticRegistry(): ToolRegistry {
+  const registry = createToolRegistry();
+  registry.register(buildTool({
+    name: "kgTool",
+    description: "Query knowledge graph",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { name: "林远", traits: ["冷静"] } }),
+  }));
+  registry.register(buildTool({
+    name: "memTool",
+    description: "Query memory",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { memories: [] } }),
+  }));
+  registry.register(buildTool({
+    name: "docTool",
+    description: "Read document",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { content: "..." } }),
+  }));
+  // documentRead: also read-only, agentic-accessible
+  registry.register(buildTool({
+    name: "documentRead",
+    description: "Read document text",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { text: "..." } }),
+  }));
+  // documentWrite and versionSnapshot intentionally NOT registered in agentic registry
+  return registry;
+}
+
+/** Build a full write registry (used by orchestrator for write-back, NOT by agentic loop) */
+function createWriteRegistry(): ToolRegistry {
+  const registry = createToolRegistry();
+  registry.register(buildTool({
+    name: "documentWrite",
+    description: "Write to document",
+    isConcurrencySafe: false,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "v-write-001" } }),
+  }));
+  registry.register(buildTool({
+    name: "versionSnapshot",
+    description: "Create version snapshot",
+    isConcurrencySafe: false,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "v-snap-001" } }),
+  }));
+  return registry;
+}
+
+function makeToolCallInfo(name: string, args: Record<string, unknown> = {}, id?: string): ToolCallInfo {
+  return { id: id ?? `call-${name}-${Date.now()}`, name, arguments: args };
+}
+
+// ─── test suite ─────────────────────────────────────────────────────
+
+describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
+  let agenticRegistry: ToolRegistry;
+  let agenticHandler: ToolUseHandler;
+  let writeRegistry: ToolRegistry;
+  let permissionGate: ReturnType<typeof createMockPermissionGate>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    agenticRegistry = createReadOnlyAgenticRegistry();
+    agenticHandler = createToolUseHandler(agenticRegistry, {
+      maxToolRounds: 5,
+      toolTimeoutMs: 10_000,
+      maxConcurrentTools: 4,
+      agenticLoop: true,
+    });
+    writeRegistry = createWriteRegistry();
+    permissionGate = createMockPermissionGate(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  describe("Happy path — continue 技能触发 Agentic Loop", () => {
+    it("AI 第一轮返回 tool_use，执行 kgTool，第二轮返回 stop → 完整事件序列正确", async () => {
+      // Round 1: AI returns tool_use with kgTool call
+      // Round 2: AI returns stop after seeing tool results
+      let callCount = 0;
+      const kgToolCallId = "call-kg-001";
+
+      const generateText = vi.fn().mockImplementation(async (args: {
+        messages?: Array<{ role: string; content: string }>;
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: return partial text + tool_use
+          args.emitChunk("林远", 2);
+          return {
+            fullText: "林远",
+            usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "林远的性格特点" }, kgToolCallId)],
+          };
+        }
+        // Second call: messages should include tool results
+        expect(args.messages).toBeDefined();
+        expect(args.messages!.length).toBeGreaterThan(0);
+        // Verify tool result was injected (role: tool)
+        const toolMsg = args.messages!.find((m) => m.role === "tool");
+        expect(toolMsg).toBeDefined();
+
+        args.emitChunk("缓步走向那扇门，", 10);
+        args.emitChunk("眼神沉静。", 15);
+        return {
+          fullText: "缓步走向那扇门，眼神沉静。",
+          usage: { promptTokens: 30, completionTokens: 15, totalTokens: 45 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Must include tool-use-started and tool-use-completed
+      expect(types).toContain("tool-use-started");
+      expect(types).toContain("tool-use-completed");
+      expect(types).not.toContain("tool-use-failed");
+
+      // Verify order: tool-use-started before tool-use-completed, after first ai-chunk
+      const startedIdx = types.indexOf("tool-use-started");
+      const completedIdx = types.indexOf("tool-use-completed");
+      expect(startedIdx).toBeLessThan(completedIdx);
+
+      // tool-use-started must come AFTER first ai-chunk
+      const firstChunkIdx = types.indexOf("ai-chunk");
+      expect(firstChunkIdx).toBeLessThan(startedIdx);
+
+      // tool-use-started event shape
+      const startedEvent = events[startedIdx];
+      expect(startedEvent.round).toBe(1);
+      expect(startedEvent.toolNames).toEqual(["kgTool"]);
+
+      // tool-use-completed event shape
+      const completedEvent = events[completedIdx];
+      expect(completedEvent.round).toBe(1);
+      const results = completedEvent.results as Array<{ toolName: string; success: boolean; durationMs: number }>;
+      expect(results).toHaveLength(1);
+      expect(results[0].toolName).toBe("kgTool");
+      expect(results[0].success).toBe(true);
+      expect(completedEvent.hasNextRound).toBe(false);
+
+      // ai-done must appear after tool-use loop
+      const aiDoneIdx = types.indexOf("ai-done");
+      expect(aiDoneIdx).toBeGreaterThan(completedIdx);
+
+      // Final fullText should be from round 2
+      const aiDoneEvent = events[aiDoneIdx];
+      expect(aiDoneEvent.fullText).toBe("缓步走向那扇门，眼神沉静。");
+
+      // generateText was called twice
+      expect(callCount).toBe(2);
+
+      // Pipeline continues normally: write-back-done (since permission auto-allow)
+      expect(types).toContain("write-back-done");
+      expect(types).toContain("hooks-done");
+    });
+
+    it("两轮 tool-use 后 stop → round 事件递增", async () => {
+      let callCount = 0;
+
+      const generateText = vi.fn().mockImplementation(async (args: {
+        messages?: Array<{ role: string; content: string }>;
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          args.emitChunk("第一轮", 3);
+          return {
+            fullText: "第一轮",
+            usage: { promptTokens: 10, completionTokens: 3, totalTokens: 13 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "人物A" }, "call-r1")],
+          };
+        }
+        if (callCount === 2) {
+          args.emitChunk("第二轮", 6);
+          return {
+            fullText: "第二轮",
+            usage: { promptTokens: 20, completionTokens: 6, totalTokens: 26 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("memTool", { query: "偏好" }, "call-r2")],
+          };
+        }
+        args.emitChunk("最终续写内容", 12);
+        return {
+          fullText: "最终续写内容",
+          usage: { promptTokens: 30, completionTokens: 12, totalTokens: 42 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      const startedEvents = events.filter((e) => e.type === "tool-use-started");
+      const completedEvents = events.filter((e) => e.type === "tool-use-completed");
+
+      expect(startedEvents).toHaveLength(2);
+      expect(completedEvents).toHaveLength(2);
+
+      expect(startedEvents[0].round).toBe(1);
+      expect(startedEvents[1].round).toBe(2);
+      expect(completedEvents[0].round).toBe(1);
+      expect(completedEvents[1].round).toBe(2);
+
+      // First round: kgTool started, second: memTool started
+      expect(startedEvents[0].toolNames).toEqual(["kgTool"]);
+      expect(startedEvents[1].toolNames).toEqual(["memTool"]);
+
+      // hasNextRound: first true (round 2 coming), second false (no more)
+      expect(completedEvents[0].hasNextRound).toBe(true);
+      expect(completedEvents[1].hasNextRound).toBe(false);
+
+      expect(callCount).toBe(3);
+      expect(types).toContain("ai-done");
+    });
+  });
+
+  // ── All-failed ───────────────────────────────────────────────────
+
+  describe("All-failed — 本轮所有 tool call 均失败", () => {
+    it("kgTool 失败 → yield tool-use-failed(TOOL_USE_ALL_FAILED) → 继续到 ai-done", async () => {
+      // Create a registry where kgTool always fails
+      const failingRegistry = createToolRegistry();
+      failingRegistry.register(buildTool({
+        name: "kgTool",
+        description: "Always fails",
+        isConcurrencySafe: true,
+        execute: vi.fn().mockResolvedValue({
+          success: false,
+          error: { code: "KG_ERROR", message: "KG not available" },
+        }),
+      }));
+
+      const failingHandler = createToolUseHandler(failingRegistry, {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      });
+
+      let callCount = 0;
+      const generateText = vi.fn().mockImplementation(async (args: {
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          args.emitChunk("部分续写", 4);
+          return {
+            fullText: "部分续写",
+            usage: { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "林远" }, "call-fail")],
+          };
+        }
+        // Should NOT be called after all-failed
+        return {
+          fullText: "不应该到这里",
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: failingHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Must have tool-use-started
+      expect(types).toContain("tool-use-started");
+
+      // Must yield tool-use-failed with TOOL_USE_ALL_FAILED
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+      expect(failedEvent!.round).toBe(1);
+
+      // Pipeline should NOT call AI again after all-failed
+      expect(callCount).toBe(1);
+
+      // Should continue to ai-done with partial text
+      expect(types).toContain("ai-done");
+      const aiDoneEvent = events.find((e) => e.type === "ai-done");
+      expect((aiDoneEvent!.fullText as string)).toBe("部分续写");
+
+      // Should still complete write-back (permission auto-allow)
+      expect(types).toContain("write-back-done");
+    });
+
+    it("未注册的 tool → TOOL_USE_TOOL_NOT_FOUND 导致 all-failed → tool-use-failed", async () => {
+      // Empty agentic registry - no tools registered
+      const emptyRegistry = createToolRegistry();
+      const emptyHandler = createToolUseHandler(emptyRegistry, {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      });
+
+      const generateText = vi.fn()
+        .mockResolvedValueOnce({
+          fullText: "AI 想调用不存在的工具",
+          usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("unknownTool", {}, "call-unknown")],
+        })
+        .mockResolvedValueOnce({
+          fullText: "不应调用第二次",
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: emptyHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+
+      // AI was only called once (no re-call after all-failed)
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Max-rounds 熔断 ──────────────────────────────────────────────
+
+  describe("Max-rounds 熔断", () => {
+    it("AI 持续返回 tool_use，到达 maxToolRounds(5) → TOOL_USE_MAX_ROUNDS_EXCEEDED", async () => {
+      let callCount = 0;
+
+      const generateText = vi.fn().mockImplementation(async (args: {
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        args.emitChunk(`轮次${callCount}`, callCount * 2);
+        // Always return tool_use until max rounds
+        return {
+          fullText: `轮次${callCount}`,
+          usage: { promptTokens: 5, completionTokens: callCount * 2, totalTokens: 5 + callCount * 2 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("kgTool", { query: `query-${callCount}` }, `call-${callCount}`)],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Should have exactly 5 tool-use-started events (maxToolRounds = 5)
+      const startedEvents = events.filter((e) => e.type === "tool-use-started");
+      expect(startedEvents).toHaveLength(5);
+
+      // Should have tool-use-failed with TOOL_USE_MAX_ROUNDS_EXCEEDED at the end
+      const failedEvents = events.filter((e) => e.type === "tool-use-failed");
+      expect(failedEvents.length).toBeGreaterThanOrEqual(1);
+      const maxRoundsEvent = failedEvents.find(
+        (e) => (e.error as { code: string }).code === "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+      );
+      expect(maxRoundsEvent).toBeDefined();
+      expect(maxRoundsEvent!.round).toBe(5);
+
+      // Should still proceed to ai-done with last partial content
+      expect(types).toContain("ai-done");
+
+      // AI was called 1 (initial) + 5 (after each tool round) = 6 times
+      expect(callCount).toBe(6);
+    });
+  });
+
+  // ── 只读边界 ─────────────────────────────────────────────────────
+
+  describe("只读边界 — documentWrite / versionSnapshot 不在 agentic registry", () => {
+    it("AI 请求 documentWrite → TOOL_USE_TOOL_NOT_FOUND → all-failed", async () => {
+      // The agenticRegistry (read-only) does NOT have documentWrite
+      // Even if the write registry has it, AI cannot access it via the agentic loop
+
+      const generateText = vi.fn()
+        .mockResolvedValueOnce({
+          fullText: "AI 试图写入文档",
+          usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("documentWrite", { content: "恶意写入" }, "call-write")],
+        });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler, // backed by read-only agenticRegistry
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+
+      // tool-use-started should be emitted (we tried to call it)
+      const startedEvent = events.find((e) => e.type === "tool-use-started");
+      expect(startedEvent).toBeDefined();
+      expect(startedEvent!.toolNames).toEqual(["documentWrite"]);
+
+      // Should fail because documentWrite is not in agentic registry
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+
+      // Verify that documentWrite was NOT called (tool not found in agentic registry)
+      void writeRegistry; // registry is not called directly here
+    });
+
+    it("AI 请求 versionSnapshot → TOOL_USE_TOOL_NOT_FOUND → all-failed", async () => {
+      const generateText = vi.fn()
+        .mockResolvedValueOnce({
+          fullText: "尝试快照",
+          usage: { promptTokens: 5, completionTokens: 3, totalTokens: 8 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("versionSnapshot", {}, "call-snap")],
+        });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+
+      // AI was only called once (no re-call after all-failed)
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+
+    it("agentic registry 中不包含 documentWrite（只读约束验证）", () => {
+      // Direct registry inspection
+      expect(agenticRegistry.get("documentWrite")).toBeUndefined();
+      expect(agenticRegistry.get("versionSnapshot")).toBeUndefined();
+
+      // Read-only tools ARE available
+      expect(agenticRegistry.get("kgTool")).toBeDefined();
+      expect(agenticRegistry.get("memTool")).toBeDefined();
+      expect(agenticRegistry.get("docTool")).toBeDefined();
+      expect(agenticRegistry.get("documentRead")).toBeDefined();
+    });
+  });
+
+  // ── 非 Agentic skill 忽略 tool_use ──────────────────────────────
+
+  describe("非 Agentic skill — polish/rewrite 不触发 tool-use loop", () => {
+    it("polish skill (agenticLoop: false) → AI 意外返回 tool_use → 忽略，使用已生成文本", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "润色后的文字。",
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+        // AI accidentally returns tool_use, but skill doesn't have agenticLoop enabled
+        finishReason: "tool_use" as const,
+        toolCalls: [makeToolCallInfo("kgTool", {}, "call-ignored")],
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({
+        skillId: "polish",
+        input: { selectedText: "他慢慢地走到了那扇门的前面" },
+        agenticLoop: false, // polish does NOT enable agentic loop
+      })));
+
+      const types = eventTypes(events);
+
+      // NO tool-use events
+      expect(types).not.toContain("tool-use-started");
+      expect(types).not.toContain("tool-use-completed");
+      expect(types).not.toContain("tool-use-failed");
+
+      // AI was only called once
+      expect(generateText).toHaveBeenCalledTimes(1);
+
+      // ai-done uses the text from the single AI call
+      const aiDoneEvent = events.find((e) => e.type === "ai-done");
+      expect(aiDoneEvent).toBeDefined();
+      expect(aiDoneEvent!.fullText).toBe("润色后的文字。");
+
+      // Pipeline completes normally
+      expect(types).toContain("write-back-done");
+    });
+  });
+
+  // ── WritingRequest.agenticLoop flag ─────────────────────────────
+
+  describe("agenticLoop flag 控制", () => {
+    it("agenticLoop: undefined → 默认不启用 agentic loop", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "续写内容",
+        usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+        finishReason: "tool_use" as const,
+        toolCalls: [makeToolCallInfo("kgTool", {}, "call-x")],
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      // No agenticLoop flag set
+      const events = await collectEvents(orchestrator.execute(makeRequest({
+        agenticLoop: undefined,
+      })));
+
+      const types = eventTypes(events);
+      expect(types).not.toContain("tool-use-started");
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+
+    it("agenticLoop: true 但没有 toolUseHandler → 不触发 loop", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "续写",
+        usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+        finishReason: "tool_use" as const,
+        toolCalls: [makeToolCallInfo("kgTool", {}, "call-y")],
+      });
+
+      // No toolUseHandler in config
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        // toolUseHandler: intentionally omitted
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({ agenticLoop: true })));
+      const types = eventTypes(events);
+
+      // No tool-use events since toolUseHandler is not in config
+      expect(types).not.toContain("tool-use-started");
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── finishReason === null (IPC production case) ─────────────────
+
+  describe("finishReason === null 时不触发 loop（生产 IPC 路径）", () => {
+    it("generateText 返回 finishReason: null → 正常走完 ai-done，不触发 tool-use", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "续写结果",
+        usage: { promptTokens: 10, completionTokens: 8, totalTokens: 18 },
+        finishReason: null, // IPC 生产路径返回 null
+        toolCalls: [],
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({ agenticLoop: true })));
+      const types = eventTypes(events);
+
+      expect(types).not.toContain("tool-use-started");
+      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(types).toContain("ai-done");
+    });
+  });
+});

--- a/apps/desktop/main/src/services/skills/__tests__/tool-use-handler.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/tool-use-handler.test.ts
@@ -235,6 +235,59 @@ describe("ToolUseHandler — Agentic Loop", () => {
       expect(results[0].success).toBe(true);
     });
 
+    it("多个 isConcurrencySafe=false tools 严格串行执行（F5：spec 并发分区）", async () => {
+      // Two unsafe tools — the second must not start until the first finishes
+      const executionOrder: string[] = [];
+
+      registry.register(buildTool({
+        name: "unsafeA",
+        description: "Unsafe tool A",
+        isConcurrencySafe: false,
+        execute: vi.fn().mockImplementation(async () => {
+          executionOrder.push("unsafeA-start");
+          await new Promise((r) => setTimeout(r, 100));
+          executionOrder.push("unsafeA-end");
+          return { success: true, data: { tool: "A" } };
+        }),
+      }));
+
+      registry.register(buildTool({
+        name: "unsafeB",
+        description: "Unsafe tool B",
+        isConcurrencySafe: false,
+        execute: vi.fn().mockImplementation(async () => {
+          executionOrder.push("unsafeB-start");
+          await new Promise((r) => setTimeout(r, 50));
+          executionOrder.push("unsafeB-end");
+          return { success: true, data: { tool: "B" } };
+        }),
+      }));
+
+      const calls: ParsedToolCall[] = [
+        { callId: "c1", toolName: "unsafeA", arguments: {} },
+        { callId: "c2", toolName: "unsafeB", arguments: {} },
+      ];
+
+      const resultPromise = handler.executeToolBatch(calls, makeToolContext());
+      await vi.advanceTimersByTimeAsync(200);
+      const results = await resultPromise;
+
+      expect(results).toHaveLength(2);
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(true);
+
+      // Serial: A must fully complete before B starts
+      expect(executionOrder.indexOf("unsafeA-start")).toBeLessThan(
+        executionOrder.indexOf("unsafeA-end"),
+      );
+      expect(executionOrder.indexOf("unsafeA-end")).toBeLessThan(
+        executionOrder.indexOf("unsafeB-start"),
+      );
+      expect(executionOrder.indexOf("unsafeB-start")).toBeLessThan(
+        executionOrder.indexOf("unsafeB-end"),
+      );
+    });
+
     it("结果按原始顺序返回", async () => {
       const calls: ParsedToolCall[] = [
         { callId: "c1", toolName: "kgTool", arguments: { query: "first" } },

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -9,7 +9,8 @@
  */
 
 import type { ToolRegistry } from "./toolRegistry";
-import type { StreamChunk } from "../ai/streaming";
+import type { StreamChunk, ToolCallInfo } from "../ai/streaming";
+import type { ToolUseHandler } from "./toolUseHandler";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -27,6 +28,8 @@ export interface WritingRequest {
     text: string;
     selectionTextHash: string;
   };
+  /** P2: set to true for skills that support Agentic Loop (e.g. continue) */
+  agenticLoop?: boolean;
 }
 
 export type WritingEventType =
@@ -41,7 +44,11 @@ export type WritingEventType =
   | "write-back-done"
   | "hooks-done"
   | "aborted"
-  | "error";
+  | "error"
+  // P2 Agentic Loop events
+  | "tool-use-started"
+  | "tool-use-completed"
+  | "tool-use-failed";
 
 export type WritingEvent = {
   type: WritingEventType;
@@ -70,6 +77,10 @@ interface PreparedRequest {
 type GeneratedTextResult = {
   fullText: string;
   usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  /** P2: finish reason from the AI */
+  finishReason?: "stop" | "tool_use" | null;
+  /** P2: tool calls requested by the AI */
+  toolCalls?: ToolCallInfo[];
 };
 
 function readVersionId(data: unknown): string | null {
@@ -102,14 +113,22 @@ export interface OrchestratorConfig {
   permissionGate: PermissionGate;
   postWritingHooks: PostWritingHook[];
   defaultTimeoutMs: number;
+  /** P2: handler for Agentic Loop tool execution (read-only registry) */
+  toolUseHandler?: ToolUseHandler;
   prepareRequest?: (request: WritingRequest) => Promise<PreparedRequest>;
   generateText?: (args: {
     request: WritingRequest;
     signal: AbortSignal;
     emitChunk: (delta: string, accumulatedTokens: number) => void;
+    /** P2: updated messages for subsequent agentic loop rounds */
+    messages?: Array<{ role: string; content: string }>;
   }) => Promise<{
     fullText: string;
     usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+    /** P2: finish reason from the AI (null = streaming, stop = done, tool_use = wants tools) */
+    finishReason?: "stop" | "tool_use" | null;
+    /** P2: tool calls requested by the AI when finishReason === 'tool_use' */
+    toolCalls?: ToolCallInfo[];
   }>;
 }
 
@@ -260,11 +279,15 @@ export function createWritingOrchestrator(
         const MAX_AI_RETRIES = 2;
         let aiAttempt = 0;
         let aiSuccess = false;
+        let lastFinishReason: "stop" | "tool_use" | null = null;
+        let lastToolCalls: ToolCallInfo[] = [];
 
         while (aiAttempt <= MAX_AI_RETRIES && !aiSuccess) {
           try {
             fullText = "";
             lastTokens = 0;
+            lastFinishReason = null;
+            lastToolCalls = [];
 
             if (config.generateText) {
               const chunkQueue: Array<{
@@ -341,7 +364,10 @@ export function createWritingOrchestrator(
 
               fullText = generatedResult.fullText;
               lastTokens = generatedResult.usage.completionTokens;
+              lastFinishReason = generatedResult.finishReason ?? null;
+              lastToolCalls = generatedResult.toolCalls ?? [];
             } else {
+              let streamFinishReason: "stop" | "tool_use" | null = null;
               const gen = config.aiService.streamChat(
                 prepared.messages,
                 {
@@ -361,11 +387,15 @@ export function createWritingOrchestrator(
 
                 fullText += chunk.delta;
                 lastTokens = chunk.accumulatedTokens;
+                if (chunk.finishReason !== null) {
+                  streamFinishReason = chunk.finishReason;
+                }
                 yield makeEvent("ai-chunk", requestId, {
                   delta: chunk.delta,
                   accumulatedTokens: chunk.accumulatedTokens,
                 });
               }
+              lastFinishReason = streamFinishReason;
             }
 
             aiSuccess = true;
@@ -398,6 +428,180 @@ export function createWritingOrchestrator(
             },
           });
           return;
+        }
+
+        // Stage 4.5 (P2): Agentic tool-use loop
+        // Only runs when request.agenticLoop is true AND toolUseHandler is configured
+        // AND the AI returned finishReason === 'tool_use'
+        if (request.agenticLoop && config.toolUseHandler && config.generateText) {
+          const AGENTIC_MAX_ROUNDS = 5;
+          let agenticRound = 0;
+          let agenticMessages: Array<{ role: string; content: string }> | undefined;
+
+          while (lastFinishReason === "tool_use" && agenticRound < AGENTIC_MAX_ROUNDS) {
+            agenticRound++;
+
+            // Parse tool calls (may fail with TOOL_USE_PARSE_FAILED)
+            let parsedCalls;
+            try {
+              parsedCalls = config.toolUseHandler.parseToolCalls(lastToolCalls);
+            } catch (parseErr: unknown) {
+              const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+              yield makeEvent("tool-use-failed", requestId, {
+                round: agenticRound,
+                error: { code: "TOOL_USE_PARSE_FAILED", message: msg, retryable: false },
+              });
+              break;
+            }
+
+            // Yield tool-use-started
+            yield makeEvent("tool-use-started", requestId, {
+              round: agenticRound,
+              toolNames: parsedCalls.map((c) => c.toolName),
+            });
+
+            if (abortController.signal.aborted) {
+              taskStates.set(requestId, "killed");
+              yield makeEvent("aborted", requestId, { reason: "user-abort" });
+              return;
+            }
+
+            // Execute tools via the agentic (read-only) registry
+            const toolCtx = {
+              documentId: request.documentId,
+              requestId,
+              ...(request.projectId !== undefined ? { projectId: request.projectId } : {}),
+            };
+            const results = await config.toolUseHandler.executeToolBatch(parsedCalls, toolCtx);
+
+            // Check all-failed
+            const summary = config.toolUseHandler.getBatchSummary(results);
+            if (summary.allFailed) {
+              yield makeEvent("tool-use-failed", requestId, {
+                round: agenticRound,
+                error: {
+                  code: "TOOL_USE_ALL_FAILED",
+                  message: "All tool calls in this round failed",
+                  retryable: false,
+                },
+              });
+              break;
+            }
+
+            // Inject tool results into message history
+            const baseMsgs = agenticMessages ?? prepared.messages;
+            // Append assistant message (partial AI text before tool_use) then tool results
+            type ToolMsg = { role: "system" | "user" | "assistant" | "tool"; content: string; toolCallId?: string };
+            const msgsWithAssistant: ToolMsg[] = [
+              ...(baseMsgs.map((m) => ({
+                role: m.role as "system" | "user" | "assistant" | "tool",
+                content: m.content,
+              }))),
+              { role: "assistant" as const, content: fullText },
+            ];
+            agenticMessages = config.toolUseHandler.injectResults(
+              msgsWithAssistant,
+              results,
+            ) as Array<{ role: string; content: string }>;
+
+            if (abortController.signal.aborted) {
+              taskStates.set(requestId, "killed");
+              yield makeEvent("aborted", requestId, { reason: "user-abort" });
+              return;
+            }
+
+            // Re-call AI with injected messages
+            const nextChunkQueue: Array<{ delta: string; accumulatedTokens: number }> = [];
+            let nextResult: GeneratedTextResult | undefined;
+            let nextError: unknown = null;
+            let nextSettled = false;
+            let nextNotify: (() => void) | null = null;
+            const nextWake = () => {
+              const r = nextNotify;
+              nextNotify = null;
+              r?.();
+            };
+
+            const nextGenPromise = config
+              .generateText({
+                request,
+                signal: abortController.signal,
+                emitChunk: (delta, accumulatedTokens) => {
+                  nextChunkQueue.push({ delta, accumulatedTokens });
+                  nextWake();
+                },
+                messages: agenticMessages,
+              })
+              .then(
+                (r) => { nextResult = r; nextSettled = true; nextWake(); },
+                (e: unknown) => { nextError = e; nextSettled = true; nextWake(); },
+              );
+
+            let roundFullText = "";
+            while (!nextSettled || nextChunkQueue.length > 0) {
+              if (abortController.signal.aborted) {
+                taskStates.set(requestId, "killed");
+                yield makeEvent("aborted", requestId, { reason: "abort-during-ai" });
+                return;
+              }
+
+              const nextChunk = nextChunkQueue.shift();
+              if (nextChunk) {
+                roundFullText += nextChunk.delta;
+                lastTokens = nextChunk.accumulatedTokens;
+                yield makeEvent("ai-chunk", requestId, {
+                  delta: nextChunk.delta,
+                  accumulatedTokens: nextChunk.accumulatedTokens,
+                });
+                continue;
+              }
+
+              await new Promise<void>((resolve) => {
+                const onAbort = () => resolve();
+                nextNotify = resolve;
+                abortController.signal.addEventListener("abort", onAbort, { once: true });
+              });
+            }
+
+            await nextGenPromise;
+            if (nextError) {
+              throw nextError;
+            }
+            if (!nextResult) {
+              throw new Error("generateText completed without result in agentic round");
+            }
+
+            fullText = nextResult.fullText || roundFullText;
+            lastTokens = nextResult.usage.completionTokens;
+            lastFinishReason = nextResult.finishReason ?? null;
+            lastToolCalls = nextResult.toolCalls ?? [];
+
+            const hasNextRound =
+              lastFinishReason === "tool_use" && agenticRound < AGENTIC_MAX_ROUNDS;
+
+            // Yield tool-use-completed
+            yield makeEvent("tool-use-completed", requestId, {
+              round: agenticRound,
+              results: results.map((r) => ({
+                toolName: r.toolName,
+                success: r.success,
+                durationMs: r.durationMs,
+              })),
+              hasNextRound,
+            });
+          }
+
+          // Max rounds exceeded
+          if (agenticRound >= AGENTIC_MAX_ROUNDS && lastFinishReason === "tool_use") {
+            yield makeEvent("tool-use-failed", requestId, {
+              round: agenticRound,
+              error: {
+                code: "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+                message: `Maximum tool rounds (${AGENTIC_MAX_ROUNDS}) exceeded`,
+                retryable: false,
+              },
+            });
+          }
         }
 
         // Stage 5: ai-done

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -121,7 +121,7 @@ export interface OrchestratorConfig {
     signal: AbortSignal;
     emitChunk: (delta: string, accumulatedTokens: number) => void;
     /** P2: updated messages for subsequent agentic loop rounds */
-    messages?: Array<{ role: string; content: string }>;
+    messages?: Array<{ role: string; content: string; toolCallId?: string }>;
   }) => Promise<{
     fullText: string;
     usage: { promptTokens: number; completionTokens: number; totalTokens: number };
@@ -437,7 +437,7 @@ export function createWritingOrchestrator(
         // AND the AI returned finishReason === 'tool_use'
         if (request.agenticLoop && config.toolUseHandler && config.generateText) {
           let agenticRound = 0;
-          let agenticMessages: Array<{ role: string; content: string }> | undefined;
+          let agenticMessages: Array<{ role: string; content: string; toolCallId?: string }> | undefined;
 
           while (lastFinishReason === "tool_use" && agenticRound < AGENTIC_MAX_ROUNDS) {
             agenticRound++;
@@ -503,7 +503,7 @@ export function createWritingOrchestrator(
             agenticMessages = config.toolUseHandler.injectResults(
               msgsWithAssistant,
               results,
-            ) as Array<{ role: string; content: string }>;
+            ) as Array<{ role: string; content: string; toolCallId?: string }>;
 
             if (abortController.signal.aborted) {
               taskStates.set(requestId, "killed");

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -142,6 +142,8 @@ export interface WritingOrchestrator {
 const VALID_SKILL_IDS = ["polish", "expand", "summarize", "translate", "rewrite", "continue"];
 const PERMISSION_TIMEOUT_MS = 120_000;
 const MAX_TASK_ENTRIES = 1000;
+/** P2: Maximum agentic tool-use rounds — exported so ToolUseConfig.maxToolRounds stays in sync */
+export const AGENTIC_MAX_ROUNDS = 5;
 
 export function createWritingOrchestrator(
   config: OrchestratorConfig,
@@ -434,7 +436,6 @@ export function createWritingOrchestrator(
         // Only runs when request.agenticLoop is true AND toolUseHandler is configured
         // AND the AI returned finishReason === 'tool_use'
         if (request.agenticLoop && config.toolUseHandler && config.generateText) {
-          const AGENTIC_MAX_ROUNDS = 5;
           let agenticRound = 0;
           let agenticMessages: Array<{ role: string; content: string }> | undefined;
 

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -194,7 +194,6 @@ export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistr
 
   return registry;
 }
-}
 
 /**
  * P2: Create a read-only agentic tool registry for use in the Agentic Loop.

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -194,3 +194,131 @@ export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistr
 
   return registry;
 }
+}
+
+/**
+ * P2: Create a read-only agentic tool registry for use in the Agentic Loop.
+ *
+ * Only exposes tools that AI is permitted to call autonomously:
+ * - kgTool: query knowledge graph (read-only)
+ * - memTool: query writing memory (read-only)
+ * - docTool: read document content (read-only)
+ * - documentRead: read document text (P1 built-in, read-only)
+ *
+ * Intentionally EXCLUDES: documentWrite, versionSnapshot
+ * (AI must not be able to write documents autonomously)
+ */
+export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistry {
+  const registry = createToolRegistry();
+  const service = createDocumentService({ db: args.db, logger: args.logger });
+
+  // kgTool: query knowledge graph
+  // P2 stub — returns empty result when KG data is unavailable
+  registry.register(
+    buildTool({
+      name: "kgTool",
+      description: "Query the knowledge graph for character traits, locations, and world settings",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const query = typeof ctx["query"] === "string" ? ctx["query"] : "";
+        args.logger.info("agentic_tool_kg_query", { query, requestId: ctx.requestId });
+        // P2 stub: KG module not yet implemented, return empty
+        return {
+          success: true,
+          data: { entities: [], query },
+        };
+      },
+    }),
+  );
+
+  // memTool: query writing memory
+  // P2 stub — returns empty memories when Memory module is unavailable
+  registry.register(
+    buildTool({
+      name: "memTool",
+      description: "Query writing memory for style preferences and past writing patterns",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const query = typeof ctx["query"] === "string" ? ctx["query"] : "";
+        args.logger.info("agentic_tool_mem_query", { query, requestId: ctx.requestId });
+        // P2 stub: Memory module not yet fully implemented, return empty
+        return {
+          success: true,
+          data: { memories: [], query },
+        };
+      },
+    }),
+  );
+
+  // docTool: read document content
+  registry.register(
+    buildTool({
+      name: "docTool",
+      description: "Read the content of a document or chapter for context",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const targetDocId =
+          typeof ctx["targetDocumentId"] === "string"
+            ? ctx["targetDocumentId"]
+            : ctx.documentId;
+        const projectId =
+          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
+
+        if (!projectId) {
+          return {
+            success: true,
+            data: { content: "", documentId: targetDocId },
+          };
+        }
+
+        const result = service.read({ projectId, documentId: targetDocId });
+        if (!result.ok) {
+          return {
+            success: false,
+            error: { code: result.error.code, message: result.error.message },
+          };
+        }
+
+        return {
+          success: true,
+          data: { content: result.data.contentJson, documentId: targetDocId },
+        };
+      },
+    }),
+  );
+
+  // documentRead: read document text (P1 built-in, agentic-accessible)
+  registry.register(
+    buildTool({
+      name: "documentRead",
+      description: "Read the raw text of the current document",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const projectId =
+          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
+
+        if (!projectId) {
+          return {
+            success: true,
+            data: { text: "", documentId: ctx.documentId },
+          };
+        }
+
+        const result = service.read({ projectId, documentId: ctx.documentId });
+        if (!result.ok) {
+          return {
+            success: false,
+            error: { code: result.error.code, message: result.error.message },
+          };
+        }
+
+        return {
+          success: true,
+          data: { text: result.data.contentJson, documentId: ctx.documentId },
+        };
+      },
+    }),
+  );
+
+  return registry;
+}

--- a/apps/desktop/preload/src/aiStreamBridge.ts
+++ b/apps/desktop/preload/src/aiStreamBridge.ts
@@ -4,7 +4,9 @@ import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
+  type SkillToolUseEvent,
 } from "@shared/types/ai";
 import {
   JUDGE_RESULT_CHANNEL,
@@ -93,6 +95,28 @@ function isJudgeResultEvent(x: unknown): x is JudgeResultEvent {
   );
 }
 
+/**
+ * Best-effort runtime validation for tool-use push payload.
+ *
+ * Why: malformed push payloads must be ignored safely in preload.
+ */
+function isSkillToolUseEvent(x: unknown): x is SkillToolUseEvent {
+  if (!isRecord(x)) {
+    return false;
+  }
+  if (typeof x.executionId !== "string" || typeof x.runId !== "string" || typeof x.ts !== "number") {
+    return false;
+  }
+  if (typeof x.round !== "number") {
+    return false;
+  }
+  return (
+    x.type === "tool-use-started" ||
+    x.type === "tool-use-completed" ||
+    x.type === "tool-use-failed"
+  );
+}
+
 export type AiStreamBridgeApi = {
   registerAiStreamConsumer: () => IpcResponse<{ subscriptionId: string }>;
   releaseAiStreamConsumer: (subscriptionId: string) => void;
@@ -144,6 +168,19 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   const onSkillQueueStatus = (_evt: unknown, payload: unknown) => {
     forwardEvent(SKILL_QUEUE_STATUS_CHANNEL, payload);
   };
+  const onSkillToolUse = (_evt: unknown, payload: unknown) => {
+    if (subscriptions.count() === 0) {
+      return;
+    }
+    if (!isSkillToolUseEvent(payload)) {
+      return;
+    }
+    window.dispatchEvent(
+      new CustomEvent<SkillToolUseEvent>(SKILL_TOOL_USE_CHANNEL, {
+        detail: payload,
+      }),
+    );
+  };
   const onJudgeResult = (_evt: unknown, payload: unknown) => {
     if (subscriptions.count() === 0) {
       return;
@@ -162,6 +199,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   ipcRenderer.on(SKILL_STREAM_CHUNK_CHANNEL, onSkillStreamChunk);
   ipcRenderer.on(SKILL_STREAM_DONE_CHANNEL, onSkillStreamDone);
   ipcRenderer.on(SKILL_QUEUE_STATUS_CHANNEL, onSkillQueueStatus);
+  ipcRenderer.on(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
   ipcRenderer.on(JUDGE_RESULT_CHANNEL, onJudgeResult);
 
   return {
@@ -179,6 +217,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
         SKILL_QUEUE_STATUS_CHANNEL,
         onSkillQueueStatus,
       );
+      ipcRenderer.removeListener(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
       ipcRenderer.removeListener(JUDGE_RESULT_CHANNEL, onJudgeResult);
     },
   };

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -3,6 +3,8 @@ import type { IpcError } from "./ipc-generated";
 export const SKILL_STREAM_CHUNK_CHANNEL = "skill:stream:chunk" as const;
 export const SKILL_STREAM_DONE_CHANNEL = "skill:stream:done" as const;
 export const SKILL_QUEUE_STATUS_CHANNEL = "skill:queue:status" as const;
+/** P2: Agentic Loop tool-use event channel */
+export const SKILL_TOOL_USE_CHANNEL = "skill:tool-use" as const;
 
 export type AiStreamTerminal = "completed" | "cancelled" | "error";
 
@@ -64,3 +66,39 @@ export type AiStreamEvent =
   | AiStreamChunkEvent
   | AiStreamDoneEvent
   | AiQueueStatusEvent;
+
+/** P2: Tool-use event sent when an Agentic Loop tool call starts */
+export type SkillToolUseStartedEvent = {
+  type: "tool-use-started";
+  executionId: string;
+  runId: string;
+  round: number;
+  toolNames: string[];
+  ts: number;
+};
+
+/** P2: Tool-use event sent when an Agentic Loop round completes */
+export type SkillToolUseCompletedEvent = {
+  type: "tool-use-completed";
+  executionId: string;
+  runId: string;
+  round: number;
+  results: Array<{ toolName: string; success: boolean; durationMs: number }>;
+  hasNextRound: boolean;
+  ts: number;
+};
+
+/** P2: Tool-use event sent when an Agentic Loop round fails */
+export type SkillToolUseFailedEvent = {
+  type: "tool-use-failed";
+  executionId: string;
+  runId: string;
+  round: number;
+  error: { code: string; message: string; retryable: boolean };
+  ts: number;
+};
+
+export type SkillToolUseEvent =
+  | SkillToolUseStartedEvent
+  | SkillToolUseCompletedEvent
+  | SkillToolUseFailedEvent;

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -41,6 +41,10 @@ export type AiStreamDoneEvent = {
   outputText: string;
   error?: IpcError;
   result?: SkillResult;
+  /** P2: AI finish reason — 'stop' = normal completion, 'tool_use' = AI wants to call tools */
+  finishReason?: "stop" | "tool_use";
+  /** P2: Tool calls requested by the AI when finishReason === 'tool_use' */
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
   ts: number;
 };
 


### PR DESCRIPTION
Closes #47

## Summary

本 PR 完成 P2 第一条主缝：**WritingOrchestrator × ToolUseHandler** 端到端闭环接线。

### Core Changes (original)

| File | Change |
|------|--------|
| `orchestrator.ts` | Update `generateText` contract: return adds `finishReason`/`toolCalls`; args adds `messages?`; add `WritingRequest.agenticLoop` flag; insert tool-use-loop (Stage 4.5) between stream-response and ai-done |
| `orchestrator.ts` | Add `WritingEventType`: `tool-use-started` / `tool-use-completed` / `tool-use-failed` |
| `writingTooling.ts` | Add `createAgenticToolRegistry`: read-only tools (kgTool, memTool, docTool, documentRead), excludes documentWrite / versionSnapshot |
| `ipc/ai.ts` | Wire agentic registry + ToolUseHandler; set `agenticLoop: true` for continue skill; forward tool-use events via `SKILL_TOOL_USE_CHANNEL` |
| `packages/shared/types/ai.ts` | Add `SKILL_TOOL_USE_CHANNEL` + `SkillToolUse{Started,Completed,Failed}Event` |
| `orchestrator-agentic-loop.test.ts` | 12 new integration tests |

### Audit Fixes (bd88459)

| Finding | Fix |
|---------|-----|
| **F1 Blocking** — production `generateText` missing `finishReason`/`toolCalls` | Thread through `AiStreamDoneEvent`; parse OpenAI `finish_reason`+`tool_calls` and Anthropic `stop_reason`+`tool_use` blocks in streaming handlers; capture and return in `generateText` |
| **F2 Blocking** — production `generateText` ignores `messages` parameter | Add `overrideMessages` to `aiService.runSkill`; when `messages` provided, bypass skillExecutor and call aiService directly with injected message history |
| **F3 Blocking** — `SKILL_TOOL_USE_CHANNEL` not registered in preload | Add channel listener + `isSkillToolUseEvent` guard + dispose cleanup in `aiStreamBridge.ts` |
| **F4 Significant** — `{} as Database.Database` type deception | Replace with `createToolRegistry()` (empty registry) when `deps.db === null` — tools fail with NOT_FOUND instead of runtime explosion |
| **F5 Significant** — missing multi-unsafe-tool serial partition test | Add test with two unsafe tools, verify `unsafeA-end` strictly before `unsafeB-start` via execution order array |
| **F6 Minor** — `AGENTIC_MAX_ROUNDS` and `maxToolRounds` duplicated | Export `AGENTIC_MAX_ROUNDS` from `orchestrator.ts`, import in `ipc/ai.ts` for `ToolUseConfig.maxToolRounds` |
| **F7 Blocking** — overrideMessages path dropped tool history on round 2+ | Preserve `toolCallId` on OpenAI tool messages; convert Anthropic tool history into `tool_result` user blocks; add provider-level regression tests in `aiService-override-messages-tool.test.ts` |

## Validation Evidence

```bash
pnpm --dir apps/desktop exec vitest run --config vitest.config.core.ts   main/src/services/ai/__tests__/aiService-override-messages-tool.test.ts   main/src/services/skills/__tests__/tool-use-handler.test.ts   main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts   main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
# 4 files / 54 tests passed on bd88459
```

```bash
pnpm typecheck
# PASS
```

```bash
scripts/agent_pr_preflight.sh 50
# PASS
```

```text
GitHub required checks on bd88459: Build / Test / Quality Check / check = GREEN
```

## Visual Evidence

Backend-only PR — no UI changes.

### Embedded Screenshots

N/A（backend service only）

### Storybook Artifact / Link

- Link: N/A（backend service only）
- Visual acceptance note: N/A（no frontend changes）

## Risk & Rollback

**Risk**: Low — no behavioral change to existing P1 flow. F1/F2 activate only when AI provider returns `finish_reason: tool_calls` or Anthropic `stop_reason: tool_use`. F3/F4/F5/F6 are defensive hardening with no user-visible behavior change.

**Rollback**:
```bash
git revert bd88459
# or revert this PR — no breaking dependencies
```
Baseline main SHA: 08786f7f07cdc5180a0be5fe315e5bb00e93a797

## Audit Gate

- `scripts/agent_pr_preflight.sh`: GREEN (all local checks passed)
- Required checks: GREEN (Build / Test / Quality Check / check all passed on bd88459)
- [ ] Dual independent audit Subagents both publish `FINAL-VERDICT` + `ACCEPT` (zero findings)
- [x] auto-merge disabled, NOT merging


