### PR TITLE
feat: enable continue tool-use loop

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts
@@ -191,7 +191,7 @@ describe("ai:skill:run cursor propagation regression", () => {
     vi.restoreAllMocks();
   });
 
-  it("builtin:continue 显式 cursorPosition 会同时透传给 prepareRequest 与 skillExecutor 的 context assembly", async () => {
+  it("builtin:continue 显式 cursorPosition 会透传给 context assembly", async () => {
     const harness = createHarness();
     opened.push(harness.db);
     const { projectId, documentId } = createProjectAndDocument({
@@ -216,23 +216,11 @@ describe("ai:skill:run cursor propagation regression", () => {
 
     expect(run.ok).toBe(true);
     expect(run.data?.status).toBe("preview");
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     expect(assembleSpy.mock.calls.map(([request]) => request.cursorPosition)).toEqual([
-      3,
       3,
     ]);
     expect(assembleSpy.mock.calls).toEqual([
-      [
-        expect.objectContaining({
-          projectId,
-          documentId,
-          cursorPosition: 3,
-          skillId: "builtin:continue",
-          additionalInput: "甲乙丙丁",
-          provider: "ai-service",
-          model: "gpt-5.2",
-        }),
-      ],
       [
         expect.objectContaining({
           projectId,
@@ -270,8 +258,7 @@ describe("ai:skill:run cursor propagation regression", () => {
     });
 
     // PM pos 3 in single-para doc "甲乙丙丁" → text offset 2 (after 乙)
-    // Both calls (prepareRequest + skillExecutor) must receive textOffset=2
-    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([2, 2]);
+    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([2]);
   });
 
   it("builtin:continue 保留 leading whitespace 的 anchor：PM pos 4 → textOffset 3", async () => {
@@ -293,7 +280,7 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3, 3]);
+    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3]);
   });
 
   it("builtin:continue 跨段落时会把 deriveContent 的换行计入 textOffset", async () => {
@@ -329,7 +316,7 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3, 3]);
+    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3]);
   });
 
   // RED→GREEN regression: Audit-B BLOCKING FINDING — selection skills (polish/rewrite) must
@@ -390,9 +377,9 @@ describe("ai:skill:run cursor propagation regression", () => {
   });
 
   // RED TEST: P1 input-bridge blocker — when the IPC payload carries an explicit
-  // `precedingText` field (document-window semantic), both assemble() calls must
+  // `precedingText` field (document-window semantic), assemble() must
   // receive that text as additionalInput instead of falling back to an empty string.
-  it("builtin:continue precedingText 通过 IPC payload 传入时，两路 assemble 均收到 precedingText 作为 additionalInput", async () => {
+  it("builtin:continue precedingText 通过 IPC payload 传入时，assemble 收到 precedingText 作为 additionalInput", async () => {
     const harness = createHarness();
     opened.push(harness.db);
     const { projectId, documentId } = createProjectAndDocument({
@@ -412,13 +399,9 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    // Both prepareRequest and generateText/skillExecutor assemble calls must use precedingText
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     const additionalInputs = assembleSpy.mock.calls.map((args: unknown[]) => (args[0] as { additionalInput: unknown }).additionalInput);
-    expect(additionalInputs).toEqual([
-      "夜幕降临，街灯次第亮起。",
-      "夜幕降临，街灯次第亮起。",
-    ]);
+    expect(additionalInputs).toEqual(["夜幕降临，街灯次第亮起。"]);
   });
 
   // RED TEST: selection skills must NOT pick up precedingText — their input stays in `input`.
@@ -449,15 +432,15 @@ describe("ai:skill:run cursor propagation regression", () => {
     });
 
     // Selection skill: additionalInput must come from `input`, not `precedingText`
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     const additionalInputs = assembleSpy.mock.calls.map((args: unknown[]) => (args[0] as { additionalInput: unknown }).additionalInput);
     expect(additionalInputs.every((ai: unknown) => ai === selectionText)).toBe(true);
   });
 
   // RED TEST: WritingRequest.input.precedingText bridge — when the orchestrator is given
-  // a WritingRequest that already carries precedingText (and no selectedText), the
-  // prepareRequest and generateText callbacks must not discard it by returning "".
-  it("builtin:continue IPC payload precedingText 非空、input 为空时 assembleContext 不得收到空 additionalInput", async () => {
+   // a WritingRequest that already carries precedingText (and no selectedText), the
+   // prepareRequest callback must not discard it by returning "".
+   it("builtin:continue IPC payload precedingText 非空、input 为空时 assembleContext 不得收到空 additionalInput", async () => {
     const harness = createHarness();
     opened.push(harness.db);
     const { projectId, documentId } = createProjectAndDocument({
@@ -477,8 +460,7 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
-    // Neither call may receive empty-string additionalInput when precedingText is non-empty
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     const additionalInputs = assembleSpy.mock.calls.map((args: unknown[]) => (args[0] as { additionalInput: unknown }).additionalInput);
     expect(additionalInputs.every((ai: unknown) => typeof ai === "string" && ai.length > 0)).toBe(true);
   });

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-tool-use-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-tool-use-ipc.test.ts
@@ -235,4 +235,43 @@ describe("ai:skill:run tool-use IPC forwarding", () => {
       },
     });
   });
+
+  it("preview 前通过 skill:tool-use 透出 warning", async () => {
+    orchestratorExecuteSpy.mockReset();
+    orchestratorExecuteSpy.mockImplementation(async function* () {
+      yield {
+        type: "warning",
+        timestamp: Date.now(),
+        message: "AI 返回 tool_use 但当前 Skill 未启用 Agentic Loop",
+      };
+      yield {
+        type: "ai-done",
+        timestamp: Date.now(),
+        fullText: "最终润色。",
+        usage: {
+          promptTokens: 10,
+          completionTokens: 4,
+          totalTokens: 14,
+        },
+      };
+      yield {
+        type: "permission-requested",
+        timestamp: Date.now(),
+        level: "preview-confirm",
+        description: "confirm writeback",
+      };
+    });
+
+    const harness = createHarness();
+    await harness.invokeSkillRun();
+
+    const toolEvents = harness.sentEvents.filter(
+      (event) => event.channel === "skill:tool-use",
+    );
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]?.payload).toMatchObject({
+      type: "tool-use-warning",
+      message: "AI 返回 tool_use 但当前 Skill 未启用 Agentic Loop",
+    });
+  });
 });

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-tool-use-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-tool-use-ipc.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IpcMain } from "electron";
+import type Database from "better-sqlite3";
+
+const { orchestratorExecuteSpy } = vi.hoisted(() => ({
+  orchestratorExecuteSpy: vi.fn(),
+}));
+
+vi.mock("../../services/skills/skillExecutor", () => ({
+  createSkillExecutor: vi.fn(() => ({
+    execute: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/skills/orchestrator", () => ({
+  createWritingOrchestrator: vi.fn(() => ({
+    execute: orchestratorExecuteSpy,
+    abort: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/ai/aiService", () => ({
+  createAiService: vi.fn(() => ({
+    runSkill: vi.fn(),
+    listModels: vi.fn(async () => ({ ok: true, data: { source: "openai", items: [] } })),
+    cancel: vi.fn(() => ({ ok: true, data: { canceled: true } })),
+    feedback: vi.fn(() => ({ ok: true, data: { recorded: true } })),
+  })),
+}));
+
+vi.mock("../../services/ai/traceStore", () => ({
+  createSqliteTraceStore: vi.fn(() => ({})),
+}));
+
+vi.mock("../../services/memory/memoryService", () => ({
+  createMemoryService: vi.fn(() => ({})),
+}));
+
+vi.mock("../../services/memory/episodicMemoryService", () => ({
+  createEpisodicMemoryService: vi.fn(() => ({})),
+  createSqliteEpisodeRepository: vi.fn(() => ({})),
+}));
+
+vi.mock("../../services/context/layerAssemblyService", () => ({
+  createContextLayerAssemblyService: vi.fn(() => ({
+    assemble: vi.fn(async () => ({ ok: true, data: { prompt: "" } })),
+  })),
+}));
+
+vi.mock("../../services/kg/kgService", () => ({
+  createKnowledgeGraphService: vi.fn(() => ({})),
+}));
+
+vi.mock("../../services/stats/statsService", () => ({
+  createStatsService: vi.fn(() => ({
+    increment: vi.fn(() => ({ ok: true, data: undefined })),
+  })),
+}));
+
+import { registerAiIpcHandlers } from "../ai";
+
+type Handler = (
+  event: {
+    sender: { id: number; send: (channel: string, payload: unknown) => void };
+  },
+  payload: unknown,
+) => Promise<unknown>;
+
+function createLogger() {
+  return {
+    logPath: "<test>",
+    info: () => undefined,
+    error: () => undefined,
+  };
+}
+
+describe("ai:skill:run tool-use IPC forwarding", () => {
+  function createHarness() {
+    const handlers = new Map<string, Handler>();
+    const sentEvents: Array<{ channel: string; payload: unknown }> = [];
+    const ipcMain = {
+      handle: (channel: string, listener: Handler) => {
+        handlers.set(channel, listener);
+      },
+    } as unknown as IpcMain;
+
+    registerAiIpcHandlers({
+      ipcMain,
+      db: {} as Database.Database,
+      userDataDir: "<test-user-data>",
+      builtinSkillsDir: "<test-skills>",
+      logger: createLogger(),
+      env: process.env,
+    });
+
+    return {
+      sentEvents,
+      async invokeSkillRun() {
+        const handler = handlers.get("ai:skill:run");
+        if (!handler) {
+          throw new Error("Missing ai:skill:run handler");
+        }
+        return await handler(
+          {
+            sender: {
+              id: 7,
+              send: (channel: string, payload: unknown) => {
+                sentEvents.push({ channel, payload });
+              },
+            },
+          },
+          {
+            skillId: "builtin:continue",
+            hasSelection: false,
+            input: "甲乙丙丁",
+            mode: "ask",
+            model: "gpt-5.2",
+            stream: true,
+            context: {
+              projectId: "project-1",
+              documentId: "doc-1",
+            },
+          },
+        );
+      },
+    };
+  }
+
+  it("preview 前通过 skill:tool-use 透出 started/completed", async () => {
+    orchestratorExecuteSpy.mockReset();
+    orchestratorExecuteSpy.mockImplementation(async function* () {
+      yield {
+        type: "tool-use-started",
+        timestamp: Date.now(),
+        round: 1,
+        toolNames: ["documentRead"],
+      };
+      yield {
+        type: "tool-use-completed",
+        timestamp: Date.now(),
+        round: 1,
+        results: [{ toolName: "documentRead", success: true, durationMs: 12 }],
+        hasNextRound: true,
+      };
+      yield {
+        type: "ai-done",
+        timestamp: Date.now(),
+        fullText: "最终续写。",
+        usage: {
+          promptTokens: 10,
+          completionTokens: 4,
+          totalTokens: 14,
+        },
+      };
+      yield {
+        type: "permission-requested",
+        timestamp: Date.now(),
+        level: "preview-confirm",
+        description: "confirm writeback",
+      };
+    });
+
+    const harness = createHarness();
+    const result = await harness.invokeSkillRun();
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        status: "preview",
+        outputText: "最终续写。",
+      },
+    });
+    const toolEvents = harness.sentEvents.filter(
+      (event) => event.channel === "skill:tool-use",
+    );
+    expect(toolEvents).toHaveLength(2);
+    expect(toolEvents[0]?.payload).toMatchObject({
+      type: "tool-use-started",
+      round: 1,
+      toolNames: ["documentRead"],
+    });
+    expect(toolEvents[1]?.payload).toMatchObject({
+      type: "tool-use-completed",
+      round: 1,
+      hasNextRound: true,
+      results: [{ toolName: "documentRead", success: true, durationMs: 12 }],
+    });
+  });
+
+  it("preview 前通过 skill:tool-use 透出 failed", async () => {
+    orchestratorExecuteSpy.mockReset();
+    orchestratorExecuteSpy.mockImplementation(async function* () {
+      yield {
+        type: "tool-use-failed",
+        timestamp: Date.now(),
+        round: 2,
+        error: {
+          code: "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+          message: "Maximum tool rounds exceeded",
+          retryable: false,
+        },
+      };
+      yield {
+        type: "ai-done",
+        timestamp: Date.now(),
+        fullText: "部分续写。",
+        usage: {
+          promptTokens: 10,
+          completionTokens: 4,
+          totalTokens: 14,
+        },
+      };
+      yield {
+        type: "permission-requested",
+        timestamp: Date.now(),
+        level: "preview-confirm",
+        description: "confirm writeback",
+      };
+    });
+
+    const harness = createHarness();
+    await harness.invokeSkillRun();
+
+    const toolEvents = harness.sentEvents.filter(
+      (event) => event.channel === "skill:tool-use",
+    );
+    expect(toolEvents).toHaveLength(1);
+    expect(toolEvents[0]?.payload).toMatchObject({
+      type: "tool-use-failed",
+      round: 2,
+      error: {
+        code: "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+        message: "Maximum tool rounds exceeded",
+      },
+    });
+  });
+});

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -741,6 +741,35 @@ function emitOrchestratorToolUseEvent(args: {
   });
 }
 
+function emitOrchestratorWarningEvent(args: {
+  ctx: AiIpcContext;
+  sender: Electron.WebContents;
+  executionId: string;
+  runId: string;
+  traceId: string;
+  event: WritingEvent;
+}): void {
+  safeEmitToRenderer({
+    logger: args.ctx.deps.logger,
+    sender: args.sender,
+    event: {
+      type: "tool-use-warning",
+      executionId: args.executionId,
+      runId: args.runId,
+      traceId: args.traceId,
+      message: String(args.event.message ?? ""),
+      ...(Array.isArray(args.event.discardedToolNames)
+        ? {
+            discardedToolNames: args.event.discardedToolNames.map((name) =>
+              String(name),
+            ),
+          }
+        : {}),
+      ts: nowTs(),
+    },
+  });
+}
+
 /**
  * Normalize AI run response payload to the IPC contract surface.
  *
@@ -949,6 +978,7 @@ function safeEmitToRenderer(args: {
         : args.event.type === "tool-use-started"
           || args.event.type === "tool-use-completed"
           || args.event.type === "tool-use-failed"
+          || args.event.type === "tool-use-warning"
           ? SKILL_TOOL_USE_CHANNEL
         : SKILL_STREAM_DONE_CHANNEL;
   try {
@@ -1498,6 +1528,18 @@ async function drainPreviewUntilPause(args: {
       continue;
     }
 
+    if (event.type === "warning") {
+      emitOrchestratorWarningEvent({
+        ctx: args.ctx,
+        sender: args.sender,
+        executionId: args.executionId,
+        runId: args.runId,
+        traceId: args.traceId,
+        event,
+      });
+      continue;
+    }
+
     if (event.type === "permission-requested") {
       const session = {
         executionId: args.executionId,
@@ -1641,6 +1683,17 @@ async function continuePreviewSession(args: {
       || event.type === "tool-use-failed"
     ) {
       emitOrchestratorToolUseEvent({
+        ctx: args.ctx,
+        sender: args.session.sender,
+        executionId: args.session.executionId,
+        runId: args.session.runId,
+        traceId: args.session.traceId,
+        event,
+      });
+      continue;
+    }
+    if (event.type === "warning") {
+      emitOrchestratorWarningEvent({
         ctx: args.ctx,
         sender: args.session.sender,
         executionId: args.session.executionId,

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -9,7 +9,9 @@ import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
+  type AiToolUseEvent,
 } from "@shared/types/ai";
 import type { Logger } from "../logging/logger";
 import { createIpcPushBackpressureGate } from "./pushBackpressure";
@@ -28,7 +30,6 @@ import {
 } from "../services/memory/preferenceLearning";
 import { createStatsService } from "../services/stats/statsService";
 import { createSkillService } from "../services/skills/skillService";
-import { createSkillExecutor } from "../services/skills/skillExecutor";
 import { normalizeAssembledContextPrompt } from "../services/skills/contextPromptPolicy";
 import { createContextLayerAssemblyService } from "../services/context/layerAssemblyService";
 import { createKnowledgeGraphService } from "../services/kg/kgService";
@@ -39,10 +40,15 @@ import {
   createWritingOrchestrator,
   type WritingEvent,
 } from "../services/skills/orchestrator";
-import { createWritingToolRegistry } from "../services/skills/writingTooling";
+import {
+  createAgenticToolRegistry,
+  createWritingToolRegistry,
+} from "../services/skills/writingTooling";
 import { estimateTokens } from "../services/context/tokenEstimation";
 import { createDocumentService } from "../services/documents/documentService";
 import { editorSchema } from "../services/editor/prosemirrorSchema";
+import { createAIServiceAdapter } from "../services/ai/aiServiceAdapter";
+import type { ChatMessage } from "../services/ai/aiServiceAdapter";
 
 /**
  * Convert a ProseMirror document position to a plain-text character offset.
@@ -404,7 +410,7 @@ async function prepareWritingRequest(args: {
   | {
       ok: true;
       data: {
-        messages: Array<{ role: string; content: string }>;
+        messages: ChatMessage[];
         tokenCount: number;
         modelId: string;
       };
@@ -448,6 +454,33 @@ async function prepareWritingRequest(args: {
         message: resolvedData.skill.error_message ?? "Skill is invalid",
       },
     };
+  }
+
+  const dependsOn = resolvedData.skill.dependsOn ?? [];
+  if (dependsOn.length > 0) {
+    const missing: string[] = [];
+    for (const dependencyId of dependsOn) {
+      const available = skillSvc.isDependencyAvailable({ dependencyId });
+      if (!available.ok) {
+        return {
+          ok: false,
+          error: available.error,
+        };
+      }
+      if (!available.data.available) {
+        missing.push(dependencyId);
+      }
+    }
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        error: {
+          code: "SKILL_DEPENDENCY_MISSING",
+          message: "Skill dependency missing",
+          details: missing,
+        },
+      };
+    }
   }
 
   const input = args.payload.input;
@@ -540,7 +573,7 @@ async function prepareWritingRequest(args: {
       role: "user",
       content: userPrompt,
     },
-  ];
+  ] as ChatMessage[];
 
   const tokenCount = estimateTokens(
     messages.map((message) => message.content).join("\n\n"),
@@ -635,6 +668,76 @@ function emitOrchestratorDone(args: {
       },
       ts: nowTs(),
     },
+  });
+}
+
+function emitOrchestratorToolUseEvent(args: {
+  ctx: AiIpcContext;
+  sender: Electron.WebContents;
+  executionId: string;
+  runId: string;
+  traceId: string;
+  event: WritingEvent;
+}): void {
+  let payload: AiToolUseEvent;
+  if (args.event.type === "tool-use-started") {
+    payload = {
+      type: "tool-use-started",
+      executionId: args.executionId,
+      runId: args.runId,
+      traceId: args.traceId,
+      round: Number(args.event.round ?? 0),
+      toolNames: Array.isArray(args.event.toolNames)
+        ? args.event.toolNames.map((name) => String(name))
+        : [],
+      ts: nowTs(),
+    };
+  } else if (args.event.type === "tool-use-completed") {
+    payload = {
+      type: "tool-use-completed",
+      executionId: args.executionId,
+      runId: args.runId,
+      traceId: args.traceId,
+      round: Number(args.event.round ?? 0),
+      results: Array.isArray(args.event.results)
+        ? args.event.results.map((result) => {
+            const record = result as Record<string, unknown>;
+            return {
+              toolName: String(record.toolName ?? ""),
+              success: Boolean(record.success),
+              durationMs:
+                typeof record.durationMs === "number" ? record.durationMs : 0,
+            };
+          })
+        : [],
+      hasNextRound: Boolean(args.event.hasNextRound),
+      ts: nowTs(),
+    };
+  } else {
+    const error =
+      typeof args.event.error === "object" && args.event.error !== null
+        ? (args.event.error as Record<string, unknown>)
+        : {};
+    payload = {
+      type: "tool-use-failed",
+      executionId: args.executionId,
+      runId: args.runId,
+      traceId: args.traceId,
+      round: Number(args.event.round ?? 0),
+      error: {
+        code: (error.code as IpcError["code"]) ?? "INTERNAL",
+        message: String(error.message ?? "Tool use failed"),
+        retryable:
+          typeof error.retryable === "boolean" ? error.retryable : false,
+      },
+      ts: nowTs(),
+    };
+  }
+
+  safeEmitToRenderer({
+    logger: args.ctx.deps.logger,
+    sender: args.sender,
+    event: payload,
   });
 }
 
@@ -836,13 +939,17 @@ function forbiddenPreviewSessionAccess(): {
 function safeEmitToRenderer(args: {
   logger: Logger;
   sender: Electron.WebContents;
-  event: AiStreamEvent;
+  event: AiStreamEvent | AiToolUseEvent;
 }): void {
   const channel =
     args.event.type === "chunk"
       ? SKILL_STREAM_CHUNK_CHANNEL
       : args.event.type === "queue"
         ? SKILL_QUEUE_STATUS_CHANNEL
+        : args.event.type === "tool-use-started"
+          || args.event.type === "tool-use-completed"
+          || args.event.type === "tool-use-failed"
+          ? SKILL_TOOL_USE_CHANNEL
         : SKILL_STREAM_DONE_CHANNEL;
   try {
     args.sender.send(channel, args.event);
@@ -1148,141 +1255,6 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         }
       : undefined,
   );
-  const skillExecutor = createSkillExecutor({
-    resolveSkill: (skillId) => {
-      if (!deps.db) {
-        return {
-          ok: false,
-          error: createDbNotReadyError(),
-        };
-      }
-      const skillSvc = createSkillService({
-        db: deps.db,
-        userDataDir: deps.userDataDir,
-        builtinSkillsDir: deps.builtinSkillsDir,
-        logger: deps.logger,
-      });
-      const resolved = skillSvc.resolveForRun({ id: skillId });
-      const resolvedData = resolved.ok
-        ? resolved.data
-        : (() => {
-            const fallback = resolveP1BuiltinSkill(skillId);
-            if (!fallback) {
-              return null;
-            }
-            return {
-              skill: fallback,
-              enabled: true,
-              inputType: fallback.inputType,
-            };
-          })();
-      if (!resolvedData) {
-        return {
-          ok: false,
-          error: resolved.ok
-            ? { code: "NOT_FOUND", message: "Skill not found" }
-            : resolved.error,
-        };
-      }
-      const fallbackSkill =
-        "error_code" in resolvedData.skill ? resolvedData.skill : undefined;
-      return {
-        ok: true,
-        data: {
-          id: resolvedData.skill.id,
-          prompt: resolvedData.skill.prompt,
-          output: resolvedData.skill.output,
-          enabled: resolvedData.enabled,
-          valid: resolvedData.skill.valid,
-          inputType: resolvedData.inputType,
-          dependsOn: resolvedData.skill.dependsOn,
-          timeoutMs: resolvedData.skill.timeoutMs,
-          error_code: fallbackSkill?.error_code,
-          error_message: fallbackSkill?.error_message,
-        },
-      };
-    },
-    checkDependencies: ({ dependsOn }) => {
-      if (!deps.db) {
-        return {
-          ok: false,
-          error: createDbNotReadyError(),
-        };
-      }
-
-      const skillSvc = createSkillService({
-        db: deps.db,
-        userDataDir: deps.userDataDir,
-        builtinSkillsDir: deps.builtinSkillsDir,
-        logger: deps.logger,
-      });
-
-      const missing: string[] = [];
-      for (const dependencyId of dependsOn) {
-        const available = skillSvc.isDependencyAvailable({ dependencyId });
-        if (!available.ok) {
-          return {
-            ok: false,
-            error: available.error,
-          };
-        }
-        if (!available.data.available) {
-          missing.push(dependencyId);
-        }
-      }
-
-      if (missing.length > 0) {
-        return {
-          ok: false,
-          error: {
-            code: "SKILL_DEPENDENCY_MISSING",
-            message: "Skill dependency missing",
-            details: missing,
-          },
-        };
-      }
-
-      return { ok: true, data: true };
-    },
-    runSkill: async (args) => {
-      return await aiService.runSkill(args);
-    },
-    assembleContext: async (args) => {
-      // Compute plain-text textOffset from PM position so the immediate layer fetcher
-      // slices the correct number of characters (see pmPosToTextOffset).
-      let textOffset: number | undefined;
-      if (
-        args.cursorPosition !== 0 &&
-        args.projectId.length > 0 &&
-        args.documentId.length > 0 &&
-        deps.db !== null
-      ) {
-        try {
-          const docSvc = createDocumentService({ db: deps.db, logger: deps.logger });
-          const docRead = docSvc.read({
-            projectId: args.projectId,
-            documentId: args.documentId,
-          });
-          if (docRead.ok && docRead.data.contentJson) {
-            const pmDoc = ProseMirrorNode.fromJSON(
-              editorSchema,
-              JSON.parse(docRead.data.contentJson) as Record<string, unknown>,
-            );
-            textOffset = pmPosToTextOffset(pmDoc, args.cursorPosition);
-          }
-        } catch {
-          // Non-fatal: fall through without textOffset
-        }
-      }
-      return await contextAssemblyService.assemble({
-        ...args,
-        ...(textOffset !== undefined ? { textOffset } : {}),
-      });
-    },
-    logger: {
-      warn: (event, data) => deps.logger.info(event, data),
-    },
-  });
   const permissionGate = createPendingPermissionGate();
   const skillServiceFactory = () => {
     if (!deps.db) {
@@ -1295,26 +1267,32 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       logger: deps.logger,
     });
   };
+  const writingToolRegistry =
+    deps.db === null
+      ? createWritingToolRegistry({
+          db: {} as Database.Database,
+          logger: deps.logger,
+        })
+      : createWritingToolRegistry({
+          db: deps.db,
+          logger: deps.logger,
+        });
+  const agenticToolRegistry =
+    deps.db === null
+      ? createAgenticToolRegistry({
+          db: {} as Database.Database,
+          logger: deps.logger,
+        })
+      : createAgenticToolRegistry({
+          db: deps.db,
+          logger: deps.logger,
+        });
   const writingOrchestrator = createWritingOrchestrator({
-    aiService: {
-      async *streamChat() {
-        return;
-      },
-      estimateTokens,
-      abort() {
-        return;
-      },
-    },
-    toolRegistry:
-      deps.db === null
-        ? createWritingToolRegistry({
-            db: {} as Database.Database,
-            logger: deps.logger,
-          })
-        : createWritingToolRegistry({
-            db: deps.db,
-            logger: deps.logger,
-          }),
+    aiService: createAIServiceAdapter(
+      aiService as Parameters<typeof createAIServiceAdapter>[0],
+    ),
+    toolRegistry: writingToolRegistry,
+    agenticToolRegistry,
     permissionGate,
     postWritingHooks: [
       {
@@ -1369,101 +1347,6 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         throw err;
       }
       return prepared.data;
-    },
-    generateText: async ({ request, signal, emitChunk }) => {
-      let outputText = "";
-      let usage = {
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
-      };
-      let sawStreamChunk = false;
-      let streamTerminalSeen = false;
-      let settleStreamCompletion: (() => void) | null = null;
-      let rejectStreamCompletion: ((error: Error) => void) | null = null;
-      const streamCompletion = new Promise<void>((resolve, reject) => {
-        settleStreamCompletion = resolve;
-        rejectStreamCompletion = reject;
-      });
-      const res = await skillExecutor.execute({
-        skillId: request.skillId,
-        hasSelection: Boolean(request.selection),
-        input: resolveWritingRequestInput(request),
-        ...(request.cursorPosition === undefined
-          ? {}
-          : { cursorPosition: request.cursorPosition }),
-        mode: "ask",
-        model: request.modelId ?? "default",
-        context: {
-          projectId: request.projectId,
-          documentId: request.documentId,
-        },
-        stream: true,
-        ts: nowTs(),
-        emitEvent: (event) => {
-          if (signal.aborted) {
-            return;
-          }
-          if (event.type === "chunk") {
-            sawStreamChunk = true;
-            outputText += event.chunk;
-            const accumulatedTokens = estimateTokens(outputText);
-            emitChunk(event.chunk, accumulatedTokens);
-            return;
-          }
-          if (event.type === "done") {
-            if (!sawStreamChunk && event.outputText.length > 0) {
-              outputText = event.outputText;
-              emitChunk(event.outputText, estimateTokens(event.outputText));
-              sawStreamChunk = true;
-            } else {
-              outputText = event.outputText;
-            }
-            usage = {
-              promptTokens: event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request)),
-              completionTokens:
-                event.result?.metadata.completionTokens ?? estimateTokens(event.outputText),
-              totalTokens:
-                (event.result?.metadata.promptTokens ?? estimateTokens(resolveWritingRequestInput(request))) +
-                (event.result?.metadata.completionTokens ?? estimateTokens(event.outputText)),
-            };
-            streamTerminalSeen = true;
-            if (event.terminal === "completed") {
-              settleStreamCompletion?.();
-            } else {
-              rejectStreamCompletion?.(
-                Object.assign(
-                  new Error(
-                    event.error?.message ??
-                      (event.terminal === "cancelled"
-                        ? "AI request canceled"
-                        : "AI stream failed"),
-                  ),
-                  {
-                    code: event.error?.code ?? "AI_SERVICE_ERROR",
-                    terminal: event.terminal,
-                  },
-                ),
-              );
-            }
-          }
-        },
-      });
-      if (!res.ok) {
-        throw res.error;
-      }
-      if (!streamTerminalSeen) {
-        await streamCompletion;
-      }
-      if (!sawStreamChunk && (res.data.outputText?.length ?? 0) > 0) {
-        const finalOutput = res.data.outputText ?? "";
-        outputText = finalOutput;
-        emitChunk(finalOutput, estimateTokens(finalOutput));
-      }
-      return {
-        fullText: outputText || res.data.outputText || "",
-        usage,
-      };
     },
   });
 
@@ -1596,6 +1479,22 @@ async function drainPreviewUntilPause(args: {
         completionTokens: number;
         totalTokens: number;
       };
+      continue;
+    }
+
+    if (
+      event.type === "tool-use-started"
+      || event.type === "tool-use-completed"
+      || event.type === "tool-use-failed"
+    ) {
+      emitOrchestratorToolUseEvent({
+        ctx: args.ctx,
+        sender: args.sender,
+        executionId: args.executionId,
+        runId: args.runId,
+        traceId: args.traceId,
+        event,
+      });
       continue;
     }
 
@@ -1736,6 +1635,21 @@ async function continuePreviewSession(args: {
     }
 
     const event = next.value;
+    if (
+      event.type === "tool-use-started"
+      || event.type === "tool-use-completed"
+      || event.type === "tool-use-failed"
+    ) {
+      emitOrchestratorToolUseEvent({
+        ctx: args.ctx,
+        sender: args.session.sender,
+        executionId: args.session.executionId,
+        runId: args.session.runId,
+        traceId: args.session.traceId,
+        event,
+      });
+      continue;
+    }
     if (event.type === "write-back-done") {
       versionId = typeof event.versionId === "string" ? event.versionId : versionId;
       continue;

--- a/apps/desktop/main/src/services/ai/__tests__/ai-public-contract-regression.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/ai-public-contract-regression.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 
+import { describe, it } from "vitest";
+
 import type { Logger } from "../../../logging/logger";
 import { createAiService } from "../aiService";
 
@@ -11,112 +13,116 @@ function createLogger(): Logger {
   };
 }
 
-const originalFetch = globalThis.fetch;
+describe("AI public contract regression", () => {
+  it("keeps createAiService public envelope compatible", async () => {
+    const originalFetch = globalThis.fetch;
 
-try {
-  globalThis.fetch = (async (input: URL | RequestInfo) => {
-    const url = String(input);
-    if (url.includes("/v1/chat/completions")) {
-      return new Response(
-        JSON.stringify({
-          choices: [{ message: { content: "contract-ok" } }],
+    try {
+      globalThis.fetch = (async (input: URL | RequestInfo) => {
+        const url = String(input);
+        if (url.includes("/v1/chat/completions")) {
+          return new Response(
+            JSON.stringify({
+              choices: [{ message: { content: "contract-ok" } }],
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+
+        if (url.includes("/v1/models")) {
+          return new Response(
+            JSON.stringify({
+              data: [{ id: "gpt-5.2", name: "GPT-5.2" }],
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+
+        return new Response("unexpected url", { status: 500 });
+      }) as typeof fetch;
+
+      const service = createAiService({
+        logger: createLogger(),
+        env: {},
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+        getProxySettings: () => ({
+          enabled: false,
+          providerMode: "openai-byok",
+          openAiByok: {
+            baseUrl: "https://api.openai.com",
+            apiKey: "sk-contract",
+          },
         }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
+      });
+
+      assert.deepEqual(Object.keys(service).sort(), [
+        "cancel",
+        "feedback",
+        "listModels",
+        "runSkill",
+      ]);
+
+      const run = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "hello",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: false,
+        ts: 1_700_000_000_000,
+        emitEvent: () => {},
+      });
+
+      assert.equal(
+        run.ok,
+        true,
+        "AI-S1-ASE-S3: runSkill contract must remain compatible",
       );
-    }
+      if (!run.ok) {
+        throw new Error("runSkill should succeed");
+      }
+      assert.equal(typeof run.data.runId, "string");
+      assert.equal(typeof run.data.executionId, "string");
+      assert.equal(run.data.outputText, "contract-ok");
 
-    if (url.includes("/v1/models")) {
-      return new Response(
-        JSON.stringify({
-          data: [{ id: "gpt-5.2", name: "GPT-5.2" }],
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
+      const canceled = service.cancel({
+        executionId: run.data.executionId,
+        ts: 1_700_000_000_001,
+      });
+      assert.equal(canceled.ok, true);
+      assert.deepEqual(canceled, { ok: true, data: { canceled: true } });
+
+      const cancelInvalid = service.cancel({
+        executionId: "   ",
+        ts: 1_700_000_000_002,
+      });
+      assert.equal(cancelInvalid.ok, false);
+      if (cancelInvalid.ok) {
+        throw new Error("cancel with empty id must fail");
+      }
+      assert.equal(cancelInvalid.error.code, "INVALID_ARGUMENT");
+
+      const models = await service.listModels();
+      assert.equal(
+        models.ok,
+        true,
+        "AI-S1-ASE-S3: listModels envelope should remain unchanged",
       );
+      if (!models.ok) {
+        throw new Error("listModels should succeed");
+      }
+      assert.equal(models.data.source, "openai");
+      assert.deepEqual(models.data.items, [
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "OpenAI" },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
     }
-
-    return new Response("unexpected url", { status: 500 });
-  }) as typeof fetch;
-
-  const service = createAiService({
-    logger: createLogger(),
-    env: {},
-    sleep: async () => {},
-    rateLimitPerMinute: 1_000,
-    getProxySettings: () => ({
-      enabled: false,
-      providerMode: "openai-byok",
-      openAiByok: {
-        baseUrl: "https://api.openai.com",
-        apiKey: "sk-contract",
-      },
-    }),
   });
-
-  assert.deepEqual(Object.keys(service).sort(), [
-    "cancel",
-    "feedback",
-    "listModels",
-    "runSkill",
-  ]);
-
-  const run = await service.runSkill({
-    skillId: "builtin:polish",
-    input: "hello",
-    mode: "ask",
-    model: "gpt-5.2",
-    stream: false,
-    ts: 1_700_000_000_000,
-    emitEvent: () => {},
-  });
-
-  assert.equal(
-    run.ok,
-    true,
-    "AI-S1-ASE-S3: runSkill contract must remain compatible",
-  );
-  if (!run.ok) {
-    throw new Error("runSkill should succeed");
-  }
-  assert.equal(typeof run.data.runId, "string");
-  assert.equal(typeof run.data.executionId, "string");
-  assert.equal(run.data.outputText, "contract-ok");
-
-  const canceled = service.cancel({
-    executionId: run.data.executionId,
-    ts: 1_700_000_000_001,
-  });
-  assert.equal(canceled.ok, true);
-  assert.deepEqual(canceled, { ok: true, data: { canceled: true } });
-
-  const cancelInvalid = service.cancel({
-    executionId: "   ",
-    ts: 1_700_000_000_002,
-  });
-  assert.equal(cancelInvalid.ok, false);
-  if (cancelInvalid.ok) {
-    throw new Error("cancel with empty id must fail");
-  }
-  assert.equal(cancelInvalid.error.code, "INVALID_ARGUMENT");
-
-  const models = await service.listModels();
-  assert.equal(
-    models.ok,
-    true,
-    "AI-S1-ASE-S3: listModels envelope should remain unchanged",
-  );
-  if (!models.ok) {
-    throw new Error("listModels should succeed");
-  }
-  assert.equal(models.data.source, "openai");
-  assert.deepEqual(models.data.items, [
-    { id: "gpt-5.2", name: "GPT-5.2", provider: "OpenAI" },
-  ]);
-} finally {
-  globalThis.fetch = originalFetch;
-}
+});

--- a/apps/desktop/main/src/services/ai/__tests__/aiService-runtime-multiturn.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiService-runtime-multiturn.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { Logger } from "../../../logging/logger";
 import type { AiStreamDoneEvent, AiStreamEvent } from "@shared/types/ai";
 import { createAiService } from "../aiService";
+import type { StreamResult } from "../streaming";
 
 function createLogger(): Logger {
   return {
@@ -10,6 +11,132 @@ function createLogger(): Logger {
     info: () => {},
     error: () => {},
   };
+}
+
+// --- hidden streamChat passes tools and parses tool_use for OpenAI ---
+{
+  const originalFetch = globalThis.fetch;
+
+  try {
+    let requestBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (_input, init) => {
+      requestBody = JSON.parse(
+        typeof init?.body === "string" ? init.body : JSON.stringify({}),
+      ) as Record<string, unknown>;
+
+      return new Response(
+        `data: ${JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call-read-1",
+                    function: {
+                      name: "documentRead",
+                      arguments: "{\"scope\":\"cursor\"}",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`
+          + `data: ${JSON.stringify({
+            choices: [
+              {
+                delta: { content: "查完继续。" },
+                finish_reason: "tool_calls",
+              },
+            ],
+          })}\n\n`
+          + "data: [DONE]\n\n",
+        {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        },
+      );
+    }) as typeof fetch;
+
+    const service = createAiService({
+      logger: createLogger(),
+      env: {
+        CREONOW_AI_PROVIDER: "openai",
+        CREONOW_AI_BASE_URL: "https://api.openai.com",
+        CREONOW_AI_API_KEY: "sk-test",
+      },
+      sleep: async () => {},
+      rateLimitPerMinute: 1_000,
+    }) as unknown as {
+      streamChat: (
+        messages: Array<{ role: "system" | "user" | "assistant" | "tool"; content: string }>,
+        options: {
+          modelId: string;
+          tools?: Array<{ name: string; description: string }>;
+          onComplete: (result: StreamResult) => void;
+          onError: (error: { message: string }) => void;
+        },
+      ) => AsyncGenerator<{ finishReason: "stop" | "tool_use" | null }>;
+    };
+
+    let completed: StreamResult | null = null;
+    const finishReasons: Array<"stop" | "tool_use" | null> = [];
+
+    await (async () => {
+      for await (const chunk of service.streamChat(
+        [
+          { role: "system", content: "你是写作助手" },
+          { role: "user", content: "继续写下去" },
+        ],
+        {
+          modelId: "gpt-5.2",
+          tools: [
+            {
+              name: "documentRead",
+              description: "Read current document",
+            },
+          ],
+          onComplete: (result) => {
+            completed = result;
+          },
+          onError: (error) => {
+            throw new Error(error.message);
+          },
+        },
+      )) {
+        finishReasons.push(chunk.finishReason);
+      }
+    })();
+
+    if (requestBody === null) {
+      throw new Error("request body should be captured");
+    }
+    if (completed === null) {
+      throw new Error("streamChat should complete with final result");
+    }
+    const sentBody = requestBody as unknown as Record<string, unknown>;
+    const result = completed as unknown as StreamResult;
+
+    assert.equal(Array.isArray(sentBody.tools), true);
+    assert.equal(
+      (sentBody.tools as Array<{ function: { name: string } }>)[0]?.function.name,
+      "documentRead",
+    );
+    assert.equal(sentBody.tool_choice, "auto");
+    assert.equal(finishReasons.includes("tool_use"), true);
+    assert.equal(result.finishReason, "tool_use");
+    assert.deepEqual(result.toolCalls, [
+      {
+        id: "call-read-1",
+        name: "documentRead",
+        arguments: { scope: "cursor" },
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 }
 
 function createDoneWaiter(): {

--- a/apps/desktop/main/src/services/ai/__tests__/aiService-runtime-multiturn.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiService-runtime-multiturn.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 
+import { describe, it } from "vitest";
+
 import type { Logger } from "../../../logging/logger";
 import type { AiStreamDoneEvent, AiStreamEvent } from "@shared/types/ai";
 import { createAiService } from "../aiService";
@@ -11,132 +13,6 @@ function createLogger(): Logger {
     info: () => {},
     error: () => {},
   };
-}
-
-// --- hidden streamChat passes tools and parses tool_use for OpenAI ---
-{
-  const originalFetch = globalThis.fetch;
-
-  try {
-    let requestBody: Record<string, unknown> | null = null;
-
-    globalThis.fetch = (async (_input, init) => {
-      requestBody = JSON.parse(
-        typeof init?.body === "string" ? init.body : JSON.stringify({}),
-      ) as Record<string, unknown>;
-
-      return new Response(
-        `data: ${JSON.stringify({
-          choices: [
-            {
-              delta: {
-                tool_calls: [
-                  {
-                    index: 0,
-                    id: "call-read-1",
-                    function: {
-                      name: "documentRead",
-                      arguments: "{\"scope\":\"cursor\"}",
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        })}\n\n`
-          + `data: ${JSON.stringify({
-            choices: [
-              {
-                delta: { content: "查完继续。" },
-                finish_reason: "tool_calls",
-              },
-            ],
-          })}\n\n`
-          + "data: [DONE]\n\n",
-        {
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-        },
-      );
-    }) as typeof fetch;
-
-    const service = createAiService({
-      logger: createLogger(),
-      env: {
-        CREONOW_AI_PROVIDER: "openai",
-        CREONOW_AI_BASE_URL: "https://api.openai.com",
-        CREONOW_AI_API_KEY: "sk-test",
-      },
-      sleep: async () => {},
-      rateLimitPerMinute: 1_000,
-    }) as unknown as {
-      streamChat: (
-        messages: Array<{ role: "system" | "user" | "assistant" | "tool"; content: string }>,
-        options: {
-          modelId: string;
-          tools?: Array<{ name: string; description: string }>;
-          onComplete: (result: StreamResult) => void;
-          onError: (error: { message: string }) => void;
-        },
-      ) => AsyncGenerator<{ finishReason: "stop" | "tool_use" | null }>;
-    };
-
-    let completed: StreamResult | null = null;
-    const finishReasons: Array<"stop" | "tool_use" | null> = [];
-
-    await (async () => {
-      for await (const chunk of service.streamChat(
-        [
-          { role: "system", content: "你是写作助手" },
-          { role: "user", content: "继续写下去" },
-        ],
-        {
-          modelId: "gpt-5.2",
-          tools: [
-            {
-              name: "documentRead",
-              description: "Read current document",
-            },
-          ],
-          onComplete: (result) => {
-            completed = result;
-          },
-          onError: (error) => {
-            throw new Error(error.message);
-          },
-        },
-      )) {
-        finishReasons.push(chunk.finishReason);
-      }
-    })();
-
-    if (requestBody === null) {
-      throw new Error("request body should be captured");
-    }
-    if (completed === null) {
-      throw new Error("streamChat should complete with final result");
-    }
-    const sentBody = requestBody as unknown as Record<string, unknown>;
-    const result = completed as unknown as StreamResult;
-
-    assert.equal(Array.isArray(sentBody.tools), true);
-    assert.equal(
-      (sentBody.tools as Array<{ function: { name: string } }>)[0]?.function.name,
-      "documentRead",
-    );
-    assert.equal(sentBody.tool_choice, "auto");
-    assert.equal(finishReasons.includes("tool_use"), true);
-    assert.equal(result.finishReason, "tool_use");
-    assert.deepEqual(result.toolCalls, [
-      {
-        id: "call-read-1",
-        name: "documentRead",
-        arguments: { scope: "cursor" },
-      },
-    ]);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
 }
 
 function createDoneWaiter(): {
@@ -178,250 +54,373 @@ function createDoneWaiter(): {
   };
 }
 
-// --- runtime assembly uses shared multi-turn chain for OpenAI stream/non-stream ---
-{
-  const originalFetch = globalThis.fetch;
+describe("AI service runtime multi-turn", () => {
+  it("passes tools and parses tool_use for OpenAI streaming", async () => {
+    const originalFetch = globalThis.fetch;
 
-  try {
-    const requestBodies: unknown[] = [];
-    let nonStreamReplyNo = 0;
-    let streamReplyNo = 0;
+    try {
+      let requestBody: Record<string, unknown> | null = null;
 
-    globalThis.fetch = (async (_input, init) => {
-      const rawBody =
-        typeof init?.body === "string" ? init.body : JSON.stringify({});
-      const parsed = JSON.parse(rawBody) as {
-        stream?: unknown;
-        messages?: Array<{ role?: unknown; content?: unknown }>;
-      };
-      requestBodies.push(parsed);
+      globalThis.fetch = (async (_input, init) => {
+        requestBody = JSON.parse(
+          typeof init?.body === "string" ? init.body : JSON.stringify({}),
+        ) as Record<string, unknown>;
 
-      if (parsed.stream === true) {
-        streamReplyNo += 1;
         return new Response(
           `data: ${JSON.stringify({
-            choices: [{ delta: { content: `oa-stream-${streamReplyNo}` } }],
-          })}\n\n` + "data: [DONE]\n\n",
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call-read-1",
+                      function: {
+                        name: "documentRead",
+                        arguments: "{\"scope\":\"cursor\"}",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          })}\n\n`
+            + `data: ${JSON.stringify({
+              choices: [
+                {
+                  delta: { content: "查完继续。" },
+                  finish_reason: "tool_calls",
+                },
+              ],
+            })}\n\n`
+            + "data: [DONE]\n\n",
           {
             status: 200,
             headers: { "content-type": "text/event-stream" },
           },
         );
-      }
+      }) as typeof fetch;
 
-      nonStreamReplyNo += 1;
-      return new Response(
-        JSON.stringify({
-          choices: [
+      const service = createAiService({
+        logger: createLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "openai",
+          CREONOW_AI_BASE_URL: "https://api.openai.com",
+          CREONOW_AI_API_KEY: "sk-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      }) as unknown as {
+        streamChat: (
+          messages: Array<{ role: "system" | "user" | "assistant" | "tool"; content: string }>,
+          options: {
+            modelId: string;
+            tools?: Array<{ name: string; description: string }>;
+            onComplete: (result: StreamResult) => void;
+            onError: (error: { message: string }) => void;
+          },
+        ) => AsyncGenerator<{ finishReason: "stop" | "tool_use" | null }>;
+      };
+
+      let completed: StreamResult | null = null;
+      const finishReasons: Array<"stop" | "tool_use" | null> = [];
+
+      for await (const chunk of service.streamChat(
+        [
+          { role: "system", content: "你是写作助手" },
+          { role: "user", content: "继续写下去" },
+        ],
+        {
+          modelId: "gpt-5.2",
+          tools: [
             {
-              message: {
-                content: `oa-nonstream-${nonStreamReplyNo}`,
-              },
+              name: "documentRead",
+              description: "Read current document",
             },
           ],
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
+          onComplete: (result) => {
+            completed = result;
+          },
+          onError: (error) => {
+            throw new Error(error.message);
+          },
         },
+      )) {
+        finishReasons.push(chunk.finishReason);
+      }
+
+      if (requestBody === null) {
+        throw new Error("request body should be captured");
+      }
+      if (completed === null) {
+        throw new Error("streamChat should complete with final result");
+      }
+      const sentBody = requestBody as Record<string, unknown>;
+      const result = completed as StreamResult;
+
+      assert.equal(Array.isArray(sentBody.tools), true);
+      assert.equal(
+        (sentBody.tools as Array<{ function: { name: string } }>)[0]?.function.name,
+        "documentRead",
       );
-    }) as typeof fetch;
-
-    const service = createAiService({
-      logger: createLogger(),
-      env: {
-        CREONOW_AI_PROVIDER: "openai",
-        CREONOW_AI_BASE_URL: "https://api.openai.com",
-        CREONOW_AI_API_KEY: "sk-test",
-      },
-      sleep: async () => {},
-      rateLimitPerMinute: 1_000,
-    });
-
-    const first = await service.runSkill({
-      skillId: "builtin:polish",
-      input: "u1",
-      mode: "ask",
-      model: "gpt-5.2",
-      stream: false,
-      ts: 1_700_000_000_000,
-      emitEvent: () => {},
-    });
-    assert.equal(first.ok, true);
-
-    const doneWaiter = createDoneWaiter();
-    const second = await service.runSkill({
-      skillId: "builtin:polish",
-      input: "u2",
-      mode: "ask",
-      model: "gpt-5.2",
-      stream: true,
-      ts: 1_700_000_000_001,
-      emitEvent: doneWaiter.onEvent,
-    });
-    assert.equal(second.ok, true);
-    if (!second.ok) {
-      throw new Error("runSkill should return ok result");
+      assert.equal(sentBody.tool_choice, "auto");
+      assert.equal(finishReasons.includes("tool_use"), true);
+      assert.equal(result.finishReason, "tool_use");
+      assert.deepEqual(result.toolCalls, [
+        {
+          id: "call-read-1",
+          name: "documentRead",
+          arguments: { scope: "cursor" },
+        },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
     }
-    doneWaiter.setExecutionId(second.data.executionId);
-    await doneWaiter.promise;
+  });
 
-    const third = await service.runSkill({
-      skillId: "builtin:polish",
-      input: "u3",
-      mode: "ask",
-      model: "gpt-5.2",
-      stream: false,
-      ts: 1_700_000_000_002,
-      emitEvent: () => {},
-    });
-    assert.equal(third.ok, true);
+  it("reuses shared multi-turn chain for OpenAI stream and non-stream requests", async () => {
+    const originalFetch = globalThis.fetch;
 
-    const thirdRequest = requestBodies[2] as {
-      messages?: Array<{ role?: unknown; content?: unknown }>;
-    };
-    const messages = thirdRequest.messages;
-    assert.ok(Array.isArray(messages), "OpenAI request must include messages");
-    if (!Array.isArray(messages)) {
-      throw new Error("messages missing");
+    try {
+      const requestBodies: unknown[] = [];
+      let nonStreamReplyNo = 0;
+      let streamReplyNo = 0;
+
+      globalThis.fetch = (async (_input, init) => {
+        const rawBody =
+          typeof init?.body === "string" ? init.body : JSON.stringify({});
+        const parsed = JSON.parse(rawBody) as {
+          stream?: unknown;
+          messages?: Array<{ role?: unknown; content?: unknown }>;
+        };
+        requestBodies.push(parsed);
+
+        if (parsed.stream === true) {
+          streamReplyNo += 1;
+          return new Response(
+            `data: ${JSON.stringify({
+              choices: [{ delta: { content: `oa-stream-${streamReplyNo}` } }],
+            })}\n\n` + "data: [DONE]\n\n",
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          );
+        }
+
+        nonStreamReplyNo += 1;
+        return new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: `oa-nonstream-${nonStreamReplyNo}`,
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }) as typeof fetch;
+
+      const service = createAiService({
+        logger: createLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "openai",
+          CREONOW_AI_BASE_URL: "https://api.openai.com",
+          CREONOW_AI_API_KEY: "sk-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      const first = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "u1",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: false,
+        ts: 1_700_000_000_000,
+        emitEvent: () => {},
+      });
+      assert.equal(first.ok, true);
+
+      const doneWaiter = createDoneWaiter();
+      const second = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "u2",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: true,
+        ts: 1_700_000_000_001,
+        emitEvent: doneWaiter.onEvent,
+      });
+      assert.equal(second.ok, true);
+      if (!second.ok) {
+        throw new Error("runSkill should return ok result");
+      }
+      doneWaiter.setExecutionId(second.data.executionId);
+      await doneWaiter.promise;
+
+      const third = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "u3",
+        mode: "ask",
+        model: "gpt-5.2",
+        stream: false,
+        ts: 1_700_000_000_002,
+        emitEvent: () => {},
+      });
+      assert.equal(third.ok, true);
+
+      const thirdRequest = requestBodies[2] as {
+        messages?: Array<{ role?: unknown; content?: unknown }>;
+      };
+      const messages = thirdRequest.messages;
+      assert.ok(Array.isArray(messages), "OpenAI request must include messages");
+      if (!Array.isArray(messages)) {
+        throw new Error("messages missing");
+      }
+
+      assert.equal(messages[1]?.role, "user");
+      assert.equal(messages[1]?.content, "u1");
+      assert.equal(messages[2]?.role, "assistant");
+      assert.equal(messages[2]?.content, "oa-nonstream-1");
+      assert.equal(messages[3]?.role, "user");
+      assert.equal(messages[3]?.content, "u2");
+      assert.equal(messages[4]?.role, "assistant");
+      assert.equal(messages[4]?.content, "oa-stream-1");
+      assert.equal(messages[5]?.role, "user");
+      assert.equal(messages[5]?.content, "u3");
+    } finally {
+      globalThis.fetch = originalFetch;
     }
+  });
 
-    assert.equal(messages[1]?.role, "user");
-    assert.equal(messages[1]?.content, "u1");
-    assert.equal(messages[2]?.role, "assistant");
-    assert.equal(messages[2]?.content, "oa-nonstream-1");
-    assert.equal(messages[3]?.role, "user");
-    assert.equal(messages[3]?.content, "u2");
-    assert.equal(messages[4]?.role, "assistant");
-    assert.equal(messages[4]?.content, "oa-stream-1");
-    assert.equal(messages[5]?.role, "user");
-    assert.equal(messages[5]?.content, "u3");
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
+  it("reuses shared multi-turn chain for Anthropic stream and non-stream requests", async () => {
+    const originalFetch = globalThis.fetch;
 
-// --- runtime assembly uses shared multi-turn chain for Anthropic stream/non-stream ---
-{
-  const originalFetch = globalThis.fetch;
+    try {
+      const requestBodies: unknown[] = [];
+      let nonStreamReplyNo = 0;
+      let streamReplyNo = 0;
 
-  try {
-    const requestBodies: unknown[] = [];
-    let nonStreamReplyNo = 0;
-    let streamReplyNo = 0;
+      globalThis.fetch = (async (_input, init) => {
+        const rawBody =
+          typeof init?.body === "string" ? init.body : JSON.stringify({});
+        const parsed = JSON.parse(rawBody) as {
+          stream?: unknown;
+          system?: unknown;
+          messages?: Array<{ role?: unknown; content?: unknown }>;
+        };
+        requestBodies.push(parsed);
 
-    globalThis.fetch = (async (_input, init) => {
-      const rawBody =
-        typeof init?.body === "string" ? init.body : JSON.stringify({});
-      const parsed = JSON.parse(rawBody) as {
-        stream?: unknown;
+        if (parsed.stream === true) {
+          streamReplyNo += 1;
+          return new Response(
+            `event: content_block_delta\n`
+              + `data: ${JSON.stringify({ delta: { text: `an-stream-${streamReplyNo}` } })}\n\n`
+              + "event: message_stop\n"
+              + "data: {}\n\n",
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          );
+        }
+
+        nonStreamReplyNo += 1;
+        return new Response(
+          JSON.stringify({
+            content: [{ text: `an-nonstream-${nonStreamReplyNo}` }],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }) as typeof fetch;
+
+      const service = createAiService({
+        logger: createLogger(),
+        env: {
+          CREONOW_AI_PROVIDER: "anthropic",
+          CREONOW_AI_BASE_URL: "https://api.anthropic.com",
+          CREONOW_AI_API_KEY: "sk-ant-test",
+        },
+        sleep: async () => {},
+        rateLimitPerMinute: 1_000,
+      });
+
+      const first = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "u1",
+        mode: "ask",
+        model: "claude-3-5-sonnet",
+        stream: false,
+        ts: 1_700_000_000_100,
+        emitEvent: () => {},
+      });
+      assert.equal(first.ok, true);
+
+      const doneWaiter = createDoneWaiter();
+      const second = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "u2",
+        mode: "ask",
+        model: "claude-3-5-sonnet",
+        stream: true,
+        ts: 1_700_000_000_101,
+        emitEvent: doneWaiter.onEvent,
+      });
+      assert.equal(second.ok, true);
+      if (!second.ok) {
+        throw new Error("runSkill should return ok result");
+      }
+      doneWaiter.setExecutionId(second.data.executionId);
+      await doneWaiter.promise;
+
+      const third = await service.runSkill({
+        skillId: "builtin:polish",
+        input: "u3",
+        mode: "ask",
+        model: "claude-3-5-sonnet",
+        stream: false,
+        ts: 1_700_000_000_102,
+        emitEvent: () => {},
+      });
+      assert.equal(third.ok, true);
+
+      const thirdRequest = requestBodies[2] as {
         system?: unknown;
         messages?: Array<{ role?: unknown; content?: unknown }>;
       };
-      requestBodies.push(parsed);
+      assert.equal(typeof thirdRequest.system, "string");
 
-      if (parsed.stream === true) {
-        streamReplyNo += 1;
-        return new Response(
-          `event: content_block_delta\n` +
-            `data: ${JSON.stringify({ delta: { text: `an-stream-${streamReplyNo}` } })}\n\n` +
-            "event: message_stop\n" +
-            "data: {}\n\n",
-          {
-            status: 200,
-            headers: { "content-type": "text/event-stream" },
-          },
-        );
+      const messages = thirdRequest.messages;
+      assert.ok(
+        Array.isArray(messages),
+        "Anthropic request must include message array",
+      );
+      if (!Array.isArray(messages)) {
+        throw new Error("messages missing");
       }
 
-      nonStreamReplyNo += 1;
-      return new Response(
-        JSON.stringify({
-          content: [{ text: `an-nonstream-${nonStreamReplyNo}` }],
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    }) as typeof fetch;
-
-    const service = createAiService({
-      logger: createLogger(),
-      env: {
-        CREONOW_AI_PROVIDER: "anthropic",
-        CREONOW_AI_BASE_URL: "https://api.anthropic.com",
-        CREONOW_AI_API_KEY: "sk-ant-test",
-      },
-      sleep: async () => {},
-      rateLimitPerMinute: 1_000,
-    });
-
-    const first = await service.runSkill({
-      skillId: "builtin:polish",
-      input: "u1",
-      mode: "ask",
-      model: "claude-3-5-sonnet",
-      stream: false,
-      ts: 1_700_000_000_100,
-      emitEvent: () => {},
-    });
-    assert.equal(first.ok, true);
-
-    const doneWaiter = createDoneWaiter();
-    const second = await service.runSkill({
-      skillId: "builtin:polish",
-      input: "u2",
-      mode: "ask",
-      model: "claude-3-5-sonnet",
-      stream: true,
-      ts: 1_700_000_000_101,
-      emitEvent: doneWaiter.onEvent,
-    });
-    assert.equal(second.ok, true);
-    if (!second.ok) {
-      throw new Error("runSkill should return ok result");
+      assert.equal(messages[0]?.role, "user");
+      assert.equal(messages[0]?.content, "u1");
+      assert.equal(messages[1]?.role, "assistant");
+      assert.equal(messages[1]?.content, "an-nonstream-1");
+      assert.equal(messages[2]?.role, "user");
+      assert.equal(messages[2]?.content, "u2");
+      assert.equal(messages[3]?.role, "assistant");
+      assert.equal(messages[3]?.content, "an-stream-1");
+      assert.equal(messages[4]?.role, "user");
+      assert.equal(messages[4]?.content, "u3");
+    } finally {
+      globalThis.fetch = originalFetch;
     }
-    doneWaiter.setExecutionId(second.data.executionId);
-    await doneWaiter.promise;
-
-    const third = await service.runSkill({
-      skillId: "builtin:polish",
-      input: "u3",
-      mode: "ask",
-      model: "claude-3-5-sonnet",
-      stream: false,
-      ts: 1_700_000_000_102,
-      emitEvent: () => {},
-    });
-    assert.equal(third.ok, true);
-
-    const thirdRequest = requestBodies[2] as {
-      system?: unknown;
-      messages?: Array<{ role?: unknown; content?: unknown }>;
-    };
-    assert.equal(typeof thirdRequest.system, "string");
-
-    const messages = thirdRequest.messages;
-    assert.ok(
-      Array.isArray(messages),
-      "Anthropic request must include message array",
-    );
-    if (!Array.isArray(messages)) {
-      throw new Error("messages missing");
-    }
-
-    assert.equal(messages[0]?.role, "user");
-    assert.equal(messages[0]?.content, "u1");
-    assert.equal(messages[1]?.role, "assistant");
-    assert.equal(messages[1]?.content, "an-nonstream-1");
-    assert.equal(messages[2]?.role, "user");
-    assert.equal(messages[2]?.content, "u2");
-    assert.equal(messages[3]?.role, "assistant");
-    assert.equal(messages[3]?.content, "an-stream-1");
-    assert.equal(messages[4]?.role, "user");
-    assert.equal(messages[4]?.content, "u3");
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
+  });
+});

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -47,6 +47,14 @@ import type { TraceStore } from "./traceStore";
 import { createAiWriteTransaction } from "./aiWriteTransaction";
 import { logWarn } from "../shared/degradationCounter";
 import { ipcError, type ServiceResult, type Err } from "../shared/ipcResult";
+import type {
+  ChatMessage as AiChatMessage,
+  ChatToolDefinition,
+  StreamChunk,
+  StreamOptions,
+  StreamResult,
+  ToolCallInfo,
+} from "./streaming";
 export type { ServiceResult };
 
 export { assembleSystemPrompt, GLOBAL_IDENTITY_PROMPT };
@@ -100,6 +108,27 @@ export type AiService = {
     evidenceRef: string;
     ts: number;
   }) => ServiceResult<{ recorded: true }>;
+};
+
+type StreamChatCapableAiService = AiService & {
+  streamChat?: (
+    messages: AiChatMessage[],
+    options: StreamOptions,
+  ) => AsyncGenerator<StreamChunk>;
+};
+
+type OpenAiToolCallFragment = {
+  index: number;
+  id?: string;
+  name?: string;
+  argumentsChunk?: string;
+};
+
+type AnthropicToolCallState = {
+  id?: string;
+  name?: string;
+  inputChunks: string[];
+  inputObject?: Record<string, unknown>;
 };
 
 type JsonObject = Record<string, unknown>;
@@ -183,6 +212,295 @@ async function parseJsonResponse(
   } catch {
     return ipcError("LLM_API_ERROR", "Non-JSON upstream response");
   }
+}
+
+function extractOpenAiFinishReason(
+  json: unknown,
+): "stop" | "tool_use" | null {
+  const obj = asObject(json);
+  const choices = obj ? obj.choices : null;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return null;
+  }
+  const first = asObject(choices[0]);
+  const finishReason = first?.finish_reason;
+  if (finishReason === "stop") {
+    return "stop";
+  }
+  if (finishReason === "tool_calls") {
+    return "tool_use";
+  }
+  return null;
+}
+
+function extractOpenAiToolCallFragments(
+  json: unknown,
+): OpenAiToolCallFragment[] {
+  const obj = asObject(json);
+  const choices = obj ? obj.choices : null;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return [];
+  }
+  const first = asObject(choices[0]);
+  const delta = asObject(first?.delta);
+  const toolCalls = delta?.tool_calls;
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+
+  const fragments: OpenAiToolCallFragment[] = [];
+  for (const rawCall of toolCalls) {
+    const call = asObject(rawCall);
+    const fn = asObject(call?.function);
+    const rawIndex = call?.index;
+    if (typeof rawIndex !== "number" || !Number.isInteger(rawIndex)) {
+      continue;
+    }
+    fragments.push({
+      index: rawIndex,
+      ...(typeof call?.id === "string" ? { id: call.id } : {}),
+      ...(typeof fn?.name === "string" ? { name: fn.name } : {}),
+      ...(typeof fn?.arguments === "string"
+        ? { argumentsChunk: fn.arguments }
+        : {}),
+    });
+  }
+  return fragments;
+}
+
+function finalizeOpenAiToolCalls(
+  fragmentsByIndex: Map<
+    number,
+    { id?: string; name?: string; argumentsChunks: string[] }
+  >,
+): ToolCallInfo[] {
+  return [...fragmentsByIndex.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([index, fragment]) => {
+      const rawArguments = fragment.argumentsChunks.join("").trim();
+      let parsedArguments: Record<string, unknown> = {};
+      if (rawArguments.length > 0) {
+        try {
+          const parsed = JSON.parse(rawArguments) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            parsedArguments = parsed as Record<string, unknown>;
+          } else {
+            parsedArguments = { value: parsed };
+          }
+        } catch {
+          parsedArguments = { raw: rawArguments };
+        }
+      }
+
+      return {
+        id: fragment.id ?? `tool-call-${index}`,
+        name: fragment.name ?? `tool-${index}`,
+        arguments: parsedArguments,
+      };
+    });
+}
+
+function extractAnthropicStopReason(
+  json: unknown,
+): "stop" | "tool_use" | null {
+  const obj = asObject(json);
+  const delta = asObject(obj?.delta);
+  const stopReason = delta?.stop_reason ?? obj?.stop_reason;
+  if (stopReason === "tool_use") {
+    return "tool_use";
+  }
+  if (
+    stopReason === "end_turn"
+    || stopReason === "stop_sequence"
+    || stopReason === "max_tokens"
+  ) {
+    return "stop";
+  }
+  return null;
+}
+
+function finalizeAnthropicToolCalls(
+  toolCallsByIndex: Map<number, AnthropicToolCallState>,
+): ToolCallInfo[] {
+  return [...toolCallsByIndex.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([index, state]) => {
+      const rawArguments = state.inputChunks.join("").trim();
+      let argumentsValue: Record<string, unknown> =
+        state.inputObject ?? {};
+
+      if (rawArguments.length > 0) {
+        try {
+          const parsed = JSON.parse(rawArguments) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            argumentsValue = parsed as Record<string, unknown>;
+          } else {
+            argumentsValue = { value: parsed };
+          }
+        } catch {
+          argumentsValue = { raw: rawArguments };
+        }
+      }
+
+      return {
+        id: state.id ?? `anthropic-tool-${index}`,
+        name: state.name ?? `tool-${index}`,
+        arguments: argumentsValue,
+      };
+    });
+}
+
+function toOpenAiMessages(messages: AiChatMessage[]): unknown[] {
+  return messages.map((message) => {
+    if (message.role === "tool") {
+      return {
+        role: "tool",
+        content: message.content,
+        ...(typeof message.toolCallId === "string"
+          ? { tool_call_id: message.toolCallId }
+          : {}),
+      };
+    }
+
+    if (
+      message.role === "assistant"
+      && Array.isArray(message.toolCalls)
+      && message.toolCalls.length > 0
+    ) {
+      return {
+        role: "assistant",
+        content: message.content,
+        tool_calls: message.toolCalls.map((toolCall) => ({
+          id: toolCall.id,
+          type: "function",
+          function: {
+            name: toolCall.name,
+            arguments: JSON.stringify(toolCall.arguments),
+          },
+        })),
+      };
+    }
+
+    return {
+      role: message.role,
+      content: message.content,
+    };
+  });
+}
+
+function toOpenAiTools(
+  tools: ChatToolDefinition[] | undefined,
+): unknown[] | undefined {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return undefined;
+  }
+  return tools.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema ?? {
+        type: "object",
+        additionalProperties: true,
+      },
+    },
+  }));
+}
+
+function toAnthropicRequest(
+  messages: AiChatMessage[],
+  tools: ChatToolDefinition[] | undefined,
+): {
+  systemText: string;
+  messages: Array<{
+    role: "user" | "assistant";
+    content: string | Array<Record<string, unknown>>;
+  }>;
+  tools?: Array<{
+    name: string;
+    description: string;
+    input_schema: Record<string, unknown>;
+  }>;
+} {
+  const systemParts: string[] = [];
+  const requestMessages: Array<{
+    role: "user" | "assistant";
+    content: string | Array<Record<string, unknown>>;
+  }> =
+    [];
+
+  for (const message of messages) {
+    if (message.role === "system") {
+      systemParts.push(message.content);
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      if (Array.isArray(message.toolCalls) && message.toolCalls.length > 0) {
+        const contentBlocks: Array<Record<string, unknown>> = [];
+        if (message.content.length > 0) {
+          contentBlocks.push({
+            type: "text",
+            text: message.content,
+          });
+        }
+        for (const toolCall of message.toolCalls) {
+          contentBlocks.push({
+            type: "tool_use",
+            id: toolCall.id,
+            name: toolCall.name,
+            input: toolCall.arguments,
+          });
+        }
+        requestMessages.push({
+          role: "assistant",
+          content: contentBlocks,
+        });
+        continue;
+      }
+      requestMessages.push({
+        role: "assistant",
+        content: message.content,
+      });
+      continue;
+    }
+
+    if (message.role === "tool") {
+      requestMessages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: message.toolCallId ?? "unknown",
+            content: message.content,
+          },
+        ],
+      });
+      continue;
+    }
+
+    requestMessages.push({
+      role: "user",
+      content: message.content,
+    });
+  }
+
+  return {
+    systemText: systemParts.join("\n\n"),
+    messages: requestMessages,
+    ...(Array.isArray(tools) && tools.length > 0
+      ? {
+          tools: tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            input_schema: tool.inputSchema ?? {
+              type: "object",
+              additionalProperties: true,
+            },
+          })),
+        }
+      : {}),
+  };
 }
 
 /**
@@ -2093,6 +2411,393 @@ function createAiMethodOps(
   return { listModels, cancel, feedback };
 }
 
+function createAiStreamChatOp(
+  deps: AiServiceDeps,
+  state: AiInternalState,
+  nonStreamHelpers: ReturnType<typeof createAiNonStreamHelpers>,
+): {
+  streamChat: (
+    messages: AiChatMessage[],
+    options: StreamOptions,
+  ) => AsyncGenerator<StreamChunk>;
+} {
+  async function* streamChat(
+    messages: AiChatMessage[],
+    options: StreamOptions,
+  ): AsyncGenerator<StreamChunk> {
+    const cfgRes = await state.providerResolver.resolveProviderConfig({
+      env: deps.env,
+      runtimeAiTimeoutMs: state.runtimeGovernance.ai.timeoutMs,
+      getFakeServer: state.getFakeServer,
+      getProxySettings: deps.getProxySettings,
+    });
+
+    if (!cfgRes.ok) {
+      const error = {
+        kind: "non-retryable" as const,
+        message: cfgRes.error.message,
+        retryCount: 0,
+      };
+      options.onError(error);
+      throw Object.assign(new Error(cfgRes.error.message), error);
+    }
+
+    const model =
+      options.modelId?.trim()
+      ?? deps.env.CREONOW_AI_MODEL?.trim()
+      ?? "";
+    const preflight = validateProviderPreflight({
+      provider: cfgRes.data.primary.provider,
+      model,
+      apiKey: cfgRes.data.primary.apiKey,
+      allowMissingApiKey: deps.env.CREONOW_E2E === "1",
+    });
+    if (!preflight.ok) {
+      const error = {
+        kind: "non-retryable" as const,
+        message: preflight.error.message,
+        retryCount: 0,
+      };
+      options.onError(error);
+      throw Object.assign(new Error(preflight.error.message), error);
+    }
+
+    const promptTokens = estimateTokenCount(
+      messages.map((message) => message.content).join("\n\n"),
+    );
+    const controller = new AbortController();
+    const abortFromOuter = () => controller.abort();
+    if (options.signal?.aborted) {
+      controller.abort();
+    } else {
+      options.signal?.addEventListener("abort", abortFromOuter, { once: true });
+    }
+
+    try {
+      const cfg = cfgRes.data.primary;
+      let content = "";
+      let finishReason: "stop" | "tool_use" | null = null;
+      let toolCalls: ToolCallInfo[] = [];
+      const anthropicToolCalls = new Map<number, AnthropicToolCallState>();
+
+      if (cfg.provider === "anthropic") {
+        const anthropicRequest = toAnthropicRequest(messages, options.tools);
+        const url = buildApiUrl({
+          baseUrl: cfg.baseUrl,
+          endpointPath: "/v1/messages",
+        });
+        const fetchRes = await nonStreamHelpers.fetchWithPolicy({
+          url,
+          init: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "anthropic-version": "2023-06-01",
+              ...(cfg.apiKey ? { "x-api-key": cfg.apiKey } : {}),
+            },
+            body: JSON.stringify({
+              model,
+              max_tokens: DEFAULT_REQUEST_MAX_TOKENS_ESTIMATE,
+              system: anthropicRequest.systemText,
+              messages: anthropicRequest.messages,
+              stream: true,
+              ...(anthropicRequest.tools
+                ? { tools: anthropicRequest.tools }
+                : {}),
+            }),
+            signal: controller.signal,
+          },
+        });
+        if (!fetchRes.ok) {
+          const retryable =
+            fetchRes.error.code === "LLM_API_ERROR"
+            || fetchRes.error.code === "TIMEOUT";
+          const error = {
+            kind: retryable ? ("retryable" as const) : ("non-retryable" as const),
+            message: fetchRes.error.message,
+            retryCount: 0,
+          };
+          options.onError(error);
+          throw Object.assign(new Error(fetchRes.error.message), error);
+        }
+
+        const res = fetchRes.data;
+        if (!res.ok) {
+          const mapped = await buildUpstreamHttpError({
+            res,
+            fallbackMessage: "AI upstream request failed",
+          });
+          const error = {
+            kind: mapped.code === "LLM_API_ERROR" ? ("retryable" as const) : ("non-retryable" as const),
+            message: mapped.message,
+            retryCount: 0,
+          };
+          options.onError(error);
+          throw Object.assign(new Error(mapped.message), error);
+        }
+        if (!res.body) {
+          const error = {
+            kind: "non-retryable" as const,
+            message: "Missing streaming response body",
+            retryCount: 0,
+          };
+          options.onError(error);
+          throw Object.assign(new Error(error.message), error);
+        }
+
+        for await (const msg of readSse({ body: res.body })) {
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          let parsed: unknown;
+          if (msg.data.length > 0) {
+            try {
+              parsed = JSON.parse(msg.data);
+            } catch {
+              parsed = null;
+            }
+          }
+
+          if (msg.event === "content_block_start") {
+            const obj = asObject(parsed);
+            const block = asObject(obj?.content_block);
+            if (block?.type === "tool_use") {
+              const index =
+                typeof obj?.index === "number" && Number.isInteger(obj.index)
+                  ? obj.index
+                  : 0;
+              const existing = anthropicToolCalls.get(index) ?? {
+                inputChunks: [],
+              };
+              if (typeof block.id === "string") {
+                existing.id = block.id;
+              }
+              if (typeof block.name === "string") {
+                existing.name = block.name;
+              }
+              const input = block.input;
+              if (input && typeof input === "object" && !Array.isArray(input)) {
+                existing.inputObject = input as Record<string, unknown>;
+              }
+              anthropicToolCalls.set(index, existing);
+            }
+            continue;
+          }
+
+          if (msg.event === "content_block_delta") {
+            const obj = asObject(parsed);
+            const delta = asObject(obj?.delta);
+            if (delta?.type === "input_json_delta") {
+              const index =
+                typeof obj?.index === "number" && Number.isInteger(obj.index)
+                  ? obj.index
+                  : 0;
+              const existing = anthropicToolCalls.get(index) ?? {
+                inputChunks: [],
+              };
+              if (typeof delta.partial_json === "string") {
+                existing.inputChunks.push(delta.partial_json);
+              }
+              anthropicToolCalls.set(index, existing);
+              continue;
+            }
+
+            const deltaText = extractAnthropicDelta(parsed);
+            if (!deltaText) {
+              continue;
+            }
+            content += deltaText;
+            yield {
+              delta: deltaText,
+              finishReason: null,
+              accumulatedTokens: estimateTokenCount(content),
+            };
+            continue;
+          }
+
+          if (msg.event === "message_delta") {
+            const parsedFinishReason = extractAnthropicStopReason(parsed);
+            if (parsedFinishReason !== null) {
+              finishReason = parsedFinishReason;
+              yield {
+                delta: "",
+                finishReason: parsedFinishReason,
+                accumulatedTokens: estimateTokenCount(content),
+              };
+            }
+            continue;
+          }
+
+          if (msg.event === "message_stop") {
+            toolCalls = finalizeAnthropicToolCalls(anthropicToolCalls);
+            if (finishReason === null) {
+              finishReason = toolCalls.length > 0 ? "tool_use" : "stop";
+            }
+            if (toolCalls.length === 0) {
+              yield {
+                delta: "",
+                finishReason: finishReason,
+                accumulatedTokens: estimateTokenCount(content),
+              };
+            }
+            break;
+          }
+        }
+      } else {
+        const url = buildApiUrl({
+          baseUrl: cfg.baseUrl,
+          endpointPath: "/v1/chat/completions",
+        });
+        const fetchRes = await nonStreamHelpers.fetchWithPolicy({
+          url,
+          init: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...(cfg.apiKey
+                ? { Authorization: `Bearer ${cfg.apiKey}` }
+                : {}),
+            },
+            body: JSON.stringify({
+              model,
+              messages: toOpenAiMessages(messages),
+              stream: true,
+              ...(toOpenAiTools(options.tools)
+                ? {
+                    tools: toOpenAiTools(options.tools),
+                    tool_choice: "auto",
+                  }
+                : {}),
+            }),
+            signal: controller.signal,
+          },
+        });
+        if (!fetchRes.ok) {
+          const retryable =
+            fetchRes.error.code === "LLM_API_ERROR"
+            || fetchRes.error.code === "TIMEOUT";
+          const error = {
+            kind: retryable ? ("retryable" as const) : ("non-retryable" as const),
+            message: fetchRes.error.message,
+            retryCount: 0,
+          };
+          options.onError(error);
+          throw Object.assign(new Error(fetchRes.error.message), error);
+        }
+
+        const res = fetchRes.data;
+        if (!res.ok) {
+          const mapped = await buildUpstreamHttpError({
+            res,
+            fallbackMessage: "AI upstream request failed",
+          });
+          const error = {
+            kind: mapped.code === "LLM_API_ERROR" ? ("retryable" as const) : ("non-retryable" as const),
+            message: mapped.message,
+            retryCount: 0,
+          };
+          options.onError(error);
+          throw Object.assign(new Error(mapped.message), error);
+        }
+        if (!res.body) {
+          const error = {
+            kind: "non-retryable" as const,
+            message: "Missing streaming response body",
+            retryCount: 0,
+          };
+          options.onError(error);
+          throw Object.assign(new Error(error.message), error);
+        }
+
+        const toolFragments = new Map<
+          number,
+          { id?: string; name?: string; argumentsChunks: string[] }
+        >();
+
+        for await (const msg of readSse({ body: res.body })) {
+          if (controller.signal.aborted) {
+            return;
+          }
+          if (msg.data === "[DONE]") {
+            break;
+          }
+
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(msg.data);
+          } catch {
+            continue;
+          }
+
+          const delta = extractOpenAiDelta(parsed) ?? "";
+          const parsedFinishReason = extractOpenAiFinishReason(parsed);
+          if (parsedFinishReason !== null) {
+            finishReason = parsedFinishReason;
+          }
+          for (const fragment of extractOpenAiToolCallFragments(parsed)) {
+            const current = toolFragments.get(fragment.index) ?? {
+              argumentsChunks: [],
+            };
+            if (fragment.id) {
+              current.id = fragment.id;
+            }
+            if (fragment.name) {
+              current.name = fragment.name;
+            }
+            if (fragment.argumentsChunk) {
+              current.argumentsChunks.push(fragment.argumentsChunk);
+            }
+            toolFragments.set(fragment.index, current);
+          }
+
+          if (delta.length > 0) {
+            content += delta;
+          }
+
+          if (delta.length > 0 || parsedFinishReason !== null) {
+            yield {
+              delta,
+              finishReason: parsedFinishReason,
+              accumulatedTokens: estimateTokenCount(content),
+            };
+          }
+        }
+
+        toolCalls = finalizeOpenAiToolCalls(toolFragments);
+        if (finishReason === null) {
+          finishReason = toolCalls.length > 0 ? "tool_use" : "stop";
+        }
+      }
+
+      const completionTokens = estimateTokenCount(content);
+      const assistantMessage: AiChatMessage = {
+        role: "assistant",
+        content,
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+      };
+      const resultMessages: AiChatMessage[] = [...messages, assistantMessage];
+      const result: StreamResult = {
+        content,
+        usage: {
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+        },
+        wasRetried: false,
+        finishReason: finishReason ?? "stop",
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        messages: resultMessages,
+      };
+      options.onComplete(result);
+    } finally {
+      options.signal?.removeEventListener("abort", abortFromOuter);
+    }
+  }
+
+  return { streamChat };
+}
+
 export function createAiService(deps: AiServiceDeps): AiService {
   const runtimeGovernance = resolveRuntimeGovernanceFromEnv(deps.env);
   const runs = new Map<string, RunEntry>();
@@ -2179,6 +2884,23 @@ export function createAiService(deps: AiServiceDeps): AiService {
     state,
     helpers,
   );
+  const { streamChat } = createAiStreamChatOp(
+    deps,
+    state,
+    nonStreamHelpers,
+  );
+  const service: StreamChatCapableAiService = {
+    runSkill,
+    listModels,
+    cancel,
+    feedback,
+  };
+  Object.defineProperty(service, "streamChat", {
+    value: streamChat,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
 
-  return { runSkill, listModels, cancel, feedback };
+  return service;
 }

--- a/apps/desktop/main/src/services/ai/aiServiceAdapter.ts
+++ b/apps/desktop/main/src/services/ai/aiServiceAdapter.ts
@@ -5,20 +5,20 @@
  */
 
 import { estimateTokens } from "../context/tokenEstimation";
-import type { StreamChunk } from "./streaming";
+import type {
+  ChatMessage,
+  StreamChunk,
+  StreamOptions,
+  StreamResult,
+} from "./streaming";
 
-export type { StreamChunk };
-
-interface StreamOptions {
-  signal?: AbortSignal;
-  onComplete: (result: { content: string; usage: { promptTokens: number; completionTokens: number }; wasRetried: boolean }) => void;
-  onError: (error: { kind: string; message: string; retryCount: number; partialContent?: string }) => void;
-}
-
-interface ChatMessage {
-  role: string;
-  content: string;
-}
+export type {
+  ChatMessage,
+  ChatToolDefinition,
+  StreamChunk,
+  StreamOptions,
+  StreamResult,
+} from "./streaming";
 
 export interface AIServiceAdapter {
   streamChat(
@@ -32,9 +32,61 @@ export interface AIServiceAdapter {
 interface UnderlyingService {
   streamChat?: (
     messages: ChatMessage[],
+    options: StreamOptions,
   ) => AsyncGenerator<StreamChunk> | Promise<AsyncGenerator<StreamChunk>>;
   runSkill?: (params: unknown) => Promise<{ ok: boolean; data?: { text?: string } }>;
   [key: string]: unknown;
+}
+
+function appendAssistantMessage(
+  messages: ChatMessage[],
+  content: string,
+): ChatMessage[] {
+  return [
+    ...messages,
+    {
+      role: "assistant",
+      content,
+    },
+  ];
+}
+
+function composeAbortSignal(
+  outerSignal: AbortSignal | undefined,
+  innerController: AbortController,
+): AbortSignal {
+  if (!outerSignal) {
+    return innerController.signal;
+  }
+  if (outerSignal.aborted) {
+    innerController.abort();
+    return innerController.signal;
+  }
+  outerSignal.addEventListener("abort", () => innerController.abort(), {
+    once: true,
+  });
+  return innerController.signal;
+}
+
+function buildFallbackResult(args: {
+  messages: ChatMessage[];
+  content: string;
+  completionTokens: number;
+}): StreamResult {
+  const promptTokens = estimateTokens(
+    args.messages.map((message) => message.content).join("\n\n"),
+  );
+  return {
+    content: args.content,
+    usage: {
+      promptTokens,
+      completionTokens: args.completionTokens,
+      totalTokens: promptTokens + args.completionTokens,
+    },
+    wasRetried: false,
+    finishReason: "stop",
+    messages: appendAssistantMessage(args.messages, args.content),
+  };
 }
 
 export function createAIServiceAdapter(
@@ -49,26 +101,31 @@ export function createAIServiceAdapter(
     ): AsyncGenerator<StreamChunk> {
       const abortController = new AbortController();
       currentAbortController = abortController;
+      const signal = composeAbortSignal(options.signal, abortController);
 
       try {
         if (typeof underlying.streamChat === "function") {
-          const genResult = underlying.streamChat(messages);
+          let didComplete = false;
+          const genResult = underlying.streamChat(messages, {
+            ...options,
+            signal,
+            onComplete: (result) => {
+              didComplete = true;
+              options.onComplete(result);
+            },
+          });
 
-          let gen: AsyncGenerator<StreamChunk>;
-          if (
+          const gen =
             genResult !== null &&
             typeof genResult === "object" &&
             typeof (genResult as AsyncGenerator<StreamChunk>).next === "function"
-          ) {
-            gen = genResult as AsyncGenerator<StreamChunk>;
-          } else {
-            gen = await (genResult as Promise<AsyncGenerator<StreamChunk>>);
-          }
+              ? (genResult as AsyncGenerator<StreamChunk>)
+              : await (genResult as Promise<AsyncGenerator<StreamChunk>>);
 
           let hasYielded = false;
 
           for await (const chunk of gen) {
-            if (abortController.signal.aborted || options.signal?.aborted) {
+            if (signal.aborted) {
               return;
             }
             hasYielded = true;
@@ -76,14 +133,29 @@ export function createAIServiceAdapter(
           }
 
           if (!hasYielded) {
+            if (!didComplete) {
+              const fallback = buildFallbackResult({
+                messages,
+                content: "",
+                completionTokens: 0,
+              });
+              options.onComplete(fallback);
+            }
             yield { delta: "", finishReason: "stop", accumulatedTokens: 0 };
           }
-        } else if (typeof underlying.runSkill === "function") {
-          if (abortController.signal.aborted || options.signal?.aborted) return;
+          return;
+        }
+
+        if (typeof underlying.runSkill === "function") {
+          if (signal.aborted) {
+            return;
+          }
 
           const result = await underlying.runSkill({ messages });
 
-          if (abortController.signal.aborted || options.signal?.aborted) return;
+          if (signal.aborted) {
+            return;
+          }
 
           const text = result?.data?.text ?? "";
           const tokens = estimateTokens(text);
@@ -91,6 +163,14 @@ export function createAIServiceAdapter(
           if (text) {
             yield { delta: text, finishReason: null, accumulatedTokens: tokens };
           }
+
+          options.onComplete(
+            buildFallbackResult({
+              messages,
+              content: text,
+              completionTokens: tokens,
+            }),
+          );
           yield { delta: "", finishReason: "stop", accumulatedTokens: tokens };
         }
       } catch (err: unknown) {

--- a/apps/desktop/main/src/services/ai/streaming.ts
+++ b/apps/desktop/main/src/services/ai/streaming.ts
@@ -18,11 +18,30 @@ export interface ToolCallInfo {
   arguments: Record<string, unknown>;
 }
 
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  toolCallId?: string;
+  toolCalls?: ToolCallInfo[];
+}
+
+export interface ChatToolDefinition {
+  name: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+}
+
 export interface StreamResult {
   content: string;
-  usage: { promptTokens: number; completionTokens: number };
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
   wasRetried: boolean;
+  finishReason?: "stop" | "tool_use" | null;
   toolCalls?: ToolCallInfo[];
+  messages?: ChatMessage[];
 }
 
 export interface StreamError {
@@ -34,13 +53,10 @@ export interface StreamError {
 
 export interface StreamOptions {
   signal?: AbortSignal;
+  modelId?: string;
+  tools?: ChatToolDefinition[];
   onComplete: (result: StreamResult) => void;
   onError: (error: StreamError) => void;
-}
-
-interface ChatMessage {
-  role: string;
-  content: string;
 }
 
 interface LLMProxy {
@@ -160,8 +176,14 @@ export function createStreamingService(
             usage: {
               promptTokens,
               completionTokens: lastTokens,
+              totalTokens: promptTokens + lastTokens,
             },
             wasRetried,
+            finishReason: "stop",
+            messages: [
+              ...messages,
+              { role: "assistant", content: accumulatedContent },
+            ],
           });
           return;
         } catch (err: unknown) {

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -68,6 +68,85 @@ function createMockAIService() {
   };
 }
 
+function createMockToolUseAIService(rounds: Array<{
+  chunks?: Array<{ delta: string; finishReason: "stop" | "tool_use" | null; accumulatedTokens: number }>;
+  result: {
+    content: string;
+    finishReason: "stop" | "tool_use";
+    toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+    messages?: Array<{
+      role: "system" | "user" | "assistant" | "tool";
+      content: string;
+      toolCallId?: string;
+      toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+    }>;
+  };
+}>) {
+  let round = 0;
+  return {
+    streamChat: vi.fn().mockImplementation(
+      (
+        messages: Array<{
+          role: "system" | "user" | "assistant" | "tool";
+          content: string;
+          toolCallId?: string;
+          toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+        }>,
+        options: {
+          onComplete: (result: {
+            content: string;
+            usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+            wasRetried: boolean;
+            finishReason: "stop" | "tool_use";
+            toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+            messages?: Array<{
+              role: "system" | "user" | "assistant" | "tool";
+              content: string;
+              toolCallId?: string;
+              toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+            }>;
+          }) => void;
+        },
+      ) => {
+        const currentRound = rounds[round] ?? rounds[rounds.length - 1];
+        round += 1;
+        return (async function* () {
+          for (const chunk of currentRound.chunks ?? []) {
+            yield chunk;
+          }
+          options.onComplete({
+            content: currentRound.result.content,
+            usage: {
+              promptTokens: 10,
+              completionTokens: Math.max(1, currentRound.result.content.length),
+              totalTokens: 10 + Math.max(1, currentRound.result.content.length),
+            },
+            wasRetried: false,
+            finishReason: currentRound.result.finishReason,
+            ...(currentRound.result.toolCalls
+              ? { toolCalls: currentRound.result.toolCalls }
+              : {}),
+            messages:
+              currentRound.result.messages
+              ?? [
+                ...messages,
+                {
+                  role: "assistant",
+                  content: currentRound.result.content,
+                  ...(currentRound.result.toolCalls
+                    ? { toolCalls: currentRound.result.toolCalls }
+                    : {}),
+                },
+              ],
+          });
+        })();
+      },
+    ),
+    estimateTokens: vi.fn().mockReturnValue(10),
+    abort: vi.fn(),
+  };
+}
+
 /** Create mock PermissionGate */
 function createMockPermissionGate(autoGrant = true) {
   return {
@@ -118,6 +197,7 @@ function buildConfig(
   overrides: Partial<OrchestratorConfig> = {},
 ): OrchestratorConfig {
   const toolRegistry = createToolRegistry();
+  const agenticToolRegistry = createToolRegistry();
   // Register V1 built-in tools
   toolRegistry.register({
     name: "documentRead",
@@ -137,10 +217,17 @@ function buildConfig(
     isConcurrencySafe: false,
     execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "snap-prewrite-001" } }),
   });
+  agenticToolRegistry.register({
+    name: "documentRead",
+    description: "Read document text",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { content: "最新稿件" } }),
+  });
 
   return {
     aiService: createMockAIService(),
     toolRegistry,
+    agenticToolRegistry,
     permissionGate: createMockPermissionGate(),
     postWritingHooks: [createMockHook("auto-save-version")],
     defaultTimeoutMs: 30_000,
@@ -342,6 +429,267 @@ describe("WritingOrchestrator", () => {
         "文字。",
       ]);
       expect(eventTypes(events)).toContain("ai-done");
+      orch.dispose();
+    });
+  });
+
+  describe("Agentic Loop — P2 tool-use", () => {
+    it("continue 遇到 tool_use → 执行只读工具 → 注入结果 → 第二轮完成", async () => {
+      const aiService = createMockToolUseAIService([
+        {
+          chunks: [
+            { delta: "我先查设定。", finishReason: null, accumulatedTokens: 4 },
+          ],
+          result: {
+            content: "我先查设定。",
+            finishReason: "tool_use",
+            toolCalls: [
+              {
+                id: "call-read-1",
+                name: "documentRead",
+                arguments: { scope: "cursor" },
+              },
+            ],
+          },
+        },
+        {
+          chunks: [
+            { delta: "最终续写。", finishReason: "stop", accumulatedTokens: 5 },
+          ],
+          result: {
+            content: "最终续写。",
+            finishReason: "stop",
+          },
+        },
+      ]);
+      const cfg = buildConfig({ aiService });
+      const orch = createWritingOrchestrator(cfg);
+
+      const events = await collectEvents(
+        orch.execute(
+          makeRequest({
+            skillId: "continue",
+            selection: undefined,
+            cursorPosition: 4,
+            input: { selectedText: "甲乙丙丁", precedingText: "甲乙丙丁" },
+          }),
+        ),
+      );
+
+      expect(eventTypes(events)).toContain("tool-use-started");
+      expect(eventTypes(events)).toContain("tool-use-completed");
+      expect(aiService.streamChat).toHaveBeenCalledTimes(2);
+      const firstCallOptions = aiService.streamChat.mock.calls[0]?.[1] as
+        | {
+            tools?: Array<{ name: string }>;
+          }
+        | undefined;
+      expect(firstCallOptions?.tools?.map((tool) => tool.name)).toContain(
+        "documentRead",
+      );
+      expect(firstCallOptions?.tools?.map((tool) => tool.name)).not.toContain(
+        "documentWrite",
+      );
+
+      const secondCallMessages = aiService.streamChat.mock.calls[1]?.[0] as
+        | Array<{ role: string; toolCallId?: string; content: string }>
+        | undefined;
+      expect(secondCallMessages?.some((message) => message.role === "tool")).toBe(
+        true,
+      );
+      expect(
+        secondCallMessages?.some(
+          (message) =>
+            message.role === "tool" && message.toolCallId === "call-read-1",
+        ),
+      ).toBe(true);
+
+      const readTool = cfg.agenticToolRegistry?.get("documentRead") as
+        | { execute: ReturnType<typeof vi.fn> }
+        | undefined;
+      expect(readTool?.execute).toHaveBeenCalledTimes(1);
+
+      const doneEvent = events.find((event) => event.type === "ai-done") as
+        | (WritingEvent & { type: "ai-done" })
+        | undefined;
+      expect(doneEvent?.fullText).toBe("最终续写。");
+
+      orch.dispose();
+    });
+
+    it("continue 请求未知只读工具时 → tool-use-failed(all-failed) → 使用本轮 partial 进入 ai-done", async () => {
+      const aiService = createMockToolUseAIService([
+        {
+          chunks: [
+            { delta: "先查工具。", finishReason: null, accumulatedTokens: 4 },
+          ],
+          result: {
+            content: "先查工具。",
+            finishReason: "tool_use",
+            toolCalls: [
+              {
+                id: "call-unknown-1",
+                name: "unknownTool",
+                arguments: {},
+              },
+            ],
+          },
+        },
+      ]);
+      const cfg = buildConfig({
+        aiService,
+        permissionGate: createMockPermissionGate(false),
+      });
+      const orch = createWritingOrchestrator(cfg);
+
+      const events = await collectEvents(
+        orch.execute(
+          makeRequest({
+            skillId: "continue",
+            selection: undefined,
+            cursorPosition: 4,
+            input: { selectedText: "甲乙丙丁", precedingText: "甲乙丙丁" },
+          }),
+        ),
+      );
+
+      expect(eventTypes(events)).toContain("tool-use-started");
+      expect(eventTypes(events)).not.toContain("tool-use-completed");
+      expect(eventTypes(events)).toContain("tool-use-failed");
+      expect(aiService.streamChat).toHaveBeenCalledTimes(1);
+
+      const failedEvent = events.find(
+        (event) => event.type === "tool-use-failed",
+      ) as (WritingEvent & { type: "tool-use-failed" }) | undefined;
+      expect(
+        (failedEvent as unknown as { error: { code: string } }).error.code,
+      ).toBe("TOOL_USE_ALL_FAILED");
+
+      const doneEvent = events.find((event) => event.type === "ai-done") as
+        | (WritingEvent & { type: "ai-done" })
+        | undefined;
+      expect(doneEvent?.fullText).toBe("先查工具。");
+
+      orch.dispose();
+    });
+
+    it("tool-use 超过最大轮次时熔断，并使用最后一轮 partial 进入 ai-done", async () => {
+      const aiService = createMockToolUseAIService([
+        {
+          result: {
+            content: "第一轮查询。",
+            finishReason: "tool_use",
+            toolCalls: [
+              {
+                id: "call-read-1",
+                name: "documentRead",
+                arguments: { scope: "cursor" },
+              },
+            ],
+          },
+        },
+        {
+          result: {
+            content: "第二轮仍想查。",
+            finishReason: "tool_use",
+            toolCalls: [
+              {
+                id: "call-read-2",
+                name: "documentRead",
+                arguments: { scope: "cursor" },
+              },
+            ],
+          },
+        },
+      ]);
+      const cfg = buildConfig({
+        aiService,
+        permissionGate: createMockPermissionGate(false),
+        resolveToolUseConfig: () => ({
+          maxToolRounds: 1,
+          toolTimeoutMs: 10_000,
+          maxConcurrentTools: 4,
+          agenticLoop: true,
+        }),
+      });
+      const orch = createWritingOrchestrator(cfg);
+
+      const events = await collectEvents(
+        orch.execute(
+          makeRequest({
+            skillId: "continue",
+            selection: undefined,
+            cursorPosition: 4,
+            input: { selectedText: "甲乙丙丁", precedingText: "甲乙丙丁" },
+          }),
+        ),
+      );
+
+      expect(aiService.streamChat).toHaveBeenCalledTimes(2);
+      const failedEvent = events.find(
+        (event) => event.type === "tool-use-failed",
+      ) as (WritingEvent & { type: "tool-use-failed" }) | undefined;
+      expect(
+        (failedEvent as unknown as { error: { code: string } }).error.code,
+      ).toBe("TOOL_USE_MAX_ROUNDS_EXCEEDED");
+
+      const doneEvent = events.find((event) => event.type === "ai-done") as
+        | (WritingEvent & { type: "ai-done" })
+        | undefined;
+      expect(doneEvent?.fullText).toBe("第二轮仍想查。");
+
+      const readTool = cfg.agenticToolRegistry?.get("documentRead") as
+        | { execute: ReturnType<typeof vi.fn> }
+        | undefined;
+      expect(readTool?.execute).toHaveBeenCalledTimes(1);
+
+      orch.dispose();
+    });
+
+    it("AI 试图调用 documentWrite 时只读边界生效，不会把写工具暴露给 agentic loop", async () => {
+      const aiService = createMockToolUseAIService([
+        {
+          result: {
+            content: "我想直接改文档。",
+            finishReason: "tool_use",
+            toolCalls: [
+              {
+                id: "call-write-1",
+                name: "documentWrite",
+                arguments: { content: "hack" },
+              },
+            ],
+          },
+        },
+      ]);
+      const cfg = buildConfig({
+        aiService,
+        permissionGate: createMockPermissionGate(false),
+      });
+      const writeTool = cfg.toolRegistry.get("documentWrite") as
+        | { execute: ReturnType<typeof vi.fn> }
+        | undefined;
+      const orch = createWritingOrchestrator(cfg);
+
+      const events = await collectEvents(
+        orch.execute(
+          makeRequest({
+            skillId: "continue",
+            selection: undefined,
+            cursorPosition: 4,
+            input: { selectedText: "甲乙丙丁", precedingText: "甲乙丙丁" },
+          }),
+        ),
+      );
+
+      const failedEvent = events.find(
+        (event) => event.type === "tool-use-failed",
+      ) as (WritingEvent & { type: "tool-use-failed" }) | undefined;
+      expect(
+        (failedEvent as unknown as { error: { code: string } }).error.code,
+      ).toBe("TOOL_USE_ALL_FAILED");
+      expect(writeTool?.execute).not.toHaveBeenCalled();
+
       orch.dispose();
     });
   });

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -434,6 +434,39 @@ describe("WritingOrchestrator", () => {
   });
 
   describe("Agentic Loop — P2 tool-use", () => {
+    it("polish 遇到意外 tool_use 时 → 忽略 toolCalls 并产出 warning", async () => {
+      const aiService = createMockToolUseAIService([
+        {
+          chunks: [{ delta: "润色后的段落", finishReason: "tool_use", accumulatedTokens: 6 }],
+          result: {
+            content: "润色后的段落",
+            finishReason: "tool_use",
+            toolCalls: [{ id: "call-1", name: "documentRead", arguments: { scope: "cursor" } }],
+          },
+        },
+      ]);
+      orchestrator.dispose();
+      config = buildConfig({ aiService });
+      orchestrator = createWritingOrchestrator(config);
+
+      const events = await collectEvents(
+        orchestrator.execute(makeRequest({ skillId: "polish" })),
+      );
+
+      const warningEvent = events.find((event) => event.type === "warning");
+      expect(warningEvent).toMatchObject({
+        type: "warning",
+        message: "AI 返回 tool_use 但当前 Skill 未启用 Agentic Loop",
+      });
+      expect(eventTypes(events)).not.toContain("tool-use-started");
+      expect(eventTypes(events)).not.toContain("tool-use-completed");
+      expect(eventTypes(events)).not.toContain("tool-use-failed");
+      expect(events.find((event) => event.type === "ai-done")).toMatchObject({
+        type: "ai-done",
+        fullText: "润色后的段落",
+      });
+    });
+
     it("continue 遇到 tool_use → 执行只读工具 → 注入结果 → 第二轮完成", async () => {
       const aiService = createMockToolUseAIService([
         {

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -45,6 +45,7 @@ export type WritingEventType =
   | "model-selected"
   | "ai-chunk"
   | "ai-done"
+  | "warning"
   | "tool-use-started"
   | "tool-use-completed"
   | "tool-use-failed"
@@ -630,16 +631,28 @@ async function* executeAiRound(args: {
             ?? (Array.isArray(roundResult.toolCalls) && roundResult.toolCalls.length > 0
               ? "tool_use"
               : "stop");
+          const hasToolCalls =
+            Array.isArray(roundResult.toolCalls) && roundResult.toolCalls.length > 0;
+          const agenticLoopEnabled = Boolean(toolUseHandler && toolUseConfig);
+
+          if (finishReason === "tool_use" && !agenticLoopEnabled) {
+            yield makeEvent("warning", requestId, {
+              message: "AI 返回 tool_use 但当前 Skill 未启用 Agentic Loop",
+            });
+            break;
+          }
 
           if (
             finishReason !== "tool_use"
             || !toolUseHandler
             || !toolUseConfig
-            || !Array.isArray(roundResult.toolCalls)
-            || roundResult.toolCalls.length === 0
+            || !hasToolCalls
           ) {
             break;
           }
+          const toolCalls = roundResult.toolCalls as NonNullable<
+            StreamResult["toolCalls"]
+          >;
 
           const nextRound = toolRoundCount + 1;
           if (nextRound > toolUseConfig.maxToolRounds) {
@@ -656,7 +669,7 @@ async function* executeAiRound(args: {
 
           let parsedCalls;
           try {
-            parsedCalls = toolUseHandler.parseToolCalls(roundResult.toolCalls);
+            parsedCalls = toolUseHandler.parseToolCalls(toolCalls);
           } catch (error) {
             const message =
               error instanceof Error ? error.message : String(error);

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -9,7 +9,17 @@
  */
 
 import type { ToolRegistry } from "./toolRegistry";
-import type { StreamChunk } from "../ai/streaming";
+import type {
+  ChatMessage,
+  ChatToolDefinition,
+  StreamChunk,
+  StreamOptions,
+  StreamResult,
+} from "../ai/streaming";
+import {
+  createToolUseHandler,
+  type ToolUseConfig,
+} from "./toolUseHandler";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -35,6 +45,9 @@ export type WritingEventType =
   | "model-selected"
   | "ai-chunk"
   | "ai-done"
+  | "tool-use-started"
+  | "tool-use-completed"
+  | "tool-use-failed"
   | "permission-requested"
   | "permission-granted"
   | "permission-denied"
@@ -54,15 +67,15 @@ type TaskState = "pending" | "running" | "paused" | "completed" | "failed" | "ki
 
 interface AIService {
   streamChat(
-    messages: Array<{ role: string; content: string }>,
-    options: { signal: AbortSignal; onComplete: (r: unknown) => void; onError: (e: unknown) => void },
+    messages: ChatMessage[],
+    options: StreamOptions,
   ): AsyncGenerator<StreamChunk>;
   estimateTokens(text: string): number;
   abort(): void;
 }
 
 interface PreparedRequest {
-  messages: Array<{ role: string; content: string }>;
+  messages: ChatMessage[];
   tokenCount: number;
   modelId: string;
 }
@@ -99,10 +112,12 @@ interface PostWritingHook {
 export interface OrchestratorConfig {
   aiService: AIService;
   toolRegistry: ToolRegistry;
+  agenticToolRegistry?: ToolRegistry;
   permissionGate: PermissionGate;
   postWritingHooks: PostWritingHook[];
   defaultTimeoutMs: number;
   prepareRequest?: (request: WritingRequest) => Promise<PreparedRequest>;
+  resolveToolUseConfig?: (request: WritingRequest) => ToolUseConfig | null;
   generateText?: (args: {
     request: WritingRequest;
     signal: AbortSignal;
@@ -154,24 +169,266 @@ export function createWritingOrchestrator(
     return { type, timestamp: Date.now(), requestId, ...extra };
   }
 
-  function makeFailureEvent(args: {
-    requestId: string;
-    code: string;
-    message: string;
-    retryable?: boolean;
+function makeFailureEvent(args: {
+  requestId: string;
+  code: string;
+  message: string;
+  retryable?: boolean;
     details?: unknown;
   }): WritingEvent {
     taskStates.set(args.requestId, "failed");
     pruneTaskStates();
-    return makeEvent("error", args.requestId, {
-      error: {
-        code: args.code,
-        message: args.message,
+  return makeEvent("error", args.requestId, {
+    error: {
+      code: args.code,
+      message: args.message,
         retryable: args.retryable ?? false,
         ...(args.details === undefined ? {} : { details: args.details }),
       },
-    });
+  });
+}
+
+function leafSkillId(skillId: string): string {
+  const parts = skillId.split(":");
+  return parts[parts.length - 1] ?? skillId;
+}
+
+function resolveDefaultToolUseConfig(
+  request: WritingRequest,
+): ToolUseConfig | null {
+  if (leafSkillId(request.skillId) !== "continue") {
+    return null;
   }
+  return {
+    maxToolRounds: 5,
+    toolTimeoutMs: 10_000,
+    maxConcurrentTools: 4,
+    agenticLoop: true,
+  };
+}
+
+function toAgenticToolDefinitions(
+  registry: ToolRegistry | undefined,
+): ChatToolDefinition[] {
+  if (!registry) {
+    return [];
+  }
+  return registry.list().map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: {
+      type: "object",
+      additionalProperties: true,
+    },
+  }));
+}
+
+function appendAssistantMessage(
+  messages: ChatMessage[],
+  result: StreamResult,
+): ChatMessage[] {
+  return [
+    ...messages,
+    {
+      role: "assistant",
+      content: result.content,
+      ...(Array.isArray(result.toolCalls) && result.toolCalls.length > 0
+        ? { toolCalls: result.toolCalls }
+        : {}),
+    },
+  ];
+}
+
+function normalizeUsage(args: {
+  result: StreamResult;
+  estimateTokens: (text: string) => number;
+  messages: ChatMessage[];
+}): {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+} {
+  const promptTokens =
+    typeof args.result.usage?.promptTokens === "number"
+      ? args.result.usage.promptTokens
+      : args.estimateTokens(args.messages.map((message) => message.content).join("\n\n"));
+  const completionTokens =
+    typeof args.result.usage?.completionTokens === "number"
+      ? args.result.usage.completionTokens
+      : args.estimateTokens(args.result.content);
+  const totalTokens =
+    typeof args.result.usage?.totalTokens === "number"
+      ? args.result.usage.totalTokens
+      : promptTokens + completionTokens;
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens,
+  };
+}
+
+async function* executeAiRound(args: {
+  config: OrchestratorConfig;
+  request: WritingRequest;
+  messages: ChatMessage[];
+  modelId: string;
+  signal: AbortSignal;
+  tools?: ChatToolDefinition[];
+}): AsyncGenerator<StreamChunk, StreamResult, void> {
+  if (args.config.generateText) {
+    const chunkQueue: Array<{
+      delta: string;
+      accumulatedTokens: number;
+    }> = [];
+    let generatedResult: GeneratedTextResult | undefined;
+    let generatedError: unknown = null;
+    let generationSettled = false;
+    let notifyChange: (() => void) | null = null;
+    const wake = () => {
+      const resolver = notifyChange;
+      notifyChange = null;
+      resolver?.();
+    };
+    const generationPromise = args.config
+      .generateText({
+        request: args.request,
+        signal: args.signal,
+        emitChunk: (delta, accumulatedTokens) => {
+          chunkQueue.push({ delta, accumulatedTokens });
+          wake();
+        },
+      })
+      .then(
+        (result) => {
+          generatedResult = result;
+          generationSettled = true;
+          wake();
+        },
+        (error: unknown) => {
+          generatedError = error;
+          generationSettled = true;
+          wake();
+        },
+      );
+
+    while (!generationSettled || chunkQueue.length > 0) {
+      if (args.signal.aborted) {
+        return {
+          content: "",
+          usage: {
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+          },
+          wasRetried: false,
+          finishReason: null,
+          messages: args.messages,
+        };
+      }
+
+      const nextChunk = chunkQueue.shift();
+      if (nextChunk) {
+        yield {
+          delta: nextChunk.delta,
+          finishReason: null,
+          accumulatedTokens: nextChunk.accumulatedTokens,
+        };
+        continue;
+      }
+
+      await new Promise<void>((resolve) => {
+        const onAbort = () => resolve();
+        notifyChange = resolve;
+        args.signal.addEventListener("abort", onAbort, { once: true });
+      });
+    }
+
+    await generationPromise;
+    if (generatedError) {
+      throw generatedError;
+    }
+    if (!generatedResult) {
+      throw new Error("generateText completed without result");
+    }
+
+    return {
+      content: generatedResult.fullText,
+      usage: generatedResult.usage,
+      wasRetried: false,
+      finishReason: "stop",
+      messages: appendAssistantMessage(args.messages, {
+        content: generatedResult.fullText,
+        usage: generatedResult.usage,
+        wasRetried: false,
+      }),
+    };
+  }
+
+  let completionResult: StreamResult | null = null;
+  let content = "";
+  let lastTokens = 0;
+  let finishReason: "stop" | "tool_use" | null = null;
+
+  const gen = args.config.aiService.streamChat(args.messages, {
+    signal: args.signal,
+    modelId: args.modelId,
+    ...(args.tools ? { tools: args.tools } : {}),
+    onComplete: (result) => {
+      completionResult = result;
+    },
+    onError: () => {},
+  });
+
+  for await (const chunk of gen) {
+    content += chunk.delta;
+    lastTokens = chunk.accumulatedTokens;
+    if (chunk.finishReason !== null) {
+      finishReason = chunk.finishReason;
+    }
+    yield chunk;
+  }
+
+  if (completionResult) {
+    const completedResult = completionResult as StreamResult;
+    return {
+      ...completedResult,
+      finishReason:
+        completedResult.finishReason
+        ?? (Array.isArray(completedResult.toolCalls) && completedResult.toolCalls.length > 0
+          ? "tool_use"
+          : finishReason ?? "stop"),
+      messages: completedResult.messages ?? appendAssistantMessage(
+        args.messages,
+        completedResult,
+      ),
+    };
+  }
+
+  const promptTokens = args.config.aiService.estimateTokens(
+    args.messages.map((message) => message.content).join("\n\n"),
+  );
+  const fallbackResult: StreamResult = {
+    content,
+    usage: {
+      promptTokens,
+      completionTokens: lastTokens,
+      totalTokens: promptTokens + lastTokens,
+    },
+    wasRetried: false,
+    finishReason: finishReason ?? "stop",
+    messages: appendAssistantMessage(args.messages, {
+      content,
+      usage: {
+        promptTokens,
+        completionTokens: lastTokens,
+        totalTokens: promptTokens + lastTokens,
+      },
+      wasRetried: false,
+      finishReason: finishReason ?? "stop",
+    }),
+  };
+  return fallbackResult;
+}
 
   return {
     execute(request: WritingRequest): AsyncGenerator<WritingEvent> {
@@ -231,7 +488,7 @@ export function createWritingOrchestrator(
                   role: "user",
                   content: request.input.selectedText ?? "",
                 },
-              ],
+              ] as ChatMessage[],
               tokenCount: config.aiService.estimateTokens(request.input.selectedText ?? ""),
               modelId: request.modelId ?? "default",
             };
@@ -253,105 +510,55 @@ export function createWritingOrchestrator(
           return;
         }
 
-         // Stage 4: AI streaming
+        // Stage 4: AI streaming + P2 tool-use loop
         let fullText = "";
-        let lastTokens = 0;
+        let conversationMessages = prepared.messages;
         let aiError: unknown = null;
+        let toolRoundCount = 0;
+        const aggregateUsage = {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+        };
         const MAX_AI_RETRIES = 2;
-        let aiAttempt = 0;
-        let aiSuccess = false;
+        const toolUseConfig =
+          config.resolveToolUseConfig?.(request)
+          ?? resolveDefaultToolUseConfig(request);
+        const toolUseHandler =
+          toolUseConfig && config.agenticToolRegistry
+            ? createToolUseHandler(config.agenticToolRegistry, {
+                ...toolUseConfig,
+                agenticLoop: true,
+              })
+            : null;
+        const agenticTools =
+          toolUseHandler && config.agenticToolRegistry
+            ? toAgenticToolDefinitions(config.agenticToolRegistry)
+            : undefined;
 
-        while (aiAttempt <= MAX_AI_RETRIES && !aiSuccess) {
-          try {
-            fullText = "";
-            lastTokens = 0;
+        while (true) {
+          let aiAttempt = 0;
+          let aiSuccess = false;
+          let roundResult: StreamResult | null = null;
 
-            if (config.generateText) {
-              const chunkQueue: Array<{
-                delta: string;
-                accumulatedTokens: number;
-              }> = [];
-              let generatedResult: GeneratedTextResult | undefined;
-              let generatedError: unknown = null;
-              let generationSettled = false;
-              let notifyChange: (() => void) | null = null;
-              const wake = () => {
-                const resolver = notifyChange;
-                notifyChange = null;
-                resolver?.();
-              };
-              const generationPromise = config
-                .generateText({
-                  request,
-                  signal: abortController.signal,
-                  emitChunk: (delta, accumulatedTokens) => {
-                    chunkQueue.push({ delta, accumulatedTokens });
-                    wake();
-                  },
-                })
-                .then(
-                  (result) => {
-                    generatedResult = result;
-                    generationSettled = true;
-                    wake();
-                  },
-                  (error: unknown) => {
-                    generatedError = error;
-                    generationSettled = true;
-                    wake();
-                  },
-                );
+          while (aiAttempt <= MAX_AI_RETRIES && !aiSuccess) {
+            try {
+              const roundGen = executeAiRound({
+                config,
+                request,
+                messages: conversationMessages,
+                modelId: prepared.modelId,
+                signal: abortController.signal,
+                ...(agenticTools ? { tools: agenticTools } : {}),
+              });
 
-              while (!generationSettled || chunkQueue.length > 0) {
-                if (abortController.signal.aborted) {
-                  taskStates.set(requestId, "killed");
-                  yield makeEvent("aborted", requestId, {
-                    reason: "abort-during-ai",
-                  });
-                  return;
+              while (true) {
+                const nextChunk = await roundGen.next();
+                if (nextChunk.done) {
+                  roundResult = nextChunk.value;
+                  break;
                 }
 
-                const nextChunk = chunkQueue.shift();
-                if (nextChunk) {
-                  fullText += nextChunk.delta;
-                  lastTokens = nextChunk.accumulatedTokens;
-                  yield makeEvent("ai-chunk", requestId, {
-                    delta: nextChunk.delta,
-                    accumulatedTokens: nextChunk.accumulatedTokens,
-                  });
-                  continue;
-                }
-
-                await new Promise<void>((resolve) => {
-                  const onAbort = () => resolve();
-                  notifyChange = resolve;
-                  abortController.signal.addEventListener("abort", onAbort, {
-                    once: true,
-                  });
-                });
-              }
-
-              await generationPromise;
-              if (generatedError) {
-                throw generatedError;
-              }
-              if (!generatedResult) {
-                throw new Error("generateText completed without result");
-              }
-
-              fullText = generatedResult.fullText;
-              lastTokens = generatedResult.usage.completionTokens;
-            } else {
-              const gen = config.aiService.streamChat(
-                prepared.messages,
-                {
-                  signal: abortController.signal,
-                  onComplete: () => {},
-                  onError: () => {},
-                },
-              );
-
-              for await (const chunk of gen) {
                 if (abortController.signal.aborted) {
                   taskStates.set(requestId, "killed");
                   yield makeEvent("aborted", requestId, { reason: "abort-during-ai" });
@@ -359,55 +566,166 @@ export function createWritingOrchestrator(
                   return;
                 }
 
-                fullText += chunk.delta;
-                lastTokens = chunk.accumulatedTokens;
                 yield makeEvent("ai-chunk", requestId, {
-                  delta: chunk.delta,
-                  accumulatedTokens: chunk.accumulatedTokens,
+                  delta: nextChunk.value.delta,
+                  accumulatedTokens: nextChunk.value.accumulatedTokens,
                 });
               }
-            }
 
-            aiSuccess = true;
-          } catch (err: unknown) {
-            aiError = err;
-            const errObj = err as Record<string, unknown>;
+              aiSuccess = true;
+            } catch (err: unknown) {
+              aiError = err;
+              const errObj = err as Record<string, unknown>;
 
-            if (errObj?.kind === "non-retryable") {
+              if (errObj?.kind === "non-retryable") {
+                break;
+              }
+
+              if (errObj?.kind === "retryable") {
+                const retryCount = (errObj.retryCount as number) ?? 0;
+                if (retryCount >= MAX_AI_RETRIES) {
+                  break;
+                }
+                aiAttempt++;
+                continue;
+              }
+
               break;
             }
+          }
 
-            if (errObj?.kind === "retryable") {
-              const retryCount = (errObj.retryCount as number) ?? 0;
-              if (retryCount >= MAX_AI_RETRIES) break;
-              aiAttempt++;
-              continue;
-            }
+          if (!aiSuccess || !roundResult) {
+            taskStates.set(requestId, "failed");
+            yield makeEvent("error", requestId, {
+              error: {
+                code: "AI_SERVICE_ERROR",
+                message: String(aiError),
+                retryable: false,
+              },
+            });
+            return;
+          }
 
+          if (abortController.signal.aborted) {
+            taskStates.set(requestId, "killed");
+            yield makeEvent("aborted", requestId, { reason: "abort-during-ai" });
+            return;
+          }
+
+          const usage = normalizeUsage({
+            result: roundResult,
+            estimateTokens: config.aiService.estimateTokens,
+            messages: conversationMessages,
+          });
+          aggregateUsage.promptTokens += usage.promptTokens;
+          aggregateUsage.completionTokens += usage.completionTokens;
+          aggregateUsage.totalTokens += usage.totalTokens;
+
+          fullText = roundResult.content;
+          conversationMessages =
+            roundResult.messages ?? appendAssistantMessage(conversationMessages, roundResult);
+
+          const finishReason =
+            roundResult.finishReason
+            ?? (Array.isArray(roundResult.toolCalls) && roundResult.toolCalls.length > 0
+              ? "tool_use"
+              : "stop");
+
+          if (
+            finishReason !== "tool_use"
+            || !toolUseHandler
+            || !toolUseConfig
+            || !Array.isArray(roundResult.toolCalls)
+            || roundResult.toolCalls.length === 0
+          ) {
             break;
           }
-        }
 
-        if (!aiSuccess) {
-          taskStates.set(requestId, "failed");
-          yield makeEvent("error", requestId, {
-            error: {
-              code: "AI_SERVICE_ERROR",
-              message: String(aiError),
-              retryable: false,
-            },
+          const nextRound = toolRoundCount + 1;
+          if (nextRound > toolUseConfig.maxToolRounds) {
+            yield makeEvent("tool-use-failed", requestId, {
+              round: nextRound,
+              error: {
+                code: "TOOL_USE_MAX_ROUNDS_EXCEEDED",
+                message: `Maximum tool rounds (${toolUseConfig.maxToolRounds}) exceeded`,
+                retryable: false,
+              },
+            });
+            break;
+          }
+
+          let parsedCalls;
+          try {
+            parsedCalls = toolUseHandler.parseToolCalls(roundResult.toolCalls);
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            yield makeEvent("tool-use-failed", requestId, {
+              round: nextRound,
+              error: {
+                code: "TOOL_USE_PARSE_FAILED",
+                message,
+                retryable: false,
+              },
+            });
+            break;
+          }
+
+          yield makeEvent("tool-use-started", requestId, {
+            round: nextRound,
+            toolNames: parsedCalls.map((call) => call.toolName),
           });
-          return;
+
+          const results = await toolUseHandler.executeToolBatch(parsedCalls, {
+            documentId: request.documentId,
+            requestId,
+            ...(request.projectId ? { projectId: request.projectId } : {}),
+            ...(request.cursorPosition === undefined
+              ? {}
+              : { cursorPosition: request.cursorPosition }),
+            ...(request.selection ? { selection: request.selection } : {}),
+          });
+          toolRoundCount = nextRound;
+
+          const summary = toolUseHandler.getBatchSummary(results);
+          if (summary.allFailed) {
+            yield makeEvent("tool-use-failed", requestId, {
+              round: nextRound,
+              error: {
+                code: summary.errorCode ?? "TOOL_USE_ALL_FAILED",
+                message: "All requested tools failed or were not eligible",
+                retryable: false,
+              },
+            });
+            break;
+          }
+
+          yield makeEvent("tool-use-completed", requestId, {
+            round: nextRound,
+            results: results.map((result) => ({
+              toolName: result.toolName,
+              success: result.success,
+              durationMs: result.durationMs,
+            })),
+            hasNextRound: true,
+          });
+
+          conversationMessages = toolUseHandler.injectResults(
+            conversationMessages,
+            results,
+          );
         }
 
         // Stage 5: ai-done
         yield makeEvent("ai-done", requestId, {
           fullText,
-          usage: {
-            promptTokens: tokenCount,
-            completionTokens: lastTokens,
-            totalTokens: tokenCount + lastTokens,
-          },
+          usage: aggregateUsage.totalTokens > 0
+            ? aggregateUsage
+            : {
+                promptTokens: tokenCount,
+                completionTokens: 0,
+                totalTokens: tokenCount,
+              },
         });
 
         if (abortController.signal.aborted) {

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -12,6 +12,48 @@ type WritingToolingArgs = {
   logger: Logger;
 };
 
+function readDocument(args: WritingToolingArgs, ctx: Record<string, unknown>) {
+  const projectId =
+    typeof ctx.projectId === "string" ? ctx.projectId.trim() : "";
+  if (projectId.length === 0) {
+    return {
+      success: false as const,
+      error: { code: "DOCUMENT_READ_FAILED", message: "projectId is required" },
+    };
+  }
+
+  const service = createDocumentService({ db: args.db, logger: args.logger });
+  const current = service.read({
+    projectId,
+    documentId: String(ctx.documentId ?? ""),
+  });
+  if (!current.ok) {
+    return {
+      success: false as const,
+      error: {
+        code: current.error.code,
+        message: current.error.message,
+        details: current.error.details,
+        retryable: current.error.retryable,
+      },
+    };
+  }
+
+  return {
+    success: true as const,
+    data: {
+      projectId,
+      documentId: String(ctx.documentId ?? ""),
+      title: current.data.title,
+      content: current.data.contentText,
+      contentJson: current.data.contentJson,
+      cursorPosition:
+        typeof ctx.cursorPosition === "number" ? ctx.cursorPosition : null,
+      selection: ctx.selection ?? null,
+    },
+  };
+}
+
 export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistry {
   const registry = createToolRegistry();
 
@@ -189,6 +231,75 @@ export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistr
           },
         };
       },
+    }),
+  );
+
+  return registry;
+}
+
+export function createAgenticToolRegistry(
+  args: WritingToolingArgs,
+): ToolRegistry {
+  const registry = createToolRegistry();
+
+  const buildReadDocumentTool = (name: string, description: string) =>
+    buildTool({
+      name,
+      description,
+      isConcurrencySafe: true,
+      execute: async (ctx) => readDocument(args, ctx),
+    });
+
+  registry.register(
+    buildReadDocumentTool(
+      "documentRead",
+      "Read current document content for agentic reasoning",
+    ),
+  );
+  registry.register(
+    buildReadDocumentTool(
+      "docTool",
+      "Read current document context for agentic reasoning",
+    ),
+  );
+
+  registry.register(
+    buildTool({
+      name: "kgTool",
+      description: "Read-only knowledge graph lookup",
+      isConcurrencySafe: true,
+      execute: async (ctx) => ({
+        success: true,
+        data: {
+          query:
+            typeof ctx.arguments === "object" &&
+            ctx.arguments !== null &&
+            typeof (ctx.arguments as Record<string, unknown>).query === "string"
+              ? (ctx.arguments as Record<string, unknown>).query
+              : "",
+          items: [],
+        },
+      }),
+    }),
+  );
+
+  registry.register(
+    buildTool({
+      name: "memTool",
+      description: "Read-only memory lookup",
+      isConcurrencySafe: true,
+      execute: async (ctx) => ({
+        success: true,
+        data: {
+          query:
+            typeof ctx.arguments === "object" &&
+            ctx.arguments !== null &&
+            typeof (ctx.arguments as Record<string, unknown>).query === "string"
+              ? (ctx.arguments as Record<string, unknown>).query
+              : "",
+          memories: [],
+        },
+      }),
     }),
   );
 

--- a/apps/desktop/preload/src/aiStreamBridge.ts
+++ b/apps/desktop/preload/src/aiStreamBridge.ts
@@ -4,7 +4,9 @@ import {
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
+  SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
+  type AiToolUseEvent,
 } from "@shared/types/ai";
 import {
   JUDGE_RESULT_CHANNEL,
@@ -65,6 +67,40 @@ function isAiStreamEvent(x: unknown): x is AiStreamEvent {
       x.terminal === "error") &&
     typeof x.outputText === "string"
   );
+}
+
+function isAiToolUseEvent(x: unknown): x is AiToolUseEvent {
+  if (!isRecord(x)) {
+    return false;
+  }
+  if (
+    (x.type !== "tool-use-started"
+      && x.type !== "tool-use-completed"
+      && x.type !== "tool-use-failed")
+    || typeof x.executionId !== "string"
+    || typeof x.runId !== "string"
+    || typeof x.traceId !== "string"
+    || typeof x.round !== "number"
+    || typeof x.ts !== "number"
+  ) {
+    return false;
+  }
+
+  if (x.type === "tool-use-started") {
+    return Array.isArray(x.toolNames) && x.toolNames.every((item) => typeof item === "string");
+  }
+  if (x.type === "tool-use-completed") {
+    return (
+      Array.isArray(x.results)
+      && x.results.every((item) =>
+        isRecord(item)
+        && typeof item.toolName === "string"
+        && typeof item.success === "boolean"
+        && typeof item.durationMs === "number")
+      && typeof x.hasNextRound === "boolean"
+    );
+  }
+  return isRecord(x.error) && typeof x.error.code === "string" && typeof x.error.message === "string";
 }
 
 /**
@@ -135,6 +171,22 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
     );
   }
 
+  function forwardToolUseEvent(channel: string, payload: unknown): void {
+    if (subscriptions.count() === 0) {
+      return;
+    }
+
+    if (!isAiToolUseEvent(payload)) {
+      return;
+    }
+
+    window.dispatchEvent(
+      new CustomEvent<AiToolUseEvent>(channel, {
+        detail: payload,
+      }),
+    );
+  }
+
   const onSkillStreamChunk = (_evt: unknown, payload: unknown) => {
     forwardEvent(SKILL_STREAM_CHUNK_CHANNEL, payload);
   };
@@ -143,6 +195,9 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   };
   const onSkillQueueStatus = (_evt: unknown, payload: unknown) => {
     forwardEvent(SKILL_QUEUE_STATUS_CHANNEL, payload);
+  };
+  const onSkillToolUse = (_evt: unknown, payload: unknown) => {
+    forwardToolUseEvent(SKILL_TOOL_USE_CHANNEL, payload);
   };
   const onJudgeResult = (_evt: unknown, payload: unknown) => {
     if (subscriptions.count() === 0) {
@@ -162,6 +217,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   ipcRenderer.on(SKILL_STREAM_CHUNK_CHANNEL, onSkillStreamChunk);
   ipcRenderer.on(SKILL_STREAM_DONE_CHANNEL, onSkillStreamDone);
   ipcRenderer.on(SKILL_QUEUE_STATUS_CHANNEL, onSkillQueueStatus);
+  ipcRenderer.on(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
   ipcRenderer.on(JUDGE_RESULT_CHANNEL, onJudgeResult);
 
   return {
@@ -179,6 +235,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
         SKILL_QUEUE_STATUS_CHANNEL,
         onSkillQueueStatus,
       );
+      ipcRenderer.removeListener(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
       ipcRenderer.removeListener(JUDGE_RESULT_CHANNEL, onJudgeResult);
     },
   };

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -96,6 +96,16 @@ export type AiToolUseFailedEvent = {
   ts: number;
 };
 
+export type AiToolUseWarningEvent = {
+  type: "tool-use-warning";
+  executionId: string;
+  runId: string;
+  traceId: string;
+  message: string;
+  discardedToolNames?: string[];
+  ts: number;
+};
+
 export type AiStreamEvent =
   | AiStreamChunkEvent
   | AiStreamDoneEvent
@@ -104,4 +114,5 @@ export type AiStreamEvent =
 export type AiToolUseEvent =
   | AiToolUseStartedEvent
   | AiToolUseCompletedEvent
-  | AiToolUseFailedEvent;
+  | AiToolUseFailedEvent
+  | AiToolUseWarningEvent;

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -3,6 +3,7 @@ import type { IpcError } from "./ipc-generated";
 export const SKILL_STREAM_CHUNK_CHANNEL = "skill:stream:chunk" as const;
 export const SKILL_STREAM_DONE_CHANNEL = "skill:stream:done" as const;
 export const SKILL_QUEUE_STATUS_CHANNEL = "skill:queue:status" as const;
+export const SKILL_TOOL_USE_CHANNEL = "skill:tool-use" as const;
 
 export type AiStreamTerminal = "completed" | "cancelled" | "error";
 
@@ -60,7 +61,47 @@ export type AiQueueStatusEvent = {
   ts: number;
 };
 
+export type AiToolUseStartedEvent = {
+  type: "tool-use-started";
+  executionId: string;
+  runId: string;
+  traceId: string;
+  round: number;
+  toolNames: string[];
+  ts: number;
+};
+
+export type AiToolUseCompletedEvent = {
+  type: "tool-use-completed";
+  executionId: string;
+  runId: string;
+  traceId: string;
+  round: number;
+  results: Array<{
+    toolName: string;
+    success: boolean;
+    durationMs: number;
+  }>;
+  hasNextRound: boolean;
+  ts: number;
+};
+
+export type AiToolUseFailedEvent = {
+  type: "tool-use-failed";
+  executionId: string;
+  runId: string;
+  traceId: string;
+  round: number;
+  error: IpcError;
+  ts: number;
+};
+
 export type AiStreamEvent =
   | AiStreamChunkEvent
   | AiStreamDoneEvent
   | AiQueueStatusEvent;
+
+export type AiToolUseEvent =
+  | AiToolUseStartedEvent
+  | AiToolUseCompletedEvent
+  | AiToolUseFailedEvent;


### PR DESCRIPTION
Skip-Reason: workspace 根目录当前没有 `pnpm lint` 脚本，因此改跑可用的 `pnpm -r --if-present lint`。

## Summary
- 让 `aiService-runtime-multiturn.test.ts` 与 `ai-public-contract-regression.test.ts` 从脚本式断言改为真正的 Vitest 用例，并保留原有回归覆盖面。
- 为 non-agentic skill 的意外 `tool_use` 补齐 warning 事件与 IPC 转发：忽略 toolCalls、保留已生成文本、向前端透出提示。
- 补齐 `writing-orchestrator` / `ai-skill-tool-use-ipc` 回归测试，锁定 authoritative findings 对应行为。

Closes #47

## Impact Scope
- `polish` 等非 agentic skill 在 AI 意外返回 `finishReason: 'tool_use'` 时，不再尝试进入 tool-use loop；会直接使用当前文本结果，并发出 warning。
- 两个 AI 回归测试现在会被 `apps/desktop/vitest.config.core.ts` 真正收集并执行，纳入 Vitest 门禁。

## Validation Evidence
- [x] `pnpm -C apps/desktop exec vitest run --config vitest.config.core.ts main/src/services/ai/__tests__/aiService-runtime-multiturn.test.ts main/src/services/ai/__tests__/ai-public-contract-regression.test.ts main/src/services/skills/__tests__/writing-orchestrator.test.ts main/src/ipc/__tests__/ai-skill-tool-use-ipc.test.ts`
  - Result: 4 files, 52 tests passed（包含上述两份 AI regression tests 与新增 orchestrator warning / IPC warning 用例）
- [x] `pnpm typecheck`
- [x] `pnpm -r --if-present lint`
- [x] `scripts/agent_pr_preflight.sh`
- [x] `gh pr checks 53`
  - Result: `CI: creonow-app/Build` / `CI: creonow-app/Quality Check` / `CI: creonow-app/Test` / `CI/check` 全绿
- Additional validation note: 根 workspace 无 `pnpm lint`；本次未保留误导性的 `pnpm lint` 勾选项。

## Visual Evidence

### Embedded Screenshots
N/A（非前端改动）

### Storybook Artifact / Link
- Link: N/A（非前端改动）
- Visual acceptance note: N/A（非前端改动）

- [x] N/A（非前端改动）

## Test Coverage
- 更新 orchestrator / IPC / AI service 回归测试，覆盖 non-agentic tool_use warning、OpenAI/Anthropic multi-turn 契约、以及两份 AI regression tests 的真实 Vitest 执行路径。

## Risk & Rollback
- Worst case if not fixed: 非 agentic skill 会误入 tool-use 分支，或 AI regression tests 再次静默脱离门禁。
- Rollback ref: e04b09ec6dc8a50eb3189d3cb29f3bf799b1b534^
- Recovery note: `git revert e04b09ec6dc8a50eb3189d3cb29f3bf799b1b534`

## Audit Gate
- `scripts/agent_pr_preflight.sh`: PASS
- Required checks: GREEN
