### PR TITLE
fix: close P2 end-to-end tool loop (#47)

### DIFF
--- a/apps/desktop/main/src/__tests__/ai-stream-bridge.tool-use.test.ts
+++ b/apps/desktop/main/src/__tests__/ai-stream-bridge.tool-use.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SKILL_QUEUE_STATUS_CHANNEL,
+  SKILL_STREAM_CHUNK_CHANNEL,
+  SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
+} from "@shared/types/ai";
+
+const on = vi.fn();
+const removeListener = vi.fn();
+
+vi.mock("electron", () => ({
+  ipcRenderer: {
+    on,
+    removeListener,
+  },
+}));
+
+describe("registerAiStreamBridge tool-use forwarding", () => {
+  beforeEach(() => {
+    on.mockReset();
+    removeListener.mockReset();
+    const eventTarget = new EventTarget();
+    Object.assign(globalThis, { window: eventTarget });
+  });
+
+  it("preload 将 SKILL_TOOL_USE_CHANNEL 转发给 renderer", async () => {
+    const { registerAiStreamBridge } = await import("../../../preload/src/aiStreamBridge");
+    const bridge = registerAiStreamBridge();
+    const subscription = bridge.registerAiStreamConsumer();
+    expect(subscription.ok).toBe(true);
+
+    const received: Array<{ type: string; round: number }> = [];
+    window.addEventListener(SKILL_TOOL_USE_CHANNEL, (event) => {
+      const detail = (event as CustomEvent<{ type: string; round: number }>).detail;
+      received.push(detail);
+    });
+
+    const listener = on.mock.calls.find((call) => call[0] === SKILL_TOOL_USE_CHANNEL)?.[1];
+    expect(typeof listener).toBe("function");
+    listener?.({}, {
+      type: "tool-use-started",
+      executionId: "exec-1",
+      runId: "run-1",
+      round: 1,
+      toolNames: ["kgTool"],
+      ts: Date.now(),
+    });
+
+    expect(received).toEqual([expect.objectContaining({ type: "tool-use-started", round: 1 })]);
+    bridge.dispose();
+    expect(removeListener).toHaveBeenCalledWith(SKILL_TOOL_USE_CHANNEL, expect.any(Function));
+    expect(on).toHaveBeenCalledWith(SKILL_STREAM_CHUNK_CHANNEL, expect.any(Function));
+    expect(on).toHaveBeenCalledWith(SKILL_STREAM_DONE_CHANNEL, expect.any(Function));
+    expect(on).toHaveBeenCalledWith(SKILL_QUEUE_STATUS_CHANNEL, expect.any(Function));
+  });
+});

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-tool-use-loop.production.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-tool-use-loop.production.test.ts
@@ -1,0 +1,260 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAiService } from "../../services/ai/aiService";
+import { createWritingOrchestrator } from "../../services/skills/orchestrator";
+import { createSkillExecutor } from "../../services/skills/skillExecutor";
+import { createToolUseHandler } from "../../services/skills/toolUseHandler";
+import { createWritingToolRegistry, createAgenticToolRegistry } from "../../services/skills/writingTooling";
+import { createDocumentService } from "../../services/documents/documentService";
+import type { Logger } from "../../logging/logger";
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../db/migrations",
+);
+
+function createLogger(): Logger {
+  return { logPath: "<test>", info: () => {}, error: () => {} };
+}
+
+function applyAllMigrations(db: Database.Database): void {
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(".sql") && !file.includes("vec"))
+    .sort();
+  for (const file of files) {
+    db.exec(fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"));
+  }
+}
+
+function createProjectAndDocument(args: { db: Database.Database; text: string }) {
+  const projectId = "proj-1";
+  args.db
+    .prepare(
+      "INSERT INTO projects (project_id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(projectId, "测试项目", "/worktree/test-root", Date.now(), Date.now());
+
+  const service = createDocumentService({ db: args.db, logger: createLogger() });
+  const created = service.create({ projectId, title: "第一章", type: "chapter" });
+  if (!created.ok) {
+    throw new Error(created.error.message);
+  }
+  const saved = service.save({
+    projectId,
+    documentId: created.data.documentId,
+    contentJson: {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: args.text }] }],
+    },
+    actor: "user",
+    reason: "manual-save",
+  });
+  if (!saved.ok) {
+    throw new Error(saved.error.message);
+  }
+  return { projectId, documentId: created.data.documentId };
+}
+
+describe("production continue tool-use loop", () => {
+  const opened: Database.Database[] = [];
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    for (const db of opened.splice(0)) {
+      db.close();
+    }
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("continue 走通 real skillExecutor → aiService → tool result injection → ai-done", async () => {
+    const db = new Database(":memory:");
+    opened.push(db);
+    db.pragma("foreign_keys = ON");
+    applyAllMigrations(db);
+    const { projectId, documentId } = createProjectAndDocument({
+      db,
+      text: "夜幕降临，街灯次第亮起。",
+    });
+
+    const requestBodies: Array<Record<string, unknown>> = [];
+    let callNo = 0;
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      callNo += 1;
+      const rawBody = typeof init?.body === "string" ? init.body : "{}";
+      requestBodies.push(JSON.parse(rawBody) as Record<string, unknown>);
+      if (callNo === 1) {
+        return new Response(
+          [
+            `data: ${JSON.stringify({ choices: [{ delta: { content: "先看角色设定。" } }] })}`,
+            `data: ${JSON.stringify({
+              choices: [{
+                delta: {
+                  tool_calls: [{
+                    id: "call-kg-1",
+                    type: "function",
+                    function: {
+                      name: "kgTool",
+                      arguments: { query: "林远的性格特点" },
+                    },
+                  }],
+                },
+              }],
+            })}`,
+            `data: ${JSON.stringify({ choices: [{ finish_reason: "tool_calls" }] })}`,
+            "data: [DONE]",
+            "",
+          ].join("\n\n"),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(
+        [
+          `data: ${JSON.stringify({ choices: [{ delta: { content: "林远缓步推门，神色冷静。" } }] })}`,
+          `data: ${JSON.stringify({ choices: [{ finish_reason: "stop" }] })}`,
+          "data: [DONE]",
+          "",
+        ].join("\n\n"),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const aiService = createAiService({
+      logger: createLogger(),
+      env: {
+        CREONOW_AI_PROVIDER: "openai",
+        CREONOW_AI_BASE_URL: "https://api.openai.test",
+        CREONOW_AI_API_KEY: "sk-test",
+        CREONOW_AI_MODEL: "gpt-5.2",
+      },
+      sleep: async () => {},
+      rateLimitPerMinute: 1000,
+    });
+
+    const skillExecutor = createSkillExecutor({
+      resolveSkill: () => ({
+        ok: true,
+        data: {
+          id: "builtin:continue",
+          prompt: {
+            system:
+              "You are CreoNow's writing assistant. Continue writing from provided context, matching style and narrative constraints.",
+            user: "Continue the draft based on current context and constraints.\n\n<text>\n{{input}}\n</text>",
+          },
+          enabled: true,
+          valid: true,
+          inputType: "document",
+        },
+      }),
+      runSkill: aiService.runSkill,
+    });
+
+    const permissionGate = {
+      evaluate: vi.fn().mockResolvedValue({ level: "auto-allow", granted: true }),
+      requestPermission: vi.fn().mockResolvedValue(true),
+      releasePendingPermission: vi.fn(),
+    };
+
+    const orchestrator = createWritingOrchestrator({
+      aiService: { async *streamChat() { return; }, estimateTokens: (text) => text.length, abort: vi.fn() },
+      toolRegistry: createWritingToolRegistry({ db, logger: createLogger() }),
+      toolUseHandler: createToolUseHandler(createAgenticToolRegistry({ db, logger: createLogger() }), {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      }),
+      permissionGate,
+      postWritingHooks: [],
+      defaultTimeoutMs: 30_000,
+      prepareRequest: async () => ({
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are CreoNow's writing assistant. Continue writing from provided context, matching style and narrative constraints.",
+          },
+          {
+            role: "user",
+            content: "Continue the draft based on current context and constraints.\n\n<text>\n夜幕降临，街灯次第亮起。\n</text>",
+          },
+        ],
+        tokenCount: 10,
+        modelId: "gpt-5.2",
+      }),
+      generateText: async ({ request, signal, emitChunk, messages }) => {
+        let outputText = "";
+        let finishReason: "stop" | "tool_use" | null = null;
+        let toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> = [];
+        const res = await skillExecutor.execute({
+          skillId: request.skillId,
+          input: request.input.precedingText ?? "",
+          mode: "ask",
+          model: "gpt-5.2",
+          context: { projectId: request.projectId, documentId: request.documentId },
+          ...(messages ? { messages } : {}),
+          stream: true,
+          ts: Date.now(),
+          emitEvent: (event) => {
+            if (signal.aborted) {
+              return;
+            }
+            if (event.type === "chunk") {
+              outputText += event.chunk;
+              emitChunk(event.chunk, Number((event as { accumulatedTokens?: unknown }).accumulatedTokens ?? 0));
+              return;
+            }
+            if (event.type === "done") {
+              outputText = event.outputText;
+              finishReason = event.finishReason ?? null;
+              toolCalls = event.toolCalls ?? [];
+            }
+          },
+        });
+        if (!res.ok) {
+          throw res.error;
+        }
+        return {
+          fullText: outputText || res.data.outputText || "",
+          usage: { promptTokens: 10, completionTokens: outputText.length, totalTokens: 10 + outputText.length },
+          finishReason: finishReason ?? res.data.finishReason ?? null,
+          toolCalls: toolCalls.length > 0 ? toolCalls : (res.data.toolCalls ?? []),
+        };
+      },
+    });
+
+    const events = [] as Array<{ type: string; [key: string]: unknown }>;
+    for await (const event of orchestrator.execute({
+      requestId: "req-continue-1",
+      skillId: "builtin:continue",
+      input: { precedingText: "夜幕降临，街灯次第亮起。" },
+      documentId,
+      projectId,
+      cursorPosition: 10,
+      agenticLoop: true,
+    })) {
+      events.push(event as { type: string; [key: string]: unknown });
+    }
+
+    expect(callNo).toBe(2);
+    expect(events.map((event) => event.type)).toContain("tool-use-started");
+    expect(events.map((event) => event.type)).toContain("tool-use-completed");
+    expect(events.find((event) => event.type === "ai-done")?.fullText).toBe(
+      "林远缓步推门，神色冷静。",
+    );
+
+    const secondBody = requestBodies[1];
+    const messages = Array.isArray(secondBody.messages)
+      ? (secondBody.messages as Array<{ role?: string; content?: string }>)
+      : [];
+    const toolMessage = messages.find((message) => message.role === "tool");
+    expect(toolMessage?.content).toContain("query");
+    expect(toolMessage?.content).toContain("林远的性格特点");
+  });
+});

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1426,13 +1426,15 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       }
       return prepared.data;
     },
-    generateText: async ({ request, signal, emitChunk }) => {
+    generateText: async ({ request, signal, emitChunk, messages }) => {
       let outputText = "";
       let usage = {
         promptTokens: 0,
         completionTokens: 0,
         totalTokens: 0,
       };
+      let finishReason: "stop" | "tool_use" | null = null;
+      let toolCalls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> = [];
       let sawStreamChunk = false;
       let streamTerminalSeen = false;
       let settleStreamCompletion: (() => void) | null = null;
@@ -1454,6 +1456,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           projectId: request.projectId,
           documentId: request.documentId,
         },
+        ...(messages ? { messages } : {}),
         stream: true,
         ts: nowTs(),
         emitEvent: (event) => {
@@ -1483,6 +1486,8 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
                 (event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request))) +
                 (event.result?.metadata.completionTokens ?? estimateTokens(event.outputText)),
             };
+            finishReason = event.finishReason ?? null;
+            toolCalls = event.toolCalls ?? [];
             streamTerminalSeen = true;
             if (event.terminal === "completed") {
               settleStreamCompletion?.();
@@ -1519,6 +1524,9 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       return {
         fullText: outputText || res.data.outputText || "",
         usage,
+        finishReason: finishReason ?? res.data.finishReason ?? null,
+        toolCalls:
+          toolCalls.length > 0 ? toolCalls : (res.data.toolCalls ?? []),
       };
     },
   });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -9,6 +9,7 @@ import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
 } from "@shared/types/ai";
 import type { Logger } from "../logging/logger";
@@ -39,7 +40,8 @@ import {
   createWritingOrchestrator,
   type WritingEvent,
 } from "../services/skills/orchestrator";
-import { createWritingToolRegistry } from "../services/skills/writingTooling";
+import { createWritingToolRegistry, createAgenticToolRegistry } from "../services/skills/writingTooling";
+import { createToolUseHandler } from "../services/skills/toolUseHandler";
 import { estimateTokens } from "../services/context/tokenEstimation";
 import { createDocumentService } from "../services/documents/documentService";
 import { editorSchema } from "../services/editor/prosemirrorSchema";
@@ -597,6 +599,42 @@ function emitOrchestratorChunk(args: {
     sender: args.sender,
     event,
   });
+}
+
+/** P2: Emit a tool-use event to the renderer via SKILL_TOOL_USE_CHANNEL */
+function emitOrchestratorToolUse(args: {
+  ctx: AiIpcContext;
+  sender: Electron.WebContents;
+  executionId: string;
+  runId: string;
+  event: WritingEvent;
+}): void {
+  const { event } = args;
+  if (
+    event.type !== "tool-use-started" &&
+    event.type !== "tool-use-completed" &&
+    event.type !== "tool-use-failed"
+  ) {
+    return;
+  }
+  const base = {
+    executionId: args.executionId,
+    runId: args.runId,
+    ts: nowTs(),
+  };
+  const payload =
+    event.type === "tool-use-started"
+      ? { ...base, type: "tool-use-started" as const, round: Number(event.round), toolNames: (event.toolNames as string[]) ?? [] }
+      : event.type === "tool-use-completed"
+      ? { ...base, type: "tool-use-completed" as const, round: Number(event.round), results: (event.results as Array<{ toolName: string; success: boolean; durationMs: number }>) ?? [], hasNextRound: Boolean(event.hasNextRound) }
+      : { ...base, type: "tool-use-failed" as const, round: Number(event.round), error: (event.error as { code: string; message: string; retryable: boolean }) };
+  try {
+    args.sender.send(SKILL_TOOL_USE_CHANNEL, payload);
+  } catch (error) {
+    args.ctx.deps.logger.error("ai_tool_use_send_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 function emitOrchestratorDone(args: {
@@ -1315,6 +1353,24 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
             db: deps.db,
             logger: deps.logger,
           }),
+    // P2: Agentic tool-use handler backed by read-only tools only
+    toolUseHandler: createToolUseHandler(
+      deps.db === null
+        ? createAgenticToolRegistry({
+            db: {} as Database.Database,
+            logger: deps.logger,
+          })
+        : createAgenticToolRegistry({
+            db: deps.db,
+            logger: deps.logger,
+          }),
+      {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      },
+    ),
     permissionGate,
     postWritingHooks: [
       {
@@ -1657,6 +1713,22 @@ async function drainPreviewUntilPause(args: {
       continue;
     }
 
+    // P2: Forward tool-use events to renderer
+    if (
+      event.type === "tool-use-started" ||
+      event.type === "tool-use-completed" ||
+      event.type === "tool-use-failed"
+    ) {
+      emitOrchestratorToolUse({
+        ctx: args.ctx,
+        sender: args.sender,
+        executionId: args.executionId,
+        runId: args.runId,
+        event,
+      });
+      continue;
+    }
+
     if (event.type === "permission-denied") {
       emitOrchestratorDone({
         ctx: args.ctx,
@@ -1912,6 +1984,8 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
         modelId: normalizedPayload.model,
         ...(normalizedPayload.selection ? { selection: normalizedPayload.selection } : {}),
         ...(cursorPosition === undefined ? {} : { cursorPosition }),
+        // P2: enable agentic loop for the 'continue' skill
+        agenticLoop: leafSkillId(normalizedPayload.skillId) === "continue",
       });
 
       rememberRunInRegistry(ctx, {

--- a/apps/desktop/main/src/services/ai/aiPayloadParsers.ts
+++ b/apps/desktop/main/src/services/ai/aiPayloadParsers.ts
@@ -1,5 +1,12 @@
 type JsonObject = Record<string, unknown>;
 
+export type ParsedAiFinishReason = "stop" | "tool_use" | null;
+export type ParsedAiToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
 export type AiProvider = "anthropic" | "openai" | "proxy";
 
 function asObject(x: unknown): JsonObject | null {
@@ -37,6 +44,77 @@ export function extractOpenAiDelta(json: unknown): string | null {
   const delta = asObject(first?.delta);
   const content = delta?.content;
   return extractOpenAiContentText(content);
+}
+
+function parseToolCallArguments(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (typeof parsed === "object" && parsed !== null) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  if (typeof value === "object" && value !== null) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function normalizeOpenAiToolCall(value: unknown): ParsedAiToolCall | null {
+  const row = asObject(value);
+  const id = typeof row?.id === "string" ? row.id : "";
+  const fn = asObject(row?.function);
+  const name = typeof fn?.name === "string" ? fn.name : "";
+  if (id.length === 0 || name.length === 0) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    arguments: parseToolCallArguments(fn?.arguments),
+  };
+}
+
+function extractOpenAiChoice(json: unknown): JsonObject | null {
+  const obj = asObject(json);
+  const choices = obj ? obj.choices : null;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return null;
+  }
+  return asObject(choices[0]);
+}
+
+export function extractOpenAiFinishReason(
+  json: unknown,
+): ParsedAiFinishReason {
+  const first = extractOpenAiChoice(json);
+  const finishReason = first?.finish_reason;
+  if (finishReason === "stop") {
+    return "stop";
+  }
+  if (finishReason === "tool_calls" || finishReason === "tool_use") {
+    return "tool_use";
+  }
+  return null;
+}
+
+export function extractOpenAiToolCalls(json: unknown): ParsedAiToolCall[] {
+  const first = extractOpenAiChoice(json);
+  if (!first) {
+    return [];
+  }
+  const message = asObject(first.message);
+  const delta = asObject(first.delta);
+  const toolCalls = message?.tool_calls ?? delta?.tool_calls;
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+  return toolCalls
+    .map(normalizeOpenAiToolCall)
+    .filter((toolCall): toolCall is ParsedAiToolCall => toolCall !== null);
 }
 
 /**

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -1320,6 +1320,33 @@ function createAiRunPipelineHelpers(
     flushChunkBuffer,
   } = helpers;
 
+  function getResponseOutputText(entry: RunEntry): ServiceResult<string | undefined> {
+    if (entry.pendingChunkBuffer.length === 0) {
+      return {
+        ok: true,
+        data: entry.outputText.length > 0 ? entry.outputText : undefined,
+      };
+    }
+    const nextOutputLength =
+      entry.outputText.length + entry.pendingChunkBuffer.length;
+    if (nextOutputLength > maxSkillOutputChars) {
+      entry.controller.abort();
+      const oversizedError = buildSkillOutputTooLargeError(nextOutputLength);
+      setTerminal({
+        entry,
+        terminal: "error",
+        error: oversizedError,
+        logEvent: "ai_run_failed",
+        errorCode: oversizedError.code,
+      });
+      return { ok: false, error: oversizedError };
+    }
+    return {
+      ok: true,
+      data: `${entry.outputText}${entry.pendingChunkBuffer}`,
+    };
+  }
+
   async function executeNonStreamImpl(runCtx: {
     entry: RunEntry;
     primaryCfg: ProviderConfig;
@@ -1485,7 +1512,16 @@ function createAiRunPipelineHelpers(
     persistTraceAndGetDegradation: (
       output: string,
     ) => TracePersistenceDegradation | undefined;
-  }): Promise<void> {
+  }): Promise<
+    ServiceResult<{
+      executionId: string;
+      runId: string;
+      traceId: string;
+      outputText?: string;
+      finishReason?: "stop" | "tool_use" | null;
+      toolCalls?: AiToolCall[];
+    }>
+  > {
     const {
       entry,
       primaryCfg,
@@ -1523,7 +1559,7 @@ function createAiRunPipelineHelpers(
         }
 
         if (entry.terminal !== null) {
-          return;
+          return ipcError("CANCELED", "AI request canceled");
         }
 
         const normalizedError = normalizeSkillError(res.error);
@@ -1544,7 +1580,7 @@ function createAiRunPipelineHelpers(
                   : "ai_run_failed",
             errorCode: normalizedError.code,
           });
-          return;
+          return { ok: false, error: normalizedError };
         }
 
         replayAttempts += 1;
@@ -1566,14 +1602,27 @@ function createAiRunPipelineHelpers(
       }
 
       if (entry.terminal !== null) {
-        return;
+        return ipcError("CANCELED", "AI request canceled");
       }
 
       if (entry.completionTimer !== null) {
-        return;
+        return {
+          ok: true,
+          data: {
+            executionId,
+            runId,
+            traceId,
+            finishReason: entry.finishReason,
+            toolCalls: entry.toolCalls,
+          },
+        };
       }
 
       clearChunkFlushTimer(entry);
+      const responseOutputText = getResponseOutputText(entry);
+      if (!responseOutputText.ok) {
+        return responseOutputText;
+      }
       // Completion is deferred briefly so a near-simultaneous cancel can win.
       entry.completionTimer = setTimeout(() => {
         entry.completionTimer = null;
@@ -1606,9 +1655,26 @@ function createAiRunPipelineHelpers(
           });
         }, 0);
       }, STREAM_COMPLETION_SETTLE_MS);
+      return {
+        ok: true,
+        data: {
+          executionId,
+          runId,
+          traceId,
+          ...(typeof responseOutputText.data === "string"
+            ? { outputText: responseOutputText.data }
+            : {}),
+          ...(entry.finishReason === "tool_use"
+            ? {
+                finishReason: entry.finishReason,
+                toolCalls: entry.toolCalls,
+              }
+            : {}),
+        },
+      };
     } catch (error) {
       if (entry.terminal !== null) {
-        return;
+        return ipcError("CANCELED", "AI request canceled");
       }
 
       const aborted = controller.signal.aborted;
@@ -1619,22 +1685,24 @@ function createAiRunPipelineHelpers(
           logEvent: "ai_run_canceled",
           errorCode: "CANCELED",
         });
-        return;
+        return ipcError("CANCELED", "AI request canceled");
       }
 
+      const internalError = {
+        code: "INTERNAL" as const,
+        message: "AI request failed",
+        details: {
+          message: error instanceof Error ? error.message : String(error),
+        },
+      };
       setTerminal({
         entry,
         terminal: "error",
-        error: {
-          code: "INTERNAL",
-          message: "AI request failed",
-          details: {
-            message: error instanceof Error ? error.message : String(error),
-          },
-        },
+        error: internalError,
         logEvent: "ai_run_failed",
         errorCode: "INTERNAL",
       });
+      return { ok: false, error: internalError };
     }
   }
 
@@ -1957,36 +2025,21 @@ function createAiRunSkillOp(
             };
           }
 
-          void executeStreamImpl({
-            entry,
-            primaryCfg,
-            runtimeMessages,
-            model: args.model,
-            runId,
-            executionId,
-            traceId,
-            sessionKey,
-            promptTokens,
-            controller,
-            persistSuccessfulTurn,
-            persistTraceAndGetDegradation,
-          });
-
           return {
-            response: (async () => {
-              await completionPromise;
-              return {
-                ok: true,
-                data: {
-                  executionId,
-                  runId,
-                  traceId,
-                  outputText: entry.outputText,
-                  finishReason: entry.finishReason,
-                  toolCalls: entry.toolCalls,
-                },
-              };
-            })(),
+            response: executeStreamImpl({
+              entry,
+              primaryCfg,
+              runtimeMessages,
+              model: args.model,
+              runId,
+              executionId,
+              traceId,
+              sessionKey,
+              promptTokens,
+              controller,
+              persistSuccessfulTurn,
+              persistTraceAndGetDegradation,
+            }),
             completion: completionPromise,
           };
         }

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { IpcError, IpcErrorCode } from "@shared/types/ipc-generated";
-import type { AiStreamEvent, AiStreamTerminal } from "@shared/types/ai";
+import type { AiStreamEvent, AiStreamTerminal, AiToolCall } from "@shared/types/ai";
 import type { Logger } from "../../logging/logger";
 import { resolveRuntimeGovernanceFromEnv } from "../../config/runtimeGovernance";
 import {
@@ -9,7 +9,7 @@ import {
   type SkillSchedulerTerminal,
 } from "../skills/skillScheduler";
 import { startFakeAiServer, type FakeAiServer } from "./fakeAiServer";
-import { buildLLMMessages, type LLMMessage } from "./buildLLMMessages";
+import { buildLLMMessages } from "./buildLLMMessages";
 import {
   createChatMessageManager,
   type ChatMessageManager,
@@ -38,8 +38,10 @@ import {
   extractAnthropicDelta,
   extractAnthropicText,
   extractOpenAiDelta,
+  extractOpenAiFinishReason,
   extractOpenAiModels,
   extractOpenAiText,
+  extractOpenAiToolCalls,
   providerDisplayName,
 } from "./aiPayloadParsers";
 import { validateProviderPreflight } from "./providerPreflight";
@@ -71,6 +73,7 @@ export type AiService = {
     model: string;
     system?: string;
     context?: { projectId?: string; documentId?: string };
+    messages?: Array<{ role: string; content: string; toolCallId?: string }>;
     stream: boolean;
     ts: number;
     emitEvent: (event: AiStreamEvent) => void;
@@ -80,6 +83,8 @@ export type AiService = {
       runId: string;
       traceId: string;
       outputText?: string;
+      finishReason?: "stop" | "tool_use" | null;
+      toolCalls?: AiToolCall[];
       degradation?: TracePersistenceDegradation;
     }>
   >;
@@ -120,6 +125,9 @@ type RunEntry = {
   resolveSchedulerTerminal: (terminal: SkillSchedulerTerminal) => void;
   seq: number;
   outputText: string;
+  finishReason: "stop" | "tool_use" | null;
+  toolCalls: AiToolCall[];
+  promptTokens: number;
   pendingChunkBuffer: string;
   pendingChunkCount: number;
   emitEvent: (event: AiStreamEvent) => void;
@@ -133,7 +141,7 @@ const SSE_PARSE_RAW_MAX_LEN = 200;
 
 type RuntimeMessages = {
   systemText: string;
-  openAiMessages: LLMMessage[];
+  openAiMessages: Array<{ role: string; content: string }>;
   anthropicMessages: Array<{ role: "user" | "assistant"; content: string }>;
 };
 
@@ -330,7 +338,27 @@ function createAiSessionHelpers(state: AiInternalState) {
     system?: string;
     input: string;
     history: Array<{ role: "user" | "assistant"; content: string }>;
+    messages?: Array<{ role: string; content: string; toolCallId?: string }>;
   }): RuntimeMessages {
+    if (Array.isArray(args.messages) && args.messages.length > 0) {
+      const openAiMessages = args.messages.map((message) => ({
+        role: message.role,
+        content: message.content,
+      }));
+      return {
+        systemText: openAiMessages
+          .filter((message) => message.role === "system")
+          .map((message) => message.content)
+          .join("\n\n"),
+        openAiMessages,
+        anthropicMessages: openAiMessages
+          .filter((message) => message.role !== "system")
+          .map((message) => ({
+            role: message.role === "assistant" ? "assistant" : "user",
+            content: message.content,
+          })),
+      };
+    }
     const systemText = combineSystemText({
       systemPrompt: args.systemPrompt,
       modeHint: modeSystemHint(args.mode) ?? undefined,
@@ -554,6 +582,8 @@ function createAiEmitHelpers(deps: AiServiceDeps, state: AiInternalState) {
       traceId: entry.traceId,
       terminal: args.terminal,
       outputText: entry.outputText,
+      finishReason: entry.finishReason,
+      toolCalls: entry.toolCalls,
       ...(args.error ? { error: args.error } : {}),
       ts: args.ts ?? Date.now(),
     });
@@ -675,6 +705,8 @@ function createAiEmitHelpers(deps: AiServiceDeps, state: AiInternalState) {
   function resetForFullPromptReplay(entry: RunEntry): void {
     entry.seq = 0;
     entry.outputText = "";
+    entry.finishReason = null;
+    entry.toolCalls = [];
     clearChunkBuffer(entry);
   }
 
@@ -1100,6 +1132,14 @@ function createAiStreamHelpers(
           continue;
         }
         const delta = extractOpenAiDelta(parsed);
+        const finishReason = extractOpenAiFinishReason(parsed);
+        const toolCalls = extractOpenAiToolCalls(parsed);
+        if (finishReason !== null) {
+          args.entry.finishReason = finishReason;
+        }
+        if (toolCalls.length > 0) {
+          args.entry.toolCalls = toolCalls;
+        }
         if (typeof delta !== "string" || delta.length === 0) {
           continue;
         }
@@ -1119,6 +1159,9 @@ function createAiStreamHelpers(
 
     if (args.entry.controller.signal.aborted) {
       return ipcError("CANCELED", "AI request canceled");
+    }
+    if (sawDone && args.entry.finishReason === null) {
+      args.entry.finishReason = "stop";
     }
     if (args.entry.terminal === null && !sawDone) {
       return ipcError("LLM_API_ERROR", "Streaming connection interrupted", {
@@ -1300,6 +1343,8 @@ function createAiRunPipelineHelpers(
       runId: string;
       traceId: string;
       outputText?: string;
+      finishReason?: "stop" | "tool_use" | null;
+      toolCalls?: AiToolCall[];
       degradation?: TracePersistenceDegradation;
     }>
   > {
@@ -1386,6 +1431,8 @@ function createAiRunPipelineHelpers(
           runId,
           traceId,
           outputText: res.data,
+          finishReason: "stop",
+          toolCalls: [],
           ...(degradation ? { degradation } : {}),
         },
       };
@@ -1664,8 +1711,14 @@ function createAiRunSkillOp(
       system: args.system,
       input: args.input,
       history,
+      messages: args.messages,
     });
-    const promptTokens = estimateTokenCount(args.input);
+    const promptTokens =
+      Array.isArray(args.messages) && args.messages.length > 0
+        ? estimateTokenCount(
+            args.messages.map((message) => message.content).join("\n\n"),
+          )
+        : estimateTokenCount(args.input);
     const projectedTokens = promptTokens + DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE;
     const hasExplicitEnvTimeout =
       (typeof deps.env.CN_AI_TIMEOUT_MS === "string" &&
@@ -1699,6 +1752,9 @@ function createAiRunSkillOp(
       resolveSchedulerTerminal: resolveCompletion,
       seq: 0,
       outputText: "",
+      finishReason: null,
+      toolCalls: [],
+      promptTokens,
       pendingChunkBuffer: "",
       pendingChunkCount: 0,
       emitEvent: args.emitEvent,
@@ -1892,6 +1948,8 @@ function createAiRunSkillOp(
                   runId: string;
                   traceId: string;
                   outputText?: string;
+                  finishReason?: "stop" | "tool_use" | null;
+                  toolCalls?: AiToolCall[];
                   degradation?: TracePersistenceDegradation;
                 }>,
               ),
@@ -1915,10 +1973,20 @@ function createAiRunSkillOp(
           });
 
           return {
-            response: Promise.resolve({
-              ok: true,
-              data: { executionId, runId, traceId },
-            }),
+            response: (async () => {
+              await completionPromise;
+              return {
+                ok: true,
+                data: {
+                  executionId,
+                  runId,
+                  traceId,
+                  outputText: entry.outputText,
+                  finishReason: entry.finishReason,
+                  toolCalls: entry.toolCalls,
+                },
+              };
+            })(),
             completion: completionPromise,
           };
         }

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -2025,22 +2025,44 @@ function createAiRunSkillOp(
             };
           }
 
+          const streamResponse = executeStreamImpl({
+            entry,
+            primaryCfg,
+            runtimeMessages,
+            model: args.model,
+            runId,
+            executionId,
+            traceId,
+            sessionKey,
+            promptTokens,
+            controller,
+            persistSuccessfulTurn,
+            persistTraceAndGetDegradation,
+          });
+          const terminalAck = completionPromise.then((terminal) => {
+            if (terminal !== "cancelled" && terminal !== "timeout") {
+              return new Promise<
+                ServiceResult<{
+                  executionId: string;
+                  runId: string;
+                  traceId: string;
+                  outputText?: string;
+                  finishReason?: "stop" | "tool_use" | null;
+                  toolCalls?: AiToolCall[];
+                  degradation?: TracePersistenceDegradation;
+                }>
+              >(() => undefined);
+            }
+            return {
+              ok: true as const,
+              data: { executionId, runId, traceId },
+            };
+          });
+
           return {
-            response: executeStreamImpl({
-              entry,
-              primaryCfg,
-              runtimeMessages,
-              model: args.model,
-              runId,
-              executionId,
-              traceId,
-              sessionKey,
-              promptTokens,
-              controller,
-              persistSuccessfulTurn,
-              persistTraceAndGetDegradation,
-            }),
+            response: Promise.race([streamResponse, terminalAck]),
             completion: completionPromise,
+            preserveResponseOnTerminalError: true,
           };
         }
 

--- a/apps/desktop/main/src/services/ai/buildLLMMessages.ts
+++ b/apps/desktop/main/src/services/ai/buildLLMMessages.ts
@@ -15,7 +15,7 @@
 import { estimateUtf8TokenCount } from "@shared/tokenBudget";
 
 export type LLMMessage = {
-  role: "system" | "user" | "assistant";
+  role: "system" | "user" | "assistant" | "tool";
   content: string;
 };
 

--- a/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
@@ -1,0 +1,705 @@
+/**
+ * WritingOrchestrator P2 Agentic Loop 集成测试
+ *
+ * Spec: openspec/specs/skill-system/spec.md — P2: Agentic Loop（Tool-Use 循环）
+ *
+ * 覆盖：
+ * - Happy path：continue 技能 → tool_use → kgTool → stop → ai-done
+ * - All-failed：所有 tool call 失败 → TOOL_USE_ALL_FAILED → 继续到 ai-done
+ * - Max-rounds 熔断：超过 maxToolRounds → TOOL_USE_MAX_ROUNDS_EXCEEDED
+ * - 只读边界：documentWrite / versionSnapshot 不在 agentic registry
+ * - 非 agentic skill 忽略 tool_use（polish skill 时工具调用被丢弃）
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type {
+  WritingRequest,
+  WritingEvent,
+} from "../orchestrator";
+import { createWritingOrchestrator } from "../orchestrator";
+import { createToolRegistry, buildTool, type ToolRegistry } from "../toolRegistry";
+import type { ToolCallInfo } from "../../ai/streaming";
+import { createToolUseHandler, type ToolUseHandler } from "../toolUseHandler";
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+async function collectEvents(gen: AsyncGenerator<WritingEvent>): Promise<WritingEvent[]> {
+  const events: WritingEvent[] = [];
+  for await (const e of gen) {
+    events.push(e);
+  }
+  return events;
+}
+
+function eventTypes(events: WritingEvent[]): string[] {
+  return events.map((e) => e.type);
+}
+
+function makeRequest(overrides: Partial<WritingRequest> = {}): WritingRequest {
+  return {
+    requestId: "req-agentic-001",
+    skillId: "continue",
+    input: { precedingText: "夜幕降临，街灯次第亮起。" },
+    documentId: "doc-001",
+    projectId: "proj-001",
+    agenticLoop: true,
+    ...overrides,
+  };
+}
+
+function createMockPermissionGate(autoGrant = true) {
+  return {
+    evaluate: vi.fn().mockResolvedValue({ level: "auto-allow", granted: true }),
+    requestPermission: vi.fn().mockResolvedValue(autoGrant),
+    releasePendingPermission: vi.fn(),
+  };
+}
+
+/** Build a read-only agentic tool registry (kgTool, memTool, docTool – no write tools) */
+function createReadOnlyAgenticRegistry(): ToolRegistry {
+  const registry = createToolRegistry();
+  registry.register(buildTool({
+    name: "kgTool",
+    description: "Query knowledge graph",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { name: "林远", traits: ["冷静"] } }),
+  }));
+  registry.register(buildTool({
+    name: "memTool",
+    description: "Query memory",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { memories: [] } }),
+  }));
+  registry.register(buildTool({
+    name: "docTool",
+    description: "Read document",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { content: "..." } }),
+  }));
+  // documentRead: also read-only, agentic-accessible
+  registry.register(buildTool({
+    name: "documentRead",
+    description: "Read document text",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { text: "..." } }),
+  }));
+  // documentWrite and versionSnapshot intentionally NOT registered in agentic registry
+  return registry;
+}
+
+/** Build a full write registry (used by orchestrator for write-back, NOT by agentic loop) */
+function createWriteRegistry(): ToolRegistry {
+  const registry = createToolRegistry();
+  registry.register(buildTool({
+    name: "documentWrite",
+    description: "Write to document",
+    isConcurrencySafe: false,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "v-write-001" } }),
+  }));
+  registry.register(buildTool({
+    name: "versionSnapshot",
+    description: "Create version snapshot",
+    isConcurrencySafe: false,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "v-snap-001" } }),
+  }));
+  return registry;
+}
+
+function makeToolCallInfo(name: string, args: Record<string, unknown> = {}, id?: string): ToolCallInfo {
+  return { id: id ?? `call-${name}-${Date.now()}`, name, arguments: args };
+}
+
+// ─── test suite ─────────────────────────────────────────────────────
+
+describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
+  let agenticRegistry: ToolRegistry;
+  let agenticHandler: ToolUseHandler;
+  let writeRegistry: ToolRegistry;
+  let permissionGate: ReturnType<typeof createMockPermissionGate>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    agenticRegistry = createReadOnlyAgenticRegistry();
+    agenticHandler = createToolUseHandler(agenticRegistry, {
+      maxToolRounds: 5,
+      toolTimeoutMs: 10_000,
+      maxConcurrentTools: 4,
+      agenticLoop: true,
+    });
+    writeRegistry = createWriteRegistry();
+    permissionGate = createMockPermissionGate(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────
+
+  describe("Happy path — continue 技能触发 Agentic Loop", () => {
+    it("AI 第一轮返回 tool_use，执行 kgTool，第二轮返回 stop → 完整事件序列正确", async () => {
+      // Round 1: AI returns tool_use with kgTool call
+      // Round 2: AI returns stop after seeing tool results
+      let callCount = 0;
+      const kgToolCallId = "call-kg-001";
+
+      const generateText = vi.fn().mockImplementation(async (args: {
+        messages?: Array<{ role: string; content: string }>;
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: return partial text + tool_use
+          args.emitChunk("林远", 2);
+          return {
+            fullText: "林远",
+            usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "林远的性格特点" }, kgToolCallId)],
+          };
+        }
+        // Second call: messages should include tool results
+        expect(args.messages).toBeDefined();
+        expect(args.messages!.length).toBeGreaterThan(0);
+        // Verify tool result was injected (role: tool)
+        const toolMsg = args.messages!.find((m) => m.role === "tool");
+        expect(toolMsg).toBeDefined();
+
+        args.emitChunk("缓步走向那扇门，", 10);
+        args.emitChunk("眼神沉静。", 15);
+        return {
+          fullText: "缓步走向那扇门，眼神沉静。",
+          usage: { promptTokens: 30, completionTokens: 15, totalTokens: 45 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Must include tool-use-started and tool-use-completed
+      expect(types).toContain("tool-use-started");
+      expect(types).toContain("tool-use-completed");
+      expect(types).not.toContain("tool-use-failed");
+
+      // Verify order: tool-use-started before tool-use-completed, after first ai-chunk
+      const startedIdx = types.indexOf("tool-use-started");
+      const completedIdx = types.indexOf("tool-use-completed");
+      expect(startedIdx).toBeLessThan(completedIdx);
+
+      // tool-use-started must come AFTER first ai-chunk
+      const firstChunkIdx = types.indexOf("ai-chunk");
+      expect(firstChunkIdx).toBeLessThan(startedIdx);
+
+      // tool-use-started event shape
+      const startedEvent = events[startedIdx];
+      expect(startedEvent.round).toBe(1);
+      expect(startedEvent.toolNames).toEqual(["kgTool"]);
+
+      // tool-use-completed event shape
+      const completedEvent = events[completedIdx];
+      expect(completedEvent.round).toBe(1);
+      const results = completedEvent.results as Array<{ toolName: string; success: boolean; durationMs: number }>;
+      expect(results).toHaveLength(1);
+      expect(results[0].toolName).toBe("kgTool");
+      expect(results[0].success).toBe(true);
+      expect(completedEvent.hasNextRound).toBe(false);
+
+      // ai-done must appear after tool-use loop
+      const aiDoneIdx = types.indexOf("ai-done");
+      expect(aiDoneIdx).toBeGreaterThan(completedIdx);
+
+      // Final fullText should be from round 2
+      const aiDoneEvent = events[aiDoneIdx];
+      expect(aiDoneEvent.fullText).toBe("缓步走向那扇门，眼神沉静。");
+
+      // generateText was called twice
+      expect(callCount).toBe(2);
+
+      // Pipeline continues normally: write-back-done (since permission auto-allow)
+      expect(types).toContain("write-back-done");
+      expect(types).toContain("hooks-done");
+    });
+
+    it("两轮 tool-use 后 stop → round 事件递增", async () => {
+      let callCount = 0;
+
+      const generateText = vi.fn().mockImplementation(async (args: {
+        messages?: Array<{ role: string; content: string }>;
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          args.emitChunk("第一轮", 3);
+          return {
+            fullText: "第一轮",
+            usage: { promptTokens: 10, completionTokens: 3, totalTokens: 13 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "人物A" }, "call-r1")],
+          };
+        }
+        if (callCount === 2) {
+          args.emitChunk("第二轮", 6);
+          return {
+            fullText: "第二轮",
+            usage: { promptTokens: 20, completionTokens: 6, totalTokens: 26 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("memTool", { query: "偏好" }, "call-r2")],
+          };
+        }
+        args.emitChunk("最终续写内容", 12);
+        return {
+          fullText: "最终续写内容",
+          usage: { promptTokens: 30, completionTokens: 12, totalTokens: 42 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      const startedEvents = events.filter((e) => e.type === "tool-use-started");
+      const completedEvents = events.filter((e) => e.type === "tool-use-completed");
+
+      expect(startedEvents).toHaveLength(2);
+      expect(completedEvents).toHaveLength(2);
+
+      expect(startedEvents[0].round).toBe(1);
+      expect(startedEvents[1].round).toBe(2);
+      expect(completedEvents[0].round).toBe(1);
+      expect(completedEvents[1].round).toBe(2);
+
+      // First round: kgTool started, second: memTool started
+      expect(startedEvents[0].toolNames).toEqual(["kgTool"]);
+      expect(startedEvents[1].toolNames).toEqual(["memTool"]);
+
+      // hasNextRound: first true (round 2 coming), second false (no more)
+      expect(completedEvents[0].hasNextRound).toBe(true);
+      expect(completedEvents[1].hasNextRound).toBe(false);
+
+      expect(callCount).toBe(3);
+      expect(types).toContain("ai-done");
+    });
+  });
+
+  // ── All-failed ───────────────────────────────────────────────────
+
+  describe("All-failed — 本轮所有 tool call 均失败", () => {
+    it("kgTool 失败 → yield tool-use-failed(TOOL_USE_ALL_FAILED) → 继续到 ai-done", async () => {
+      // Create a registry where kgTool always fails
+      const failingRegistry = createToolRegistry();
+      failingRegistry.register(buildTool({
+        name: "kgTool",
+        description: "Always fails",
+        isConcurrencySafe: true,
+        execute: vi.fn().mockResolvedValue({
+          success: false,
+          error: { code: "KG_ERROR", message: "KG not available" },
+        }),
+      }));
+
+      const failingHandler = createToolUseHandler(failingRegistry, {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      });
+
+      let callCount = 0;
+      const generateText = vi.fn().mockImplementation(async (args: {
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          args.emitChunk("部分续写", 4);
+          return {
+            fullText: "部分续写",
+            usage: { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "林远" }, "call-fail")],
+          };
+        }
+        // Should NOT be called after all-failed
+        return {
+          fullText: "不应该到这里",
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: failingHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Must have tool-use-started
+      expect(types).toContain("tool-use-started");
+
+      // Must yield tool-use-failed with TOOL_USE_ALL_FAILED
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+      expect(failedEvent!.round).toBe(1);
+
+      // Pipeline should NOT call AI again after all-failed
+      expect(callCount).toBe(1);
+
+      // Should continue to ai-done with partial text
+      expect(types).toContain("ai-done");
+      const aiDoneEvent = events.find((e) => e.type === "ai-done");
+      expect((aiDoneEvent!.fullText as string)).toBe("部分续写");
+
+      // Should still complete write-back (permission auto-allow)
+      expect(types).toContain("write-back-done");
+    });
+
+    it("未注册的 tool → TOOL_USE_TOOL_NOT_FOUND 导致 all-failed → tool-use-failed", async () => {
+      // Empty agentic registry - no tools registered
+      const emptyRegistry = createToolRegistry();
+      const emptyHandler = createToolUseHandler(emptyRegistry, {
+        maxToolRounds: 5,
+        toolTimeoutMs: 10_000,
+        maxConcurrentTools: 4,
+        agenticLoop: true,
+      });
+
+      const generateText = vi.fn()
+        .mockResolvedValueOnce({
+          fullText: "AI 想调用不存在的工具",
+          usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("unknownTool", {}, "call-unknown")],
+        })
+        .mockResolvedValueOnce({
+          fullText: "不应调用第二次",
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: emptyHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+
+      // AI was only called once (no re-call after all-failed)
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Max-rounds 熔断 ──────────────────────────────────────────────
+
+  describe("Max-rounds 熔断", () => {
+    it("AI 持续返回 tool_use，到达 maxToolRounds(5) → TOOL_USE_MAX_ROUNDS_EXCEEDED", async () => {
+      let callCount = 0;
+
+      const generateText = vi.fn().mockImplementation(async (args: {
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        args.emitChunk(`轮次${callCount}`, callCount * 2);
+        // Always return tool_use until max rounds
+        return {
+          fullText: `轮次${callCount}`,
+          usage: { promptTokens: 5, completionTokens: callCount * 2, totalTokens: 5 + callCount * 2 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("kgTool", { query: `query-${callCount}` }, `call-${callCount}`)],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Should have exactly 5 tool-use-started events (maxToolRounds = 5)
+      const startedEvents = events.filter((e) => e.type === "tool-use-started");
+      expect(startedEvents).toHaveLength(5);
+
+      // Should have tool-use-failed with TOOL_USE_MAX_ROUNDS_EXCEEDED at the end
+      const failedEvents = events.filter((e) => e.type === "tool-use-failed");
+      expect(failedEvents.length).toBeGreaterThanOrEqual(1);
+      const maxRoundsEvent = failedEvents.find(
+        (e) => (e.error as { code: string }).code === "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+      );
+      expect(maxRoundsEvent).toBeDefined();
+      expect(maxRoundsEvent!.round).toBe(5);
+
+      // Should still proceed to ai-done with last partial content
+      expect(types).toContain("ai-done");
+
+      // AI was called 1 (initial) + 5 (after each tool round) = 6 times
+      expect(callCount).toBe(6);
+    });
+  });
+
+  // ── 只读边界 ─────────────────────────────────────────────────────
+
+  describe("只读边界 — documentWrite / versionSnapshot 不在 agentic registry", () => {
+    it("AI 请求 documentWrite → TOOL_USE_TOOL_NOT_FOUND → all-failed", async () => {
+      // The agenticRegistry (read-only) does NOT have documentWrite
+      // Even if the write registry has it, AI cannot access it via the agentic loop
+
+      const generateText = vi.fn()
+        .mockResolvedValueOnce({
+          fullText: "AI 试图写入文档",
+          usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("documentWrite", { content: "恶意写入" }, "call-write")],
+        });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler, // backed by read-only agenticRegistry
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+
+      // tool-use-started should be emitted (we tried to call it)
+      const startedEvent = events.find((e) => e.type === "tool-use-started");
+      expect(startedEvent).toBeDefined();
+      expect(startedEvent!.toolNames).toEqual(["documentWrite"]);
+
+      // Should fail because documentWrite is not in agentic registry
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+
+      // Verify that documentWrite was NOT called (tool not found in agentic registry)
+      void writeRegistry; // registry is not called directly here
+    });
+
+    it("AI 请求 versionSnapshot → TOOL_USE_TOOL_NOT_FOUND → all-failed", async () => {
+      const generateText = vi.fn()
+        .mockResolvedValueOnce({
+          fullText: "尝试快照",
+          usage: { promptTokens: 5, completionTokens: 3, totalTokens: 8 },
+          finishReason: "tool_use" as const,
+          toolCalls: [makeToolCallInfo("versionSnapshot", {}, "call-snap")],
+        });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const failedEvent = events.find((e) => e.type === "tool-use-failed");
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
+
+      // AI was only called once (no re-call after all-failed)
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+
+    it("agentic registry 中不包含 documentWrite（只读约束验证）", () => {
+      // Direct registry inspection
+      expect(agenticRegistry.get("documentWrite")).toBeUndefined();
+      expect(agenticRegistry.get("versionSnapshot")).toBeUndefined();
+
+      // Read-only tools ARE available
+      expect(agenticRegistry.get("kgTool")).toBeDefined();
+      expect(agenticRegistry.get("memTool")).toBeDefined();
+      expect(agenticRegistry.get("docTool")).toBeDefined();
+      expect(agenticRegistry.get("documentRead")).toBeDefined();
+    });
+  });
+
+  // ── 非 Agentic skill 忽略 tool_use ──────────────────────────────
+
+  describe("非 Agentic skill — polish/rewrite 不触发 tool-use loop", () => {
+    it("polish skill (agenticLoop: false) → AI 意外返回 tool_use → 忽略，使用已生成文本", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "润色后的文字。",
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+        // AI accidentally returns tool_use, but skill doesn't have agenticLoop enabled
+        finishReason: "tool_use" as const,
+        toolCalls: [makeToolCallInfo("kgTool", {}, "call-ignored")],
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({
+        skillId: "polish",
+        input: { selectedText: "他慢慢地走到了那扇门的前面" },
+        agenticLoop: false, // polish does NOT enable agentic loop
+      })));
+
+      const types = eventTypes(events);
+
+      // NO tool-use events
+      expect(types).not.toContain("tool-use-started");
+      expect(types).not.toContain("tool-use-completed");
+      expect(types).not.toContain("tool-use-failed");
+
+      // AI was only called once
+      expect(generateText).toHaveBeenCalledTimes(1);
+
+      // ai-done uses the text from the single AI call
+      const aiDoneEvent = events.find((e) => e.type === "ai-done");
+      expect(aiDoneEvent).toBeDefined();
+      expect(aiDoneEvent!.fullText).toBe("润色后的文字。");
+
+      // Pipeline completes normally
+      expect(types).toContain("write-back-done");
+    });
+  });
+
+  // ── WritingRequest.agenticLoop flag ─────────────────────────────
+
+  describe("agenticLoop flag 控制", () => {
+    it("agenticLoop: undefined → 默认不启用 agentic loop", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "续写内容",
+        usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+        finishReason: "tool_use" as const,
+        toolCalls: [makeToolCallInfo("kgTool", {}, "call-x")],
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      // No agenticLoop flag set
+      const events = await collectEvents(orchestrator.execute(makeRequest({
+        agenticLoop: undefined,
+      })));
+
+      const types = eventTypes(events);
+      expect(types).not.toContain("tool-use-started");
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+
+    it("agenticLoop: true 但没有 toolUseHandler → 不触发 loop", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "续写",
+        usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+        finishReason: "tool_use" as const,
+        toolCalls: [makeToolCallInfo("kgTool", {}, "call-y")],
+      });
+
+      // No toolUseHandler in config
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 5, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        // toolUseHandler: intentionally omitted
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({ agenticLoop: true })));
+      const types = eventTypes(events);
+
+      // No tool-use events since toolUseHandler is not in config
+      expect(types).not.toContain("tool-use-started");
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── finishReason === null (IPC production case) ─────────────────
+
+  describe("finishReason === null 时不触发 loop（生产 IPC 路径）", () => {
+    it("generateText 返回 finishReason: null → 正常走完 ai-done，不触发 tool-use", async () => {
+      const generateText = vi.fn().mockResolvedValue({
+        fullText: "续写结果",
+        usage: { promptTokens: 10, completionTokens: 8, totalTokens: 18 },
+        finishReason: null, // IPC 生产路径返回 null
+        toolCalls: [],
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({ agenticLoop: true })));
+      const types = eventTypes(events);
+
+      expect(types).not.toContain("tool-use-started");
+      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(types).toContain("ai-done");
+    });
+  });
+});

--- a/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
@@ -332,6 +332,7 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
       let callCount = 0;
       const generateText = vi.fn().mockImplementation(async (args: {
         emitChunk: (delta: string, tokens: number) => void;
+        messages?: Array<{ role: string; content: string }>;
       }) => {
         callCount++;
         if (callCount === 1) {
@@ -343,10 +344,12 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
             toolCalls: [makeToolCallInfo("kgTool", { query: "林远" }, "call-fail")],
           };
         }
-        // Should NOT be called after all-failed
+        expect(args.messages).toBeDefined();
+        const failedToolMessage = args.messages?.find((message) => message.role === "tool");
+        expect(failedToolMessage?.content).toContain("KG_ERROR");
         return {
-          fullText: "不应该到这里",
-          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          fullText: "工具失败后继续续写",
+          usage: { promptTokens: 6, completionTokens: 8, totalTokens: 14 },
           finishReason: "stop" as const,
           toolCalls: [],
         };
@@ -374,13 +377,13 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
       expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
       expect(failedEvent!.round).toBe(1);
 
-      // Pipeline should NOT call AI again after all-failed
-      expect(callCount).toBe(1);
+      // Failure result must be injected and the AI must get another turn
+      expect(callCount).toBe(2);
 
-      // Should continue to ai-done with partial text
+      // Should continue to ai-done with the second-round text instead of breaking on partial text
       expect(types).toContain("ai-done");
       const aiDoneEvent = events.find((e) => e.type === "ai-done");
-      expect((aiDoneEvent!.fullText as string)).toBe("部分续写");
+      expect((aiDoneEvent!.fullText as string)).toBe("工具失败后继续续写");
 
       // Should still complete write-back (permission auto-allow)
       expect(types).toContain("write-back-done");
@@ -403,11 +406,17 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
           finishReason: "tool_use" as const,
           toolCalls: [makeToolCallInfo("unknownTool", {}, "call-unknown")],
         })
-        .mockResolvedValueOnce({
-          fullText: "不应调用第二次",
-          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
-          finishReason: "stop" as const,
-          toolCalls: [],
+        .mockImplementationOnce(async (args: {
+          messages?: Array<{ role: string; content: string }>;
+        }) => {
+          const toolMessage = args.messages?.find((message) => message.role === "tool");
+          expect(toolMessage?.content).toContain("TOOL_USE_TOOL_NOT_FOUND");
+          return {
+            fullText: "未知工具失败后仍继续生成",
+            usage: { promptTokens: 4, completionTokens: 6, totalTokens: 10 },
+            finishReason: "stop" as const,
+            toolCalls: [],
+          };
         });
 
       const orchestrator = createWritingOrchestrator({
@@ -424,9 +433,9 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
       const failedEvent = events.find((e) => e.type === "tool-use-failed");
       expect(failedEvent).toBeDefined();
       expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
-
-      // AI was only called once (no re-call after all-failed)
-      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(generateText).toHaveBeenCalledTimes(2);
+      const aiDoneEvent = events.find((e) => e.type === "ai-done");
+      expect(aiDoneEvent?.fullText).toBe("未知工具失败后仍继续生成");
     });
   });
 
@@ -532,6 +541,18 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
           usage: { promptTokens: 5, completionTokens: 3, totalTokens: 8 },
           finishReason: "tool_use" as const,
           toolCalls: [makeToolCallInfo("versionSnapshot", {}, "call-snap")],
+        })
+        .mockImplementationOnce(async (args: {
+          messages?: Array<{ role: string; content: string }>;
+        }) => {
+          const toolMessage = args.messages?.find((message) => message.role === "tool");
+          expect(toolMessage?.content).toContain("TOOL_USE_TOOL_NOT_FOUND");
+          return {
+            fullText: "未知工具失败后仍继续生成",
+            usage: { promptTokens: 4, completionTokens: 6, totalTokens: 10 },
+            finishReason: "stop" as const,
+            toolCalls: [],
+          };
         });
 
       const orchestrator = createWritingOrchestrator({
@@ -548,9 +569,9 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
       const failedEvent = events.find((e) => e.type === "tool-use-failed");
       expect(failedEvent).toBeDefined();
       expect((failedEvent!.error as { code: string }).code).toBe("TOOL_USE_ALL_FAILED");
-
-      // AI was only called once (no re-call after all-failed)
-      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(generateText).toHaveBeenCalledTimes(2);
+      const aiDoneEvent = events.find((e) => e.type === "ai-done");
+      expect(aiDoneEvent?.fullText).toBe("未知工具失败后仍继续生成");
     });
 
     it("agentic registry 中不包含 documentWrite（只读约束验证）", () => {
@@ -673,9 +694,9 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
     });
   });
 
-  // ── finishReason === null (IPC production case) ─────────────────
+  // ── finishReason === null（非 tool_use 返回） ─────────────────
 
-  describe("finishReason === null 时不触发 loop（生产 IPC 路径）", () => {
+  describe("finishReason === null 时不触发 loop（非 tool_use 返回）", () => {
     it("generateText 返回 finishReason: null → 正常走完 ai-done，不触发 tool-use", async () => {
       const generateText = vi.fn().mockResolvedValue({
         fullText: "续写结果",

--- a/apps/desktop/main/src/services/skills/__tests__/tool-use-handler.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/tool-use-handler.test.ts
@@ -677,10 +677,10 @@ describe("ToolUseHandler — Agentic Loop", () => {
           requestId: "req-001",
         }),
       );
-      // Verify AI-provided arguments are forwarded
+      // Verify AI-provided arguments are forwarded via AgenticToolContext.args
       expect(executeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          arguments: { query: "林远", entityType: "character" },
+          args: { query: "林远", entityType: "character" },
         }),
       );
     });

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -311,6 +311,7 @@ export function createWritingOrchestrator(
                     chunkQueue.push({ delta, accumulatedTokens });
                     wake();
                   },
+                  messages: prepared.messages,
                 })
                 .then(
                   (result) => {
@@ -474,19 +475,7 @@ export function createWritingOrchestrator(
             };
             const results = await config.toolUseHandler.executeToolBatch(parsedCalls, toolCtx);
 
-            // Check all-failed
             const summary = config.toolUseHandler.getBatchSummary(results);
-            if (summary.allFailed) {
-              yield makeEvent("tool-use-failed", requestId, {
-                round: agenticRound,
-                error: {
-                  code: "TOOL_USE_ALL_FAILED",
-                  message: "All tool calls in this round failed",
-                  retryable: false,
-                },
-              });
-              break;
-            }
 
             // Inject tool results into message history
             const baseMsgs = agenticMessages ?? prepared.messages;
@@ -503,6 +492,17 @@ export function createWritingOrchestrator(
               msgsWithAssistant,
               results,
             ) as Array<{ role: string; content: string }>;
+
+            if (summary.allFailed) {
+              yield makeEvent("tool-use-failed", requestId, {
+                round: agenticRound,
+                error: {
+                  code: "TOOL_USE_ALL_FAILED",
+                  message: "All tool calls in this round failed",
+                  retryable: false,
+                },
+              });
+            }
 
             if (abortController.signal.aborted) {
               taskStates.set(requestId, "killed");

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -9,7 +9,8 @@
  */
 
 import type { ToolRegistry } from "./toolRegistry";
-import type { StreamChunk } from "../ai/streaming";
+import type { StreamChunk, ToolCallInfo } from "../ai/streaming";
+import type { ToolUseHandler } from "./toolUseHandler";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -27,6 +28,8 @@ export interface WritingRequest {
     text: string;
     selectionTextHash: string;
   };
+  /** P2: set to true for skills that support Agentic Loop (e.g. continue) */
+  agenticLoop?: boolean;
 }
 
 export type WritingEventType =
@@ -41,7 +44,11 @@ export type WritingEventType =
   | "write-back-done"
   | "hooks-done"
   | "aborted"
-  | "error";
+  | "error"
+  // P2 Agentic Loop events
+  | "tool-use-started"
+  | "tool-use-completed"
+  | "tool-use-failed";
 
 export type WritingEvent = {
   type: WritingEventType;
@@ -70,6 +77,10 @@ interface PreparedRequest {
 type GeneratedTextResult = {
   fullText: string;
   usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  /** P2: finish reason from the AI */
+  finishReason?: "stop" | "tool_use" | null;
+  /** P2: tool calls requested by the AI */
+  toolCalls?: ToolCallInfo[];
 };
 
 function readVersionId(data: unknown): string | null {
@@ -102,14 +113,22 @@ export interface OrchestratorConfig {
   permissionGate: PermissionGate;
   postWritingHooks: PostWritingHook[];
   defaultTimeoutMs: number;
+  /** P2: handler for Agentic Loop tool execution (read-only registry) */
+  toolUseHandler?: ToolUseHandler;
   prepareRequest?: (request: WritingRequest) => Promise<PreparedRequest>;
   generateText?: (args: {
     request: WritingRequest;
     signal: AbortSignal;
     emitChunk: (delta: string, accumulatedTokens: number) => void;
+    /** P2: updated messages for subsequent agentic loop rounds */
+    messages?: Array<{ role: string; content: string }>;
   }) => Promise<{
     fullText: string;
     usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+    /** P2: finish reason from the AI (null = streaming, stop = done, tool_use = wants tools) */
+    finishReason?: "stop" | "tool_use" | null;
+    /** P2: tool calls requested by the AI when finishReason === 'tool_use' */
+    toolCalls?: ToolCallInfo[];
   }>;
 }
 
@@ -260,11 +279,15 @@ export function createWritingOrchestrator(
         const MAX_AI_RETRIES = 2;
         let aiAttempt = 0;
         let aiSuccess = false;
+        let lastFinishReason: "stop" | "tool_use" | null = null;
+        let lastToolCalls: ToolCallInfo[] = [];
 
         while (aiAttempt <= MAX_AI_RETRIES && !aiSuccess) {
           try {
             fullText = "";
             lastTokens = 0;
+            lastFinishReason = null;
+            lastToolCalls = [];
 
             if (config.generateText) {
               const chunkQueue: Array<{
@@ -341,7 +364,10 @@ export function createWritingOrchestrator(
 
               fullText = generatedResult.fullText;
               lastTokens = generatedResult.usage.completionTokens;
+              lastFinishReason = generatedResult.finishReason ?? null;
+              lastToolCalls = generatedResult.toolCalls ?? [];
             } else {
+              let streamFinishReason: "stop" | "tool_use" | null = null;
               const gen = config.aiService.streamChat(
                 prepared.messages,
                 {
@@ -361,11 +387,15 @@ export function createWritingOrchestrator(
 
                 fullText += chunk.delta;
                 lastTokens = chunk.accumulatedTokens;
+                if (chunk.finishReason !== null) {
+                  streamFinishReason = chunk.finishReason;
+                }
                 yield makeEvent("ai-chunk", requestId, {
                   delta: chunk.delta,
                   accumulatedTokens: chunk.accumulatedTokens,
                 });
               }
+              lastFinishReason = streamFinishReason;
             }
 
             aiSuccess = true;
@@ -398,6 +428,180 @@ export function createWritingOrchestrator(
             },
           });
           return;
+        }
+
+        // Stage 4.5 (P2): Agentic tool-use loop
+        // Only runs when request.agenticLoop is true AND toolUseHandler is configured
+        // AND the AI returned finishReason === 'tool_use'
+        if (request.agenticLoop && config.toolUseHandler && config.generateText) {
+          const AGENTIC_MAX_ROUNDS = 5;
+          let agenticRound = 0;
+          let agenticMessages: Array<{ role: string; content: string }> | undefined;
+
+          while (lastFinishReason === "tool_use" && agenticRound < AGENTIC_MAX_ROUNDS) {
+            agenticRound++;
+
+            // Parse tool calls (may fail with TOOL_USE_PARSE_FAILED)
+            let parsedCalls;
+            try {
+              parsedCalls = config.toolUseHandler.parseToolCalls(lastToolCalls);
+            } catch (parseErr: unknown) {
+              const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+              yield makeEvent("tool-use-failed", requestId, {
+                round: agenticRound,
+                error: { code: "TOOL_USE_PARSE_FAILED", message: msg, retryable: false },
+              });
+              break;
+            }
+
+            // Yield tool-use-started
+            yield makeEvent("tool-use-started", requestId, {
+              round: agenticRound,
+              toolNames: parsedCalls.map((c) => c.toolName),
+            });
+
+            if (abortController.signal.aborted) {
+              taskStates.set(requestId, "killed");
+              yield makeEvent("aborted", requestId, { reason: "user-abort" });
+              return;
+            }
+
+            // Execute tools via the agentic (read-only) registry
+            const toolCtx = {
+              documentId: request.documentId,
+              requestId,
+              ...(request.projectId !== undefined ? { projectId: request.projectId } : {}),
+            };
+            const results = await config.toolUseHandler.executeToolBatch(parsedCalls, toolCtx);
+
+            // Check all-failed
+            const summary = config.toolUseHandler.getBatchSummary(results);
+            if (summary.allFailed) {
+              yield makeEvent("tool-use-failed", requestId, {
+                round: agenticRound,
+                error: {
+                  code: "TOOL_USE_ALL_FAILED",
+                  message: "All tool calls in this round failed",
+                  retryable: false,
+                },
+              });
+              break;
+            }
+
+            // Inject tool results into message history
+            const baseMsgs = agenticMessages ?? prepared.messages;
+            // Append assistant message (partial AI text before tool_use) then tool results
+            type ToolMsg = { role: "system" | "user" | "assistant" | "tool"; content: string; toolCallId?: string };
+            const msgsWithAssistant: ToolMsg[] = [
+              ...(baseMsgs.map((m) => ({
+                role: m.role as "system" | "user" | "assistant" | "tool",
+                content: m.content,
+              }))),
+              { role: "assistant" as const, content: fullText },
+            ];
+            agenticMessages = config.toolUseHandler.injectResults(
+              msgsWithAssistant,
+              results,
+            ) as Array<{ role: string; content: string }>;
+
+            if (abortController.signal.aborted) {
+              taskStates.set(requestId, "killed");
+              yield makeEvent("aborted", requestId, { reason: "user-abort" });
+              return;
+            }
+
+            // Re-call AI with injected messages
+            const nextChunkQueue: Array<{ delta: string; accumulatedTokens: number }> = [];
+            let nextResult: GeneratedTextResult | undefined;
+            let nextError: unknown = null;
+            let nextSettled = false;
+            let nextNotify: (() => void) | null = null;
+            const nextWake = () => {
+              const r = nextNotify;
+              nextNotify = null;
+              r?.();
+            };
+
+            const nextGenPromise = config
+              .generateText({
+                request,
+                signal: abortController.signal,
+                emitChunk: (delta, accumulatedTokens) => {
+                  nextChunkQueue.push({ delta, accumulatedTokens });
+                  nextWake();
+                },
+                messages: agenticMessages,
+              })
+              .then(
+                (r) => { nextResult = r; nextSettled = true; nextWake(); },
+                (e: unknown) => { nextError = e; nextSettled = true; nextWake(); },
+              );
+
+            let roundFullText = "";
+            while (!nextSettled || nextChunkQueue.length > 0) {
+              if (abortController.signal.aborted) {
+                taskStates.set(requestId, "killed");
+                yield makeEvent("aborted", requestId, { reason: "abort-during-ai" });
+                return;
+              }
+
+              const nextChunk = nextChunkQueue.shift();
+              if (nextChunk) {
+                roundFullText += nextChunk.delta;
+                lastTokens = nextChunk.accumulatedTokens;
+                yield makeEvent("ai-chunk", requestId, {
+                  delta: nextChunk.delta,
+                  accumulatedTokens: nextChunk.accumulatedTokens,
+                });
+                continue;
+              }
+
+              await new Promise<void>((resolve) => {
+                const onAbort = () => resolve();
+                nextNotify = resolve;
+                abortController.signal.addEventListener("abort", onAbort, { once: true });
+              });
+            }
+
+            await nextGenPromise;
+            if (nextError) {
+              throw nextError;
+            }
+            if (!nextResult) {
+              throw new Error("generateText completed without result in agentic round");
+            }
+
+            fullText = nextResult.fullText || roundFullText;
+            lastTokens = nextResult.usage.completionTokens;
+            lastFinishReason = nextResult.finishReason ?? null;
+            lastToolCalls = nextResult.toolCalls ?? [];
+
+            const hasNextRound =
+              lastFinishReason === "tool_use" && agenticRound < AGENTIC_MAX_ROUNDS;
+
+            // Yield tool-use-completed
+            yield makeEvent("tool-use-completed", requestId, {
+              round: agenticRound,
+              results: results.map((r) => ({
+                toolName: r.toolName,
+                success: r.success,
+                durationMs: r.durationMs,
+              })),
+              hasNextRound,
+            });
+          }
+
+          // Max rounds exceeded
+          if (agenticRound >= AGENTIC_MAX_ROUNDS && lastFinishReason === "tool_use") {
+            yield makeEvent("tool-use-failed", requestId, {
+              round: agenticRound,
+              error: {
+                code: "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+                message: `Maximum tool rounds (${AGENTIC_MAX_ROUNDS}) exceeded`,
+                retryable: false,
+              },
+            });
+          }
         }
 
         // Stage 5: ai-done

--- a/apps/desktop/main/src/services/skills/skillExecutor.ts
+++ b/apps/desktop/main/src/services/skills/skillExecutor.ts
@@ -52,6 +52,7 @@ export type SkillExecutorRunArgs = {
   model: string;
   system?: string;
   context?: { projectId?: string; documentId?: string };
+  messages?: Array<{ role: string; content: string; toolCallId?: string }>;
   stream: boolean;
   ts: number;
   emitEvent: (event: AiStreamEvent) => void;
@@ -63,6 +64,8 @@ export type SkillExecutor = {
       executionId: string;
       runId: string;
       outputText?: string;
+      finishReason?: "stop" | "tool_use" | null;
+      toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
       contextPrompt?: string;
     }>
   >;
@@ -79,6 +82,8 @@ type SkillExecutorDeps = {
       executionId: string;
       runId: string;
       outputText?: string;
+      finishReason?: "stop" | "tool_use" | null;
+      toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
     }>
   >;
   assembleContext?: (args: {

--- a/apps/desktop/main/src/services/skills/skillScheduler.ts
+++ b/apps/desktop/main/src/services/skills/skillScheduler.ts
@@ -27,6 +27,7 @@ export type SkillQueueStatus = {
 type SkillTaskStartResult<T> = {
   response: Promise<ServiceResult<T>>;
   completion: Promise<SkillSchedulerTerminal>;
+  preserveResponseOnTerminalError?: boolean;
 };
 
 type SkillTask<T> = {
@@ -239,7 +240,7 @@ function driveTaskSettlement(ctx: {
   ): void => {
     if (result.ok) {
       const terminalError = completionTerminalResultError();
-      if (terminalError) {
+      if (terminalError && !ctx.started.preserveResponseOnTerminalError) {
         resolveResultOnce(terminalError);
         return;
       }
@@ -272,6 +273,13 @@ function driveTaskSettlement(ctx: {
       completionState.terminal !== "completed" &&
       responseState.kind === "pending"
     ) {
+      if (
+        ctx.started.preserveResponseOnTerminalError &&
+        (completionState.terminal === "cancelled" ||
+          completionState.terminal === "timeout")
+      ) {
+        return;
+      }
       if (
         completionState.terminal === "cancelled" ||
         completionState.terminal === "timeout"

--- a/apps/desktop/main/src/services/skills/toolRegistry.ts
+++ b/apps/desktop/main/src/services/skills/toolRegistry.ts
@@ -19,6 +19,10 @@ export interface ToolContext {
   [key: string]: unknown;
 }
 
+export interface AgenticToolContext extends ToolContext {
+  args: Record<string, unknown>;
+}
+
 export interface WritingTool {
   readonly name: string;
   readonly description: string;

--- a/apps/desktop/main/src/services/skills/toolUseHandler.ts
+++ b/apps/desktop/main/src/services/skills/toolUseHandler.ts
@@ -7,7 +7,12 @@
  */
 
 import type { ToolCallInfo } from "../ai/streaming";
-import type { ToolRegistry, ToolContext, WritingTool } from "./toolRegistry";
+import type {
+  AgenticToolContext,
+  ToolRegistry,
+  ToolContext,
+  WritingTool,
+} from "./toolRegistry";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -312,9 +317,9 @@ export function createToolUseHandler(
       if (safeCalls.length > 0) {
         const tasks = safeCalls.map(({ idx, call }) => async () => {
           const tool = registry.get(call.toolName)!;
-          const agenticCtx: ToolContext = {
+          const agenticCtx: AgenticToolContext = {
             ...context,
-            arguments: call.arguments,
+            args: call.arguments,
           };
           const startTime = Date.now();
           const result = await executeWithTimeout(
@@ -340,9 +345,9 @@ export function createToolUseHandler(
       // Execute unsafe tools serially
       for (const { idx, call } of unsafeCalls) {
         const tool = registry.get(call.toolName)!;
-        const agenticCtx: ToolContext = {
+        const agenticCtx: AgenticToolContext = {
           ...context,
-          arguments: call.arguments,
+          args: call.arguments,
         };
         const startTime = Date.now();
         const result = await executeWithTimeout(
@@ -392,12 +397,20 @@ export function createToolUseHandler(
       for (const result of results) {
         let content: string;
         if (result.success) {
-          content =
-            result.data !== null && result.data !== undefined
-              ? JSON.stringify(result.data)
-              : "{}";
+          if (typeof result.data === "string") {
+            content = result.data;
+          } else {
+            content =
+              result.data !== null && result.data !== undefined
+                ? JSON.stringify(result.data)
+                : "{}";
+          }
         } else {
-          content = JSON.stringify(result.error ?? { code: "UNKNOWN", message: "Unknown error" });
+          const error = result.error ?? {
+            code: "UNKNOWN",
+            message: "Unknown error",
+          };
+          content = `Tool ${result.toolName} failed (${error.code}): ${error.message}`;
         }
 
         const toolMsg: ToolMessage = {

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -4,13 +4,31 @@ import type { Logger } from "../../logging/logger";
 import { createDocumentService } from "../documents/documentService";
 import type { VersionSnapshotReason } from "../documents/documentService";
 import { appendSuggestionToDocument } from "./documentWriteback";
-import { buildTool, createToolRegistry, type ToolRegistry } from "./toolRegistry";
+import {
+  buildTool,
+  createToolRegistry,
+  type AgenticToolContext,
+  type ToolRegistry,
+} from "./toolRegistry";
 import { applySuggestionToSelection } from "./selectionWriteback";
 
 type WritingToolingArgs = {
   db: Database.Database;
   logger: Logger;
 };
+
+function readAgenticArgs(ctx: unknown): Record<string, unknown> {
+  if (
+    typeof ctx === "object" &&
+    ctx !== null &&
+    "args" in ctx &&
+    typeof (ctx as { args?: unknown }).args === "object" &&
+    (ctx as { args?: unknown }).args !== null
+  ) {
+    return (ctx as AgenticToolContext).args;
+  }
+  return {};
+}
 
 export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistry {
   const registry = createToolRegistry();
@@ -211,17 +229,19 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
   const registry = createToolRegistry();
   const service = createDocumentService({ db: args.db, logger: args.logger });
 
-  // kgTool: query knowledge graph
-  // P2 stub — returns empty result when KG data is unavailable
   registry.register(
     buildTool({
       name: "kgTool",
-      description: "Query the knowledge graph for character traits, locations, and world settings",
+      description:
+        "Query the knowledge graph for character traits, locations, and world settings",
       isConcurrencySafe: true,
       execute: async (ctx) => {
-        const query = typeof ctx["query"] === "string" ? ctx["query"] : "";
-        args.logger.info("agentic_tool_kg_query", { query, requestId: ctx.requestId });
-        // P2 stub: KG module not yet implemented, return empty
+        const toolArgs = readAgenticArgs(ctx);
+        const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
+        args.logger.info("agentic_tool_kg_query", {
+          query,
+          requestId: ctx.requestId,
+        });
         return {
           success: true,
           data: { entities: [], query },
@@ -230,17 +250,19 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
     }),
   );
 
-  // memTool: query writing memory
-  // P2 stub — returns empty memories when Memory module is unavailable
   registry.register(
     buildTool({
       name: "memTool",
-      description: "Query writing memory for style preferences and past writing patterns",
+      description:
+        "Query writing memory for style preferences and past writing patterns",
       isConcurrencySafe: true,
       execute: async (ctx) => {
-        const query = typeof ctx["query"] === "string" ? ctx["query"] : "";
-        args.logger.info("agentic_tool_mem_query", { query, requestId: ctx.requestId });
-        // P2 stub: Memory module not yet fully implemented, return empty
+        const toolArgs = readAgenticArgs(ctx);
+        const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
+        args.logger.info("agentic_tool_mem_query", {
+          query,
+          requestId: ctx.requestId,
+        });
         return {
           success: true,
           data: { memories: [], query },
@@ -249,25 +271,22 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
     }),
   );
 
-  // docTool: read document content
   registry.register(
     buildTool({
       name: "docTool",
       description: "Read the content of a document or chapter for context",
       isConcurrencySafe: true,
       execute: async (ctx) => {
+        const toolArgs = readAgenticArgs(ctx);
         const targetDocId =
-          typeof ctx["targetDocumentId"] === "string"
-            ? ctx["targetDocumentId"]
+          typeof toolArgs.targetDocumentId === "string"
+            ? toolArgs.targetDocumentId
             : ctx.documentId;
         const projectId =
-          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
+          typeof ctx.projectId === "string" ? ctx.projectId.trim() : "";
 
         if (!projectId) {
-          return {
-            success: true,
-            data: { content: "", documentId: targetDocId },
-          };
+          return { success: true, data: "" };
         }
 
         const result = service.read({ projectId, documentId: targetDocId });
@@ -280,13 +299,12 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
 
         return {
           success: true,
-          data: { content: result.data.contentJson, documentId: targetDocId },
+          data: result.data.contentText,
         };
       },
     }),
   );
 
-  // documentRead: read document text (P1 built-in, agentic-accessible)
   registry.register(
     buildTool({
       name: "documentRead",
@@ -294,13 +312,10 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
       isConcurrencySafe: true,
       execute: async (ctx) => {
         const projectId =
-          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
+          typeof ctx.projectId === "string" ? ctx.projectId.trim() : "";
 
         if (!projectId) {
-          return {
-            success: true,
-            data: { text: "", documentId: ctx.documentId },
-          };
+          return { success: true, data: "" };
         }
 
         const result = service.read({ projectId, documentId: ctx.documentId });
@@ -313,7 +328,7 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
 
         return {
           success: true,
-          data: { text: result.data.contentJson, documentId: ctx.documentId },
+          data: result.data.contentText,
         };
       },
     }),

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -194,3 +194,130 @@ export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistr
 
   return registry;
 }
+
+/**
+ * P2: Create a read-only agentic tool registry for use in the Agentic Loop.
+ *
+ * Only exposes tools that AI is permitted to call autonomously:
+ * - kgTool: query knowledge graph (read-only)
+ * - memTool: query writing memory (read-only)
+ * - docTool: read document content (read-only)
+ * - documentRead: read document text (P1 built-in, read-only)
+ *
+ * Intentionally EXCLUDES: documentWrite, versionSnapshot
+ * (AI must not be able to write documents autonomously)
+ */
+export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistry {
+  const registry = createToolRegistry();
+  const service = createDocumentService({ db: args.db, logger: args.logger });
+
+  // kgTool: query knowledge graph
+  // P2 stub — returns empty result when KG data is unavailable
+  registry.register(
+    buildTool({
+      name: "kgTool",
+      description: "Query the knowledge graph for character traits, locations, and world settings",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const query = typeof ctx["query"] === "string" ? ctx["query"] : "";
+        args.logger.info("agentic_tool_kg_query", { query, requestId: ctx.requestId });
+        // P2 stub: KG module not yet implemented, return empty
+        return {
+          success: true,
+          data: { entities: [], query },
+        };
+      },
+    }),
+  );
+
+  // memTool: query writing memory
+  // P2 stub — returns empty memories when Memory module is unavailable
+  registry.register(
+    buildTool({
+      name: "memTool",
+      description: "Query writing memory for style preferences and past writing patterns",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const query = typeof ctx["query"] === "string" ? ctx["query"] : "";
+        args.logger.info("agentic_tool_mem_query", { query, requestId: ctx.requestId });
+        // P2 stub: Memory module not yet fully implemented, return empty
+        return {
+          success: true,
+          data: { memories: [], query },
+        };
+      },
+    }),
+  );
+
+  // docTool: read document content
+  registry.register(
+    buildTool({
+      name: "docTool",
+      description: "Read the content of a document or chapter for context",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const targetDocId =
+          typeof ctx["targetDocumentId"] === "string"
+            ? ctx["targetDocumentId"]
+            : ctx.documentId;
+        const projectId =
+          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
+
+        if (!projectId) {
+          return {
+            success: true,
+            data: { content: "", documentId: targetDocId },
+          };
+        }
+
+        const result = service.read({ projectId, documentId: targetDocId });
+        if (!result.ok) {
+          return {
+            success: false,
+            error: { code: result.error.code, message: result.error.message },
+          };
+        }
+
+        return {
+          success: true,
+          data: { content: result.data.contentJson, documentId: targetDocId },
+        };
+      },
+    }),
+  );
+
+  // documentRead: read document text (P1 built-in, agentic-accessible)
+  registry.register(
+    buildTool({
+      name: "documentRead",
+      description: "Read the raw text of the current document",
+      isConcurrencySafe: true,
+      execute: async (ctx) => {
+        const projectId =
+          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
+
+        if (!projectId) {
+          return {
+            success: true,
+            data: { text: "", documentId: ctx.documentId },
+          };
+        }
+
+        const result = service.read({ projectId, documentId: ctx.documentId });
+        if (!result.ok) {
+          return {
+            success: false,
+            error: { code: result.error.code, message: result.error.message },
+          };
+        }
+
+        return {
+          success: true,
+          data: { text: result.data.contentJson, documentId: ctx.documentId },
+        };
+      },
+    }),
+  );
+
+  return registry;
+}

--- a/apps/desktop/preload/src/aiStreamBridge.ts
+++ b/apps/desktop/preload/src/aiStreamBridge.ts
@@ -4,7 +4,9 @@ import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
+  type SkillToolUseEvent,
 } from "@shared/types/ai";
 import {
   JUDGE_RESULT_CHANNEL,
@@ -65,6 +67,31 @@ function isAiStreamEvent(x: unknown): x is AiStreamEvent {
       x.terminal === "error") &&
     typeof x.outputText === "string"
   );
+}
+
+function isSkillToolUseEvent(x: unknown): x is SkillToolUseEvent {
+  if (!isRecord(x)) {
+    return false;
+  }
+  if (
+    (x.type !== "tool-use-started" &&
+      x.type !== "tool-use-completed" &&
+      x.type !== "tool-use-failed") ||
+    typeof x.executionId !== "string" ||
+    typeof x.runId !== "string" ||
+    typeof x.round !== "number" ||
+    typeof x.ts !== "number"
+  ) {
+    return false;
+  }
+
+  if (x.type === "tool-use-started") {
+    return Array.isArray(x.toolNames);
+  }
+  if (x.type === "tool-use-completed") {
+    return Array.isArray(x.results) && typeof x.hasNextRound === "boolean";
+  }
+  return isRecord(x.error);
 }
 
 /**
@@ -144,6 +171,19 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   const onSkillQueueStatus = (_evt: unknown, payload: unknown) => {
     forwardEvent(SKILL_QUEUE_STATUS_CHANNEL, payload);
   };
+  const onSkillToolUse = (_evt: unknown, payload: unknown) => {
+    if (subscriptions.count() === 0) {
+      return;
+    }
+    if (!isSkillToolUseEvent(payload)) {
+      return;
+    }
+    window.dispatchEvent(
+      new CustomEvent<SkillToolUseEvent>(SKILL_TOOL_USE_CHANNEL, {
+        detail: payload,
+      }),
+    );
+  };
   const onJudgeResult = (_evt: unknown, payload: unknown) => {
     if (subscriptions.count() === 0) {
       return;
@@ -162,6 +202,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   ipcRenderer.on(SKILL_STREAM_CHUNK_CHANNEL, onSkillStreamChunk);
   ipcRenderer.on(SKILL_STREAM_DONE_CHANNEL, onSkillStreamDone);
   ipcRenderer.on(SKILL_QUEUE_STATUS_CHANNEL, onSkillQueueStatus);
+  ipcRenderer.on(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
   ipcRenderer.on(JUDGE_RESULT_CHANNEL, onJudgeResult);
 
   return {
@@ -179,6 +220,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
         SKILL_QUEUE_STATUS_CHANNEL,
         onSkillQueueStatus,
       );
+      ipcRenderer.removeListener(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
       ipcRenderer.removeListener(JUDGE_RESULT_CHANNEL, onJudgeResult);
     },
   };

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -3,6 +3,8 @@ import type { IpcError } from "./ipc-generated";
 export const SKILL_STREAM_CHUNK_CHANNEL = "skill:stream:chunk" as const;
 export const SKILL_STREAM_DONE_CHANNEL = "skill:stream:done" as const;
 export const SKILL_QUEUE_STATUS_CHANNEL = "skill:queue:status" as const;
+/** P2: Agentic Loop tool-use event channel */
+export const SKILL_TOOL_USE_CHANNEL = "skill:tool-use" as const;
 
 export type AiStreamTerminal = "completed" | "cancelled" | "error";
 
@@ -64,3 +66,39 @@ export type AiStreamEvent =
   | AiStreamChunkEvent
   | AiStreamDoneEvent
   | AiQueueStatusEvent;
+
+/** P2: Tool-use event sent when an Agentic Loop tool call starts */
+export type SkillToolUseStartedEvent = {
+  type: "tool-use-started";
+  executionId: string;
+  runId: string;
+  round: number;
+  toolNames: string[];
+  ts: number;
+};
+
+/** P2: Tool-use event sent when an Agentic Loop round completes */
+export type SkillToolUseCompletedEvent = {
+  type: "tool-use-completed";
+  executionId: string;
+  runId: string;
+  round: number;
+  results: Array<{ toolName: string; success: boolean; durationMs: number }>;
+  hasNextRound: boolean;
+  ts: number;
+};
+
+/** P2: Tool-use event sent when an Agentic Loop round fails */
+export type SkillToolUseFailedEvent = {
+  type: "tool-use-failed";
+  executionId: string;
+  runId: string;
+  round: number;
+  error: { code: string; message: string; retryable: boolean };
+  ts: number;
+};
+
+export type SkillToolUseEvent =
+  | SkillToolUseStartedEvent
+  | SkillToolUseCompletedEvent
+  | SkillToolUseFailedEvent;

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -8,6 +8,12 @@ export const SKILL_TOOL_USE_CHANNEL = "skill:tool-use" as const;
 
 export type AiStreamTerminal = "completed" | "cancelled" | "error";
 
+export type AiToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
 export type SkillResultMetadata = {
   model: string;
   promptTokens: number;
@@ -39,6 +45,8 @@ export type AiStreamDoneEvent = {
   traceId: string;
   terminal: AiStreamTerminal;
   outputText: string;
+  finishReason?: "stop" | "tool_use" | null;
+  toolCalls?: AiToolCall[];
   error?: IpcError;
   result?: SkillResult;
   ts: number;


### PR DESCRIPTION
Skip-Reason: N/A (task branch)

## Summary
- Wire continue agentic tool-use flow end-to-end across ai IPC, skill executor, orchestrator, read-only tools, and preload forwarding.

Closes #47

## Impact Scope
- `continue` now reaches the real production tool-use loop, injects tool results into the next AI round, preserves read-only tool boundaries, and surfaces tool-use progress to renderer subscribers.

## Validation Evidence
- [x] `pnpm -C apps/desktop exec vitest run --config vitest.config.core.ts main/src/ipc/__tests__/ai-skill-tool-use-loop.production.test.ts main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts main/src/services/skills/__tests__/tool-use-handler.test.ts main/src/__tests__/ai-stream-bridge.tool-use.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- Additional validation note: Follow-up CI repairs kept the P2 loop fixes green while restoring stream cancel/timeout ack semantics required by unit + integration coverage.

## Visual Evidence

### Embedded Screenshots
N/A（非前端改动）

### Storybook Artifact / Link
- Link: N/A（非前端改动）
- Visual acceptance note: N/A（非前端改动）

- [x] N/A（非前端改动）

## Test Coverage
- Added or updated production-path coverage for continue → tool_use → tool result injection → ai-done, unknown/all-failed continuation, max-rounds fuse, read-only tool boundary, args contract, preload tool-use forwarding, and stream cancel/timeout race regressions touched by the CI repair.

## Risk & Rollback
- Worst case if not fixed: P2 continue stays trapped on the old single-round path, tool calls vanish or lose args, unknown/all-failed rounds cannot recover, and renderer never sees tool-use progress.
- Rollback ref: git revert 17d9a69e2ce5207df50fe0a2a7f3ded2b05ab919
- Recovery note: If rollback is needed, revert the CI follow-up (`17d9a69e2ce5207df50fe0a2a7f3ded2b05ab919`) and the main P2 loop commit chain (`0cb5e12a30b3ed4f092a5047c03e0dad2bc21eff`, `d48c5212c977d96497e12d70efedeec7d76d81d8`) together to restore pre-round4 behavior.

## Audit Gate
- `scripts/agent_pr_preflight.sh`: PASS (body updated for final gate verification; local rerun follows in worktree)
- Required checks: GREEN — `CI/check`, `CI: creonow-app/Quality Check`, `CI: creonow-app/Test`, `CI: creonow-app/Build`
