### PR TITLE
fix: close P2 merged-main audit gaps

### DIFF
--- a/apps/desktop/main/src/__tests__/preload/aiStreamBridge.cost-alert.test.ts
+++ b/apps/desktop/main/src/__tests__/preload/aiStreamBridge.cost-alert.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listeners = new Map<string, (event: unknown, payload: unknown) => void>();
+const dispatchEvent = vi.fn();
+
+vi.mock("electron", () => ({
+  ipcRenderer: {
+    on: vi.fn((channel: string, listener: (event: unknown, payload: unknown) => void) => {
+      listeners.set(channel, listener);
+    }),
+    removeListener: vi.fn((channel: string) => {
+      listeners.delete(channel);
+    }),
+  },
+}));
+
+describe("registerAiStreamBridge cost alert bridge", () => {
+  beforeEach(() => {
+    listeners.clear();
+    dispatchEvent.mockReset();
+    Object.defineProperty(globalThis, "window", {
+      value: { dispatchEvent },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "CustomEvent", {
+      value: class CustomEvent<T> {
+        type: string;
+        detail: T;
+        constructor(type: string, init: { detail: T }) {
+          this.type = type;
+          this.detail = init.detail;
+        }
+      },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "process", {
+      value: { pid: 1002 },
+      configurable: true,
+    });
+  });
+
+  it("将 main 发出的 cost:alert runtime 校验后转发到 renderer-facing CustomEvent", async () => {
+    const { registerAiStreamBridge } = await import("../../../../preload/src/aiStreamBridge");
+    const bridge = registerAiStreamBridge();
+    const registered = bridge.registerAiStreamConsumer();
+    expect(registered.ok).toBe(true);
+
+    const alert = {
+      kind: "warning",
+      currentCost: 1.75,
+      threshold: 2,
+      message: "Budget warning",
+      timestamp: 1_735_000_000_000,
+    };
+
+    listeners.get("cost:alert")?.({}, alert);
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0]?.[0]?.type).toBe("cost:alert");
+    expect(dispatchEvent.mock.calls[0]?.[0]?.detail).toEqual(alert);
+
+    bridge.dispose();
+  });
+});

--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -239,6 +239,37 @@ function parsePositiveInteger(
   return parsed;
 }
 
+function buildDefaultPricingTable() {
+  return {
+    currency: "USD" as const,
+    lastUpdated: "2025-01-01T00:00:00.000Z",
+    prices: {
+      "gpt-5.2": {
+        modelId: "gpt-5.2",
+        displayName: "GPT-5.2",
+        inputPricePer1K: 0.0015,
+        outputPricePer1K: 0.003,
+        effectiveDate: "2025-01-01",
+      },
+      "claude-3-5-sonnet": {
+        modelId: "claude-3-5-sonnet",
+        displayName: "Claude 3.5 Sonnet",
+        inputPricePer1K: 0.003,
+        outputPricePer1K: 0.015,
+        effectiveDate: "2025-01-01",
+      },
+    },
+  };
+}
+
+function buildDefaultBudgetPolicy() {
+  return {
+    warningThreshold: 1,
+    hardStopLimit: 5,
+    enabled: true,
+  };
+}
+
 /**
  * Register all IPC handlers.
  *
@@ -403,6 +434,12 @@ function registerIpcHandlers(deps: {
     env: deps.env,
   });
 
+  const costTracker = createCostTracker({
+    pricingTable: buildDefaultPricingTable(),
+    budgetPolicy: buildDefaultBudgetPolicy(),
+    estimateTokens,
+  });
+
   registerAiIpcHandlers({
     ipcMain: guardedIpcMain,
     db: deps.db,
@@ -412,6 +449,7 @@ function registerIpcHandlers(deps: {
     env: deps.env,
     secretStorage,
     projectSessionBinding,
+    costTracker,
   });
 
   registerAiProxyIpcHandlers({
@@ -537,12 +575,6 @@ function registerIpcHandlers(deps: {
     ipcMain: guardedIpcMain,
     db: deps.db,
     logger: deps.logger,
-  });
-
-  const costTracker = createCostTracker({
-    pricingTable: { prices: {}, currency: "USD", lastUpdated: new Date().toISOString() },
-    budgetPolicy: { warningThreshold: Infinity, hardStopLimit: Infinity, enabled: false },
-    estimateTokens,
   });
 
   registerCostIpcHandlers({

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts
@@ -1,0 +1,248 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Database from "better-sqlite3";
+import type { IpcMain } from "electron";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Logger } from "../../logging/logger";
+import { createCostTracker } from "../../services/ai/costTracker";
+import { estimateTokens } from "../../services/context/tokenEstimation";
+import { createDocumentService } from "../../services/documents/documentService";
+import { registerAiIpcHandlers } from "../ai";
+import { registerCostIpcHandlers } from "../cost";
+import { registerVersionIpcHandlers } from "../version";
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../db/migrations",
+);
+
+type Handler = (event: unknown, payload: unknown) => Promise<unknown>;
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function applyAllMigrations(db: Database.Database): void {
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(".sql") && !file.includes("vec"))
+    .sort();
+  for (const file of files) {
+    db.exec(fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"));
+  }
+}
+
+function createProjectAndDocument(args: {
+  db: Database.Database;
+  title: string;
+  text: string;
+}) {
+  const projectId = "proj-cost";
+  args.db
+    .prepare(
+      "INSERT OR IGNORE INTO projects (project_id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(projectId, "测试项目", "/worktree/test-root", Date.now(), Date.now());
+
+  const service = createDocumentService({ db: args.db, logger: createLogger() });
+  const created = service.create({
+    projectId,
+    title: args.title,
+    type: "chapter",
+  });
+  if (!created.ok) {
+    throw new Error(created.error.message);
+  }
+
+  const saved = service.save({
+    projectId,
+    documentId: created.data.documentId,
+    contentJson: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: args.text }],
+        },
+      ],
+    },
+    actor: "user",
+    reason: "manual-save",
+  });
+  if (!saved.ok) {
+    throw new Error(saved.error.message);
+  }
+
+  return { projectId, documentId: created.data.documentId };
+}
+
+function openAiStopResponse(text: string): Response {
+  const frames = [
+    {
+      choices: [
+        {
+          delta: { content: text },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      choices: [
+        {
+          delta: {},
+          finish_reason: "stop",
+        },
+      ],
+    },
+  ];
+  return new Response(
+    `${frames.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("")}data: [DONE]\n\n`,
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+function createHarness() {
+  const handlers = new Map<string, Handler>();
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applyAllMigrations(db);
+
+  const ipcMain = {
+    handle: (channel: string, listener: Handler) => {
+      handlers.set(channel, listener);
+    },
+  } as unknown as IpcMain;
+
+  const tracker = createCostTracker({
+    pricingTable: {
+      currency: "USD",
+      lastUpdated: "2025-01-01T00:00:00.000Z",
+      prices: {
+        "gpt-5.2": {
+          modelId: "gpt-5.2",
+          displayName: "GPT-5.2",
+          inputPricePer1K: 0.0015,
+          outputPricePer1K: 0.003,
+          effectiveDate: "2025-01-01",
+        },
+      },
+    },
+    budgetPolicy: {
+      warningThreshold: 1,
+      hardStopLimit: 5,
+      enabled: true,
+    },
+    estimateTokens,
+  });
+
+  registerAiIpcHandlers({
+    ipcMain,
+    db,
+    userDataDir: "<test-user-data>",
+    builtinSkillsDir: path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../skills/packages",
+    ),
+    logger: createLogger(),
+    env: {
+      ...process.env,
+      CREONOW_AI_PROVIDER: "openai",
+      CREONOW_AI_MODEL: "gpt-5.2",
+      CREONOW_AI_API_KEY: "sk-test",
+      CREONOW_AI_BASE_URL: "https://api.openai.com",
+    },
+    costTracker: tracker,
+  });
+  registerVersionIpcHandlers({
+    ipcMain,
+    db,
+    logger: createLogger(),
+  });
+  registerCostIpcHandlers({
+    ipcMain,
+    tracker,
+    logger: createLogger(),
+  });
+
+  return {
+    db,
+    async invoke<T>(channel: string, payload: unknown): Promise<T> {
+      const handler = handlers.get(channel);
+      if (!handler) {
+        throw new Error(`Missing handler: ${channel}`);
+      }
+      return (await handler(
+        { sender: { id: 1, send: vi.fn() } },
+        payload,
+      )) as T;
+    },
+  };
+}
+
+describe("ai skill cost tracking integration", () => {
+  const opened: Database.Database[] = [];
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const db of opened.splice(0)) {
+      db.close();
+    }
+  });
+
+  it("真实 ai:skill:run 后 cost:usage:* 可读取到费用数据", async () => {
+    const harness = createHarness();
+    opened.push(harness.db);
+    const current = createProjectAndDocument({
+      db: harness.db,
+      title: "当前章节",
+      text: "夜幕降临，街灯次第亮起。",
+    });
+
+    globalThis.fetch = vi.fn(async () =>
+      openAiStopResponse("他先停步观察，再轻轻推门而入。"),
+    ) as typeof fetch;
+
+    const run = await harness.invoke<{
+      ok: boolean;
+      data?: { status: "preview" | "completed" | "rejected" };
+    }>("ai:skill:run", {
+      skillId: "builtin:continue",
+      hasSelection: false,
+      input: "夜幕降临，街灯次第亮起。",
+      precedingText: "夜幕降临，街灯次第亮起。",
+      mode: "ask",
+      model: "gpt-5.2",
+      context: current,
+      stream: true,
+    });
+
+    expect(run.ok).toBe(true);
+
+    const summary = await harness.invoke<{
+      ok: boolean;
+      data: { totalRequests: number; totalCost: number };
+    }>("cost:usage:summary", undefined);
+    const list = await harness.invoke<{
+      ok: boolean;
+      data: { totalCount: number; records: Array<{ modelId: string }> };
+    }>("cost:usage:list", undefined);
+
+    expect(summary.ok).toBe(true);
+    expect(summary.data.totalRequests).toBe(1);
+    expect(summary.data.totalCost).toBeGreaterThan(0);
+    expect(list.ok).toBe(true);
+    expect(list.data.totalCount).toBe(1);
+    expect(list.data.records[0]).toMatchObject({ modelId: "gpt-5.2" });
+  });
+});

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts
@@ -245,4 +245,84 @@ describe("ai skill cost tracking integration", () => {
     expect(list.data.totalCount).toBe(1);
     expect(list.data.records[0]).toMatchObject({ modelId: "gpt-5.2" });
   });
+
+  it("preview → confirm → 下一次 run 只累计一次 sessionTotalTokens", async () => {
+    const harness = createHarness();
+    opened.push(harness.db);
+    const current = createProjectAndDocument({
+      db: harness.db,
+      title: "当前章节",
+      text: "夜幕降临，街灯次第亮起。",
+    });
+
+    globalThis.fetch = vi.fn(async () =>
+      openAiStopResponse("他先停步观察，再轻轻推门而入。"),
+    ) as typeof fetch;
+
+    const payload = {
+      skillId: "builtin:continue",
+      hasSelection: false,
+      input: "夜幕降临，街灯次第亮起。",
+      precedingText: "夜幕降临，街灯次第亮起。",
+      mode: "ask" as const,
+      model: "gpt-5.2",
+      context: current,
+      stream: true,
+    };
+
+    const firstRun = await harness.invoke<{
+      ok: boolean;
+      data?: {
+        executionId: string;
+        status: "preview" | "completed" | "rejected";
+        usage?: {
+          promptTokens: number;
+          completionTokens: number;
+          sessionTotalTokens: number;
+          estimatedCostUsd?: number;
+        };
+      };
+    }>("ai:skill:run", payload);
+
+    expect(firstRun.ok).toBe(true);
+    expect(firstRun.data?.status).toBe("preview");
+    expect(firstRun.data?.usage).toBeDefined();
+    expect(firstRun.data?.usage?.sessionTotalTokens).toBe(
+      (firstRun.data?.usage?.promptTokens ?? 0)
+        + (firstRun.data?.usage?.completionTokens ?? 0),
+    );
+
+    const confirm = await harness.invoke<{
+      ok: boolean;
+      data?: { status: "completed" | "rejected" };
+    }>("ai:skill:confirm", {
+      executionId: firstRun.data?.executionId,
+      action: "accept",
+      projectId: current.projectId,
+    });
+
+    expect(confirm.ok).toBe(true);
+    expect(confirm.data?.status).toBe("completed");
+
+    const secondRun = await harness.invoke<{
+      ok: boolean;
+      data?: {
+        status: "preview" | "completed" | "rejected";
+        usage?: {
+          promptTokens: number;
+          completionTokens: number;
+          sessionTotalTokens: number;
+          estimatedCostUsd?: number;
+        };
+      };
+    }>("ai:skill:run", payload);
+
+    expect(secondRun.ok).toBe(true);
+    expect(secondRun.data?.status).toBe("preview");
+    expect(secondRun.data?.usage).toMatchObject({
+      promptTokens: firstRun.data?.usage?.promptTokens,
+      completionTokens: firstRun.data?.usage?.completionTokens,
+      sessionTotalTokens: (firstRun.data?.usage?.sessionTotalTokens ?? 0) * 2,
+    });
+  });
 });

--- a/apps/desktop/main/src/ipc/__tests__/cost-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/cost-ipc.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import type { IpcMain } from "electron";
 
 import { registerCostIpcHandlers } from "../cost";
+import { COST_ALERT_CHANNEL } from "@shared/types/cost";
 import type {
+  BudgetAlert,
   BudgetPolicy,
   CostTracker,
   ModelPricingTable,
@@ -11,9 +13,17 @@ import type {
 } from "../../services/ai/costTracker";
 
 type Handler = (event: unknown, payload?: unknown) => Promise<unknown>;
+const browserWindows: Array<{ webContents: { send: ReturnType<typeof vi.fn> } }> = [];
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: () => browserWindows,
+  },
+}));
 
 function createHarness(trackerOverrides: Partial<CostTracker> = {}) {
   const handlers = new Map<string, Handler>();
+  let budgetAlertListener: ((alert: BudgetAlert) => void) | null = null;
 
   const ipcMain = {
     handle: (channel: string, listener: Handler) => {
@@ -47,7 +57,12 @@ function createHarness(trackerOverrides: Partial<CostTracker> = {}) {
     listRecords: vi.fn().mockReturnValue([]),
     checkBudget: vi.fn().mockReturnValue(null),
     estimateCost: vi.fn().mockReturnValue(0),
-    onBudgetAlert: vi.fn().mockReturnValue(() => {}),
+    onBudgetAlert: vi.fn().mockImplementation((callback: (alert: BudgetAlert) => void) => {
+      budgetAlertListener = callback;
+      return () => {
+        budgetAlertListener = null;
+      };
+    }),
     onCostRecorded: vi.fn().mockReturnValue(() => {}),
     updatePricingTable: vi.fn(),
     updateBudgetPolicy: vi.fn(),
@@ -77,10 +92,36 @@ function createHarness(trackerOverrides: Partial<CostTracker> = {}) {
     },
     tracker,
     logger,
+    emitBudgetAlert: (alert: BudgetAlert) => budgetAlertListener?.(alert),
   };
 }
 
 describe("cost IPC handlers", () => {
+  it("budget alert 会推送到 renderer 的 cost:alert channel", async () => {
+    browserWindows.length = 0;
+    const send = vi.fn();
+    browserWindows.push({
+      webContents: { send },
+    });
+    const harness = createHarness();
+
+    harness.emitBudgetAlert({
+      kind: "warning",
+      currentCost: 1.5,
+      threshold: 2,
+      message: "Budget warning",
+      timestamp: 1_735_000_000_000,
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      COST_ALERT_CHANNEL,
+      expect.objectContaining({
+        kind: "warning",
+        currentCost: 1.5,
+      }),
+    );
+  });
+
   describe("cost:usage:list", () => {
     it("正常调用返回 records + totalCount", async () => {
       const mockRecords: RequestCost[] = [

--- a/apps/desktop/main/src/ipc/__tests__/cost-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/cost-ipc.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import type { IpcMain } from "electron";
 
 import { registerCostIpcHandlers } from "../cost";
-import type { CostTracker, SessionCostSummary, RequestCost } from "../../services/ai/costTracker";
+import type {
+  BudgetPolicy,
+  CostTracker,
+  ModelPricingTable,
+  RequestCost,
+  SessionCostSummary,
+} from "../../services/ai/costTracker";
 
 type Handler = (event: unknown, payload?: unknown) => Promise<unknown>;
 
@@ -28,6 +34,16 @@ function createHarness(trackerOverrides: Partial<CostTracker> = {}) {
       sessionStartedAt: 1000,
     } satisfies SessionCostSummary),
     getRequestCost: vi.fn().mockReturnValue(null),
+    getPricingTable: vi.fn().mockReturnValue({
+      currency: "USD",
+      lastUpdated: "2025-01-01T00:00:00.000Z",
+      prices: {},
+    }),
+    getBudgetPolicy: vi.fn().mockReturnValue({
+      warningThreshold: 1,
+      hardStopLimit: 5,
+      enabled: true,
+    }),
     listRecords: vi.fn().mockReturnValue([]),
     checkBudget: vi.fn().mockReturnValue(null),
     estimateCost: vi.fn().mockReturnValue(0),
@@ -177,6 +193,111 @@ describe("cost IPC handlers", () => {
       expect(result.ok).toBe(true);
       expect(result.data.totalCost).toBe(0.01);
       expect(result.data.totalRequests).toBe(1);
+    });
+  });
+
+  describe("cost:budget:*", () => {
+    it("cost:budget:get 返回当前预算策略", async () => {
+      const budget = {
+        warningThreshold: 1,
+        hardStopLimit: 5,
+        enabled: true,
+      } satisfies BudgetPolicy;
+      const harness = createHarness({
+        getBudgetPolicy: vi.fn().mockReturnValue(budget),
+      } as never);
+
+      const result = await harness.invoke<{
+        ok: boolean;
+        data: BudgetPolicy;
+      }>("cost:budget:get");
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toEqual(budget);
+    });
+
+    it("cost:budget:update 校验并更新预算策略", async () => {
+      const harness = createHarness({
+        getBudgetPolicy: vi.fn().mockReturnValue({
+          warningThreshold: 1,
+          hardStopLimit: 5,
+          enabled: true,
+        } satisfies BudgetPolicy),
+      } as never);
+
+      const result = await harness.invoke<{ ok: boolean }>("cost:budget:update", {
+        warningThreshold: 2,
+        hardStopLimit: 6,
+        enabled: true,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(harness.tracker.updateBudgetPolicy).toHaveBeenCalledWith({
+        warningThreshold: 2,
+        hardStopLimit: 6,
+        enabled: true,
+      });
+    });
+  });
+
+  describe("cost:pricing:*", () => {
+    it("cost:pricing:get 返回当前定价表", async () => {
+      const pricing = {
+        currency: "USD",
+        lastUpdated: "2025-01-01T00:00:00.000Z",
+        prices: {
+          "gpt-5.2": {
+            modelId: "gpt-5.2",
+            displayName: "GPT-5.2",
+            inputPricePer1K: 0.0015,
+            outputPricePer1K: 0.003,
+            effectiveDate: "2025-01-01",
+          },
+        },
+      } satisfies ModelPricingTable;
+      const harness = createHarness({
+        getPricingTable: vi.fn().mockReturnValue(pricing),
+      } as never);
+
+      const result = await harness.invoke<{
+        ok: boolean;
+        data: ModelPricingTable;
+      }>("cost:pricing:get");
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toEqual(pricing);
+    });
+
+    it("cost:pricing:update 更新定价表", async () => {
+      const harness = createHarness({
+        getPricingTable: vi.fn().mockReturnValue({
+          currency: "USD",
+          lastUpdated: "2025-01-01T00:00:00.000Z",
+          prices: {},
+        } satisfies ModelPricingTable),
+      } as never);
+
+      const nextPricing = {
+        currency: "USD",
+        lastUpdated: "2025-01-02T00:00:00.000Z",
+        prices: {
+          "claude-3-5-sonnet": {
+            modelId: "claude-3-5-sonnet",
+            displayName: "Claude 3.5 Sonnet",
+            inputPricePer1K: 0.003,
+            outputPricePer1K: 0.015,
+            effectiveDate: "2025-01-02",
+          },
+        },
+      } satisfies ModelPricingTable;
+
+      const result = await harness.invoke<{ ok: boolean }>(
+        "cost:pricing:update",
+        nextPricing,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(harness.tracker.updatePricingTable).toHaveBeenCalledWith(nextPricing);
     });
   });
 });

--- a/apps/desktop/main/src/ipc/__tests__/diff-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/diff-ipc.test.ts
@@ -50,8 +50,21 @@ describe("diff IPC handlers", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(result.data.steps).toHaveLength(1);
-      expect(result.data.stats.totalChanges).toBe(1);
+      expect(result.data.steps).toEqual([
+        {
+          type: "replace",
+          from: 6,
+          to: 8,
+          text: "the",
+        },
+        {
+          type: "replace",
+          from: 9,
+          to: 11,
+          text: "e",
+        },
+      ]);
+      expect(result.data.stats.totalChanges).toBe(2);
     });
 
     it("相同文本返回空步骤", async () => {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -953,6 +953,7 @@ type PendingPreviewSession = {
   generator: AsyncGenerator<WritingEvent>;
   outputText: string;
   usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  usageSummary?: SkillRunUsage;
   completion: Promise<IpcResponse<SkillRunConfirmResponse>>;
 };
 
@@ -1080,7 +1081,35 @@ function resolveUsageContextKey(context?: SkillRunPayload["context"]): string {
   return "global";
 }
 
-function buildSkillRunUsage(
+function buildSkillRunUsage(args: {
+  modelPricingByModel: Map<string, ModelPricing>;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  sessionTotalTokens: number;
+}): SkillRunUsage {
+  const promptTokens = Math.max(0, args.promptTokens);
+  const completionTokens = Math.max(0, args.completionTokens);
+  const pricing = args.modelPricingByModel.get(args.model.trim());
+  const estimatedCostUsd =
+    pricing === undefined
+      ? undefined
+      : Number(
+          (
+            (promptTokens / 1000) * pricing.promptPer1kTokens
+            + (completionTokens / 1000) * pricing.completionPer1kTokens
+          ).toFixed(6),
+        );
+
+  return {
+    promptTokens,
+    completionTokens,
+    sessionTotalTokens: Math.max(0, args.sessionTotalTokens),
+    ...(typeof estimatedCostUsd === "number" ? { estimatedCostUsd } : {}),
+  };
+}
+
+function recordSkillRunUsage(
   ctx: AiIpcContext,
   args: {
     model: string;
@@ -1095,25 +1124,13 @@ function buildSkillRunUsage(
   const nextTotal = (ctx.sessionTokenTotalsByContext.get(key) ?? 0) + delta;
   ctx.sessionTokenTotalsByContext.set(key, nextTotal);
 
-  const pricing = ctx.modelPricingByModel.get(args.model.trim());
-  const estimatedCostUsd =
-    pricing === undefined
-      ? undefined
-      : Number(
-          (
-            (Math.max(0, args.promptTokens) / 1000) *
-              pricing.promptPer1kTokens +
-            (Math.max(0, args.completionTokens) / 1000) *
-              pricing.completionPer1kTokens
-          ).toFixed(6),
-        );
-
-  return {
-    promptTokens: Math.max(0, args.promptTokens),
-    completionTokens: Math.max(0, args.completionTokens),
+  return buildSkillRunUsage({
+    modelPricingByModel: ctx.modelPricingByModel,
+    model: args.model,
+    promptTokens: args.promptTokens,
+    completionTokens: args.completionTokens,
     sessionTotalTokens: nextTotal,
-    ...(typeof estimatedCostUsd === "number" ? { estimatedCostUsd } : {}),
-  };
+  });
 }
 
 /**
@@ -1675,12 +1692,20 @@ async function drainPreviewUntilPause(args: {
         completionTokens: number;
         totalTokens: number;
       }
-    | undefined;
+      | undefined;
   let versionId: string | undefined;
 
   while (true) {
     const next = await args.generator.next();
     if (next.done) {
+      const usageSummary = usage
+        ? recordSkillRunUsage(args.ctx, {
+            model: args.payload.model,
+            context: args.payload.context,
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+          })
+        : undefined;
       emitOrchestratorDone({
         ctx: args.ctx,
         sender: args.sender,
@@ -1690,14 +1715,7 @@ async function drainPreviewUntilPause(args: {
         terminal: "completed",
         outputText,
         model: args.payload.model,
-        usage: usage
-          ? buildSkillRunUsage(args.ctx, {
-              model: args.payload.model,
-              context: args.payload.context,
-              promptTokens: usage.promptTokens,
-              completionTokens: usage.completionTokens,
-            })
-          : undefined,
+        usage: usageSummary,
       });
       return {
         ok: true,
@@ -1708,16 +1726,7 @@ async function drainPreviewUntilPause(args: {
           ...(versionId ? { versionId } : {}),
           outputText,
           candidates: buildPreviewCandidates({ runId: args.runId, outputText }),
-          ...(usage
-            ? {
-                usage: buildSkillRunUsage(args.ctx, {
-                  model: args.payload.model,
-                  context: args.payload.context,
-                  promptTokens: usage.promptTokens,
-                  completionTokens: usage.completionTokens,
-                }),
-              }
-            : {}),
+          ...(usageSummary ? { usage: usageSummary } : {}),
           ...(args.payload.promptDiagnostics
             ? { promptDiagnostics: args.payload.promptDiagnostics }
             : {}),
@@ -1751,6 +1760,14 @@ async function drainPreviewUntilPause(args: {
     }
 
     if (event.type === "permission-requested") {
+      const usageSummary = usage
+        ? recordSkillRunUsage(args.ctx, {
+            model: args.payload.model,
+            context: args.payload.context,
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+          })
+        : undefined;
       const session = {
         executionId: args.executionId,
         runId: args.runId,
@@ -1760,6 +1777,7 @@ async function drainPreviewUntilPause(args: {
         generator: args.generator,
         outputText,
         usage,
+        usageSummary,
       } as PendingPreviewSession;
       session.completion = Promise.resolve()
         .then(() =>
@@ -1786,16 +1804,7 @@ async function drainPreviewUntilPause(args: {
           previewId: args.executionId,
           outputText,
           candidates: buildPreviewCandidates({ runId: args.runId, outputText }),
-          ...(usage
-            ? {
-                usage: buildSkillRunUsage(args.ctx, {
-                  model: args.payload.model,
-                  context: args.payload.context,
-                  promptTokens: usage.promptTokens,
-                  completionTokens: usage.completionTokens,
-                }),
-              }
-            : {}),
+          ...(usageSummary ? { usage: usageSummary } : {}),
           ...(args.payload.promptDiagnostics
             ? { promptDiagnostics: args.payload.promptDiagnostics }
             : {}),
@@ -1871,6 +1880,16 @@ async function continuePreviewSession(args: {
   while (true) {
     const next = await args.session.generator.next();
     if (next.done) {
+      const usageSummary =
+        args.session.usageSummary
+        ?? (args.session.usage
+          ? recordSkillRunUsage(args.ctx, {
+              model: args.session.payload.model,
+              context: args.session.payload.context,
+              promptTokens: args.session.usage.promptTokens,
+              completionTokens: args.session.usage.completionTokens,
+            })
+          : undefined);
       emitOrchestratorDone({
         ctx: args.ctx,
         sender: args.session.sender,
@@ -1880,14 +1899,7 @@ async function continuePreviewSession(args: {
         terminal: "completed",
         outputText: args.session.outputText,
         model: args.session.payload.model,
-        usage: args.session.usage
-          ? buildSkillRunUsage(args.ctx, {
-              model: args.session.payload.model,
-              context: args.session.payload.context,
-              promptTokens: args.session.usage.promptTokens,
-              completionTokens: args.session.usage.completionTokens,
-            })
-          : undefined,
+        usage: usageSummary,
       });
       args.ctx.previewSessions.delete(args.session.executionId);
       return {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -48,6 +48,7 @@ import { createToolUseHandler } from "../services/skills/toolUseHandler";
 import { estimateTokens } from "../services/context/tokenEstimation";
 import { createDocumentService } from "../services/documents/documentService";
 import { editorSchema } from "../services/editor/prosemirrorSchema";
+import type { CostTracker } from "../services/ai/costTracker";
 
 /**
  * Convert a ProseMirror document position to a plain-text character offset.
@@ -914,6 +915,7 @@ type AiIpcDeps = {
   env: NodeJS.ProcessEnv;
   secretStorage?: SecretStorageAdapter;
   projectSessionBinding?: ProjectSessionBindingRegistry;
+  costTracker?: CostTracker;
 };
 
 type AiIpcContext = {
@@ -1382,6 +1384,12 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
     permissionGate,
     postWritingHooks: [
       {
+        name: "cost-tracking",
+        async execute() {
+          deps.costTracker?.checkBudget();
+        },
+      },
+      {
         name: "auto-save-version",
         async execute() {
           return;
@@ -1389,6 +1397,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       },
     ],
     defaultTimeoutMs: 30_000,
+    costTracker: deps.costTracker,
     prepareRequest: async (request) => {
       const prepared = await prepareWritingRequest({
         ctx: {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1165,6 +1165,13 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
   const sessionTokenTotalsByContext = new Map<string, number>();
   const modelPricingByModel = parseModelPricingMap(deps.env);
   const degradationCounter = new DegradationCounter();
+  const kgServiceForContext =
+    deps.db !== null
+      ? createKnowledgeGraphService({
+          db: deps.db,
+          logger: deps.logger,
+        })
+      : undefined;
   const memoryServiceForContext =
     deps.db !== null
       ? createMemoryService({
@@ -1189,10 +1196,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       ? {
           logger: deps.logger,
           degradationCounter,
-          kgService: createKnowledgeGraphService({
-            db: deps.db,
-            logger: deps.logger,
-          }),
+          ...(kgServiceForContext ? { kgService: kgServiceForContext } : {}),
           ...(memoryServiceForContext
             ? { memoryService: memoryServiceForContext }
             : {}),
@@ -1373,6 +1377,8 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         : createAgenticToolRegistry({
             db: deps.db,
             logger: deps.logger,
+            ...(kgServiceForContext ? { kgService: kgServiceForContext } : {}),
+            ...(memoryServiceForContext ? { memoryService: memoryServiceForContext } : {}),
           }),
       {
         maxToolRounds: AGENTIC_MAX_ROUNDS,

--- a/apps/desktop/main/src/ipc/contract/ipc-contract.ts
+++ b/apps/desktop/main/src/ipc/contract/ipc-contract.ts
@@ -212,12 +212,31 @@ const CONTEXT_LAYER_SUMMARY_SCHEMA = s.object({
   warnings: s.optional(s.array(s.string())),
 });
 
+const CONTEXT_COMPRESSED_HISTORY_SUMMARY_SCHEMA = s.object({
+  source: s.array(s.string()),
+  tokenCount: s.number(),
+  truncated: s.boolean(),
+  warnings: s.optional(s.array(s.string())),
+  compressed: s.boolean(),
+  compressionRatio: s.optional(s.number()),
+});
+
 const CONTEXT_LAYER_DETAIL_SCHEMA = s.object({
   content: s.string(),
   source: s.array(s.string()),
   tokenCount: s.number(),
   truncated: s.boolean(),
   warnings: s.optional(s.array(s.string())),
+});
+
+const CONTEXT_COMPRESSED_HISTORY_DETAIL_SCHEMA = s.object({
+  content: s.string(),
+  source: s.array(s.string()),
+  tokenCount: s.number(),
+  truncated: s.boolean(),
+  warnings: s.optional(s.array(s.string())),
+  compressed: s.boolean(),
+  compressionRatio: s.optional(s.number()),
 });
 
 const CONTEXT_ASSEMBLE_RESPONSE_SCHEMA = s.object({
@@ -227,8 +246,10 @@ const CONTEXT_ASSEMBLE_RESPONSE_SCHEMA = s.object({
   stablePrefixUnchanged: s.boolean(),
   warnings: s.array(s.string()),
   capacityPercent: s.number(),
+  compressionApplied: s.optional(s.boolean()),
   layers: s.object({
     rules: CONTEXT_LAYER_SUMMARY_SCHEMA,
+    compressedHistory: CONTEXT_COMPRESSED_HISTORY_SUMMARY_SCHEMA,
     immediate: CONTEXT_LAYER_SUMMARY_SCHEMA,
   }),
 });
@@ -236,6 +257,7 @@ const CONTEXT_ASSEMBLE_RESPONSE_SCHEMA = s.object({
 const CONTEXT_INSPECT_RESPONSE_SCHEMA = s.object({
   layersDetail: s.object({
     rules: CONTEXT_LAYER_DETAIL_SCHEMA,
+    compressedHistory: CONTEXT_COMPRESSED_HISTORY_DETAIL_SCHEMA,
     immediate: CONTEXT_LAYER_DETAIL_SCHEMA,
   }),
   totals: s.object({
@@ -247,6 +269,27 @@ const CONTEXT_INSPECT_RESPONSE_SCHEMA = s.object({
     requestedBy: s.string(),
     requestedAt: s.number(),
   }),
+});
+
+const COST_BUDGET_POLICY_SCHEMA = s.object({
+  warningThreshold: s.number(),
+  hardStopLimit: s.number(),
+  enabled: s.boolean(),
+});
+
+const COST_MODEL_PRICING_SCHEMA = s.object({
+  modelId: s.string(),
+  displayName: s.string(),
+  inputPricePer1K: s.number(),
+  outputPricePer1K: s.number(),
+  cachedInputPricePer1K: s.optional(s.number()),
+  effectiveDate: s.string(),
+});
+
+const COST_MODEL_PRICING_TABLE_SCHEMA = s.object({
+  currency: s.literal("USD"),
+  lastUpdated: s.string(),
+  prices: s.record(COST_MODEL_PRICING_SCHEMA),
 });
 
 const CONTEXT_BUDGET_LAYER_SCHEMA = s.object({
@@ -2438,6 +2481,22 @@ export const ipcContract = {
         ),
         sessionStartedAt: s.number(),
       }),
+    },
+    "cost:budget:get": {
+      request: s.object({}),
+      response: COST_BUDGET_POLICY_SCHEMA,
+    },
+    "cost:budget:update": {
+      request: COST_BUDGET_POLICY_SCHEMA,
+      response: COST_BUDGET_POLICY_SCHEMA,
+    },
+    "cost:pricing:get": {
+      request: s.object({}),
+      response: COST_MODEL_PRICING_TABLE_SCHEMA,
+    },
+    "cost:pricing:update": {
+      request: COST_MODEL_PRICING_TABLE_SCHEMA,
+      response: COST_MODEL_PRICING_TABLE_SCHEMA,
     },
   },
 } as const;

--- a/apps/desktop/main/src/ipc/cost.ts
+++ b/apps/desktop/main/src/ipc/cost.ts
@@ -1,18 +1,14 @@
-/**
- * Cost IPC handlers — 费用查询
- */
-
-import type { IpcMain } from "electron";
+import { BrowserWindow, type IpcMain } from "electron";
 
 import type { IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
 import type {
+  BudgetPolicy,
   CostTracker,
+  ModelPricingTable,
   RequestCost,
 } from "../services/ai/costTracker";
 import { ipcError } from "../services/shared/ipcResult";
-
-// ─── Request / Response types ───────────────────────────────────────
 
 interface CostUsageListRequest {
   skillId?: string;
@@ -41,22 +37,100 @@ interface CostUsageSummaryResponse {
   sessionStartedAt: number;
 }
 
-// ─── Registration ───────────────────────────────────────────────────
+function validateBudgetPolicy(payload: unknown): BudgetPolicy | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const policy = payload as Record<string, unknown>;
+  if (
+    typeof policy.warningThreshold !== "number" ||
+    !Number.isFinite(policy.warningThreshold) ||
+    typeof policy.hardStopLimit !== "number" ||
+    !Number.isFinite(policy.hardStopLimit) ||
+    typeof policy.enabled !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    warningThreshold: policy.warningThreshold,
+    hardStopLimit: policy.hardStopLimit,
+    enabled: policy.enabled,
+  };
+}
+
+function validatePricingTable(payload: unknown): ModelPricingTable | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const table = payload as Record<string, unknown>;
+  if (table.currency !== "USD" || typeof table.lastUpdated !== "string") {
+    return null;
+  }
+  const prices = table.prices;
+  if (!prices || typeof prices !== "object" || Array.isArray(prices)) {
+    return null;
+  }
+
+  const normalizedPrices: ModelPricingTable["prices"] = {};
+  for (const [modelId, rawPricing] of Object.entries(prices)) {
+    if (!rawPricing || typeof rawPricing !== "object" || Array.isArray(rawPricing)) {
+      return null;
+    }
+    const pricing = rawPricing as Record<string, unknown>;
+    if (
+      typeof pricing.displayName !== "string" ||
+      typeof pricing.inputPricePer1K !== "number" ||
+      !Number.isFinite(pricing.inputPricePer1K) ||
+      typeof pricing.outputPricePer1K !== "number" ||
+      !Number.isFinite(pricing.outputPricePer1K) ||
+      typeof pricing.effectiveDate !== "string"
+    ) {
+      return null;
+    }
+    normalizedPrices[modelId] = {
+      modelId,
+      displayName: pricing.displayName,
+      inputPricePer1K: pricing.inputPricePer1K,
+      outputPricePer1K: pricing.outputPricePer1K,
+      ...(typeof pricing.cachedInputPricePer1K === "number"
+        ? { cachedInputPricePer1K: pricing.cachedInputPricePer1K }
+        : {}),
+      effectiveDate: pricing.effectiveDate,
+    };
+  }
+
+  return {
+    currency: "USD",
+    lastUpdated: table.lastUpdated,
+    prices: normalizedPrices,
+  };
+}
 
 export function registerCostIpcHandlers(deps: {
   ipcMain: IpcMain;
   tracker: CostTracker;
   logger: Logger;
 }): void {
+  deps.tracker.onBudgetAlert((alert) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      try {
+        win.webContents.send("cost:alert", alert);
+      } catch (error) {
+        deps.logger.error("cost:alert send failed", {
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  });
+
   deps.ipcMain.handle(
     "cost:usage:list",
     async (
-      _e,
+      _event,
       payload: CostUsageListRequest | undefined,
     ): Promise<IpcResponse<CostUsageListResponse>> => {
       try {
-        const filter: { skillId?: string; since?: number; limit?: number } = {};
-
+        const filter: CostUsageListRequest = {};
         if (payload?.skillId !== undefined) {
           if (typeof payload.skillId !== "string") {
             return ipcError("INVALID_ARGUMENT", "skillId must be a string");
@@ -70,19 +144,20 @@ export function registerCostIpcHandlers(deps: {
           filter.since = payload.since;
         }
         if (payload?.limit !== undefined) {
-          if (typeof payload.limit !== "number" || !Number.isInteger(payload.limit) || payload.limit < 1) {
+          if (
+            typeof payload.limit !== "number" ||
+            !Number.isInteger(payload.limit) ||
+            payload.limit < 1
+          ) {
             return ipcError("INVALID_ARGUMENT", "limit must be a positive integer");
           }
           filter.limit = payload.limit;
         }
 
         const records = deps.tracker.listRecords(filter);
-        return {
-          ok: true,
-          data: { records, totalCount: records.length },
-        };
-      } catch (err) {
-        deps.logger.error("cost:usage:list failed", { reason: String(err) });
+        return { ok: true, data: { records, totalCount: records.length } };
+      } catch (error) {
+        deps.logger.error("cost:usage:list failed", { reason: String(error) });
         return ipcError("INTERNAL", "Failed to list cost records");
       }
     },
@@ -91,73 +166,98 @@ export function registerCostIpcHandlers(deps: {
   deps.ipcMain.handle(
     "cost:usage:summary",
     async (
-      _e,
+      _event,
       payload: CostUsageSummaryRequest | undefined,
     ): Promise<IpcResponse<CostUsageSummaryResponse>> => {
       try {
-        const fullSummary = deps.tracker.getSessionCost();
-
-        if (payload?.skillId !== undefined) {
-          if (typeof payload.skillId !== "string") {
-            return ipcError("INVALID_ARGUMENT", "skillId must be a string");
-          }
+        const summary = deps.tracker.getSessionCost();
+        if (payload?.skillId !== undefined && typeof payload.skillId !== "string") {
+          return ipcError("INVALID_ARGUMENT", "skillId must be a string");
         }
-        if (payload?.since !== undefined) {
-          if (typeof payload.since !== "number" || !Number.isFinite(payload.since)) {
-            return ipcError("INVALID_ARGUMENT", "since must be a finite number");
-          }
+        if (
+          payload?.since !== undefined &&
+          (typeof payload.since !== "number" || !Number.isFinite(payload.since))
+        ) {
+          return ipcError("INVALID_ARGUMENT", "since must be a finite number");
         }
 
-        // Apply optional filters: if skillId or since is provided, recompute
-        // from matching records rather than returning the full session aggregate.
         if (payload?.skillId !== undefined || payload?.since !== undefined) {
-          const matchingRecords = deps.tracker.listRecords({
+          const records = deps.tracker.listRecords({
             skillId: payload?.skillId,
             since: payload?.since,
           });
+          const aggregate: CostUsageSummaryResponse = {
+            totalCost: 0,
+            totalRequests: records.length,
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCachedTokens: 0,
+            costByModel: {},
+            costBySkill: {},
+            sessionStartedAt: summary.sessionStartedAt,
+          };
 
-          let totalCost = 0;
-          let totalInputTokens = 0;
-          let totalOutputTokens = 0;
-          let totalCachedTokens = 0;
-          const costByModel: Record<string, { cost: number; requests: number }> = {};
-          const costBySkill: Record<string, { cost: number; requests: number }> = {};
-
-          for (const r of matchingRecords) {
-            totalCost += r.cost;
-            totalInputTokens += r.inputTokens;
-            totalOutputTokens += r.outputTokens;
-            totalCachedTokens += r.cachedTokens;
-
-            if (!costByModel[r.modelId]) costByModel[r.modelId] = { cost: 0, requests: 0 };
-            costByModel[r.modelId].cost += r.cost;
-            costByModel[r.modelId].requests += 1;
-
-            if (!costBySkill[r.skillId]) costBySkill[r.skillId] = { cost: 0, requests: 0 };
-            costBySkill[r.skillId].cost += r.cost;
-            costBySkill[r.skillId].requests += 1;
+          for (const record of records) {
+            aggregate.totalCost += record.cost;
+            aggregate.totalInputTokens += record.inputTokens;
+            aggregate.totalOutputTokens += record.outputTokens;
+            aggregate.totalCachedTokens += record.cachedTokens;
+            aggregate.costByModel[record.modelId] ??= { cost: 0, requests: 0 };
+            aggregate.costByModel[record.modelId].cost += record.cost;
+            aggregate.costByModel[record.modelId].requests += 1;
+            aggregate.costBySkill[record.skillId] ??= { cost: 0, requests: 0 };
+            aggregate.costBySkill[record.skillId].cost += record.cost;
+            aggregate.costBySkill[record.skillId].requests += 1;
           }
 
-          return {
-            ok: true,
-            data: {
-              totalCost,
-              totalRequests: matchingRecords.length,
-              totalInputTokens,
-              totalOutputTokens,
-              totalCachedTokens,
-              costByModel,
-              costBySkill,
-              sessionStartedAt: fullSummary.sessionStartedAt,
-            },
-          };
+          return { ok: true, data: aggregate };
         }
 
-        return { ok: true, data: fullSummary };
-      } catch (err) {
-        deps.logger.error("cost:usage:summary failed", { reason: String(err) });
+        return { ok: true, data: summary };
+      } catch (error) {
+        deps.logger.error("cost:usage:summary failed", { reason: String(error) });
         return ipcError("INTERNAL", "Failed to get cost summary");
       }
+    },
+  );
+
+  deps.ipcMain.handle(
+    "cost:budget:get",
+    async (): Promise<IpcResponse<BudgetPolicy>> => ({
+      ok: true,
+      data: deps.tracker.getBudgetPolicy(),
+    }),
+  );
+
+  deps.ipcMain.handle(
+    "cost:budget:update",
+    async (_event, payload: unknown): Promise<IpcResponse<BudgetPolicy>> => {
+      const policy = validateBudgetPolicy(payload);
+      if (!policy) {
+        return ipcError("INVALID_ARGUMENT", "Invalid budget policy");
+      }
+      deps.tracker.updateBudgetPolicy(policy);
+      return { ok: true, data: deps.tracker.getBudgetPolicy() };
+    },
+  );
+
+  deps.ipcMain.handle(
+    "cost:pricing:get",
+    async (): Promise<IpcResponse<ModelPricingTable>> => ({
+      ok: true,
+      data: deps.tracker.getPricingTable(),
+    }),
+  );
+
+  deps.ipcMain.handle(
+    "cost:pricing:update",
+    async (_event, payload: unknown): Promise<IpcResponse<ModelPricingTable>> => {
+      const table = validatePricingTable(payload);
+      if (!table) {
+        return ipcError("INVALID_ARGUMENT", "Invalid pricing table");
+      }
+      deps.tracker.updatePricingTable(table);
+      return { ok: true, data: deps.tracker.getPricingTable() };
     },
   );
 }

--- a/apps/desktop/main/src/ipc/cost.ts
+++ b/apps/desktop/main/src/ipc/cost.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, type IpcMain } from "electron";
 
 import type { IpcResponse } from "@shared/types/ipc-generated";
+import { COST_ALERT_CHANNEL } from "@shared/types/cost";
 import type { Logger } from "../logging/logger";
 import type {
   BudgetPolicy,
@@ -114,7 +115,7 @@ export function registerCostIpcHandlers(deps: {
   deps.tracker.onBudgetAlert((alert) => {
     for (const win of BrowserWindow.getAllWindows()) {
       try {
-        win.webContents.send("cost:alert", alert);
+        win.webContents.send(COST_ALERT_CHANNEL, alert);
       } catch (error) {
         deps.logger.error("cost:alert send failed", {
           reason: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/main/src/services/ai/costTracker.ts
+++ b/apps/desktop/main/src/services/ai/costTracker.ts
@@ -76,6 +76,8 @@ export interface CostTracker {
 
   getSessionCost(): SessionCostSummary;
   getRequestCost(requestId: string): RequestCost | null;
+  getPricingTable(): ModelPricingTable;
+  getBudgetPolicy(): BudgetPolicy;
   listRecords(filter?: {
     skillId?: string;
     since?: number;
@@ -302,6 +304,23 @@ export function createCostTracker(config: CostTrackerConfig): CostTracker {
 
     getRequestCost(requestId: string): RequestCost | null {
       return records.get(requestId) ?? null;
+    },
+
+    getPricingTable(): ModelPricingTable {
+      return {
+        currency: pricingTable.currency,
+        lastUpdated: pricingTable.lastUpdated,
+        prices: Object.fromEntries(
+          Object.entries(pricingTable.prices).map(([modelId, pricing]) => [
+            modelId,
+            { ...pricing },
+          ]),
+        ),
+      };
+    },
+
+    getBudgetPolicy(): BudgetPolicy {
+      return { ...budgetPolicy };
     },
 
     listRecords(filter?: {

--- a/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
+++ b/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
@@ -114,7 +114,7 @@ describe("createContextLayerAssemblyService contract regression", () => {
     expect(cyclePath, cyclePath?.join(" -> ")).toBeNull();
   });
 
-  it("keeps the public P1 contract phase-cut to rules + immediate even when later layers are populated", async () => {
+  it("P2 组装结果暴露 compressed-history 与 compressionApplied", async () => {
     const service = createContextLayerAssemblyService({
       rules: async () => ({
         chunks: [{ source: "rules:test", content: "Rule content" }],
@@ -141,18 +141,55 @@ describe("createContextLayerAssemblyService contract regression", () => {
     const second = await service.assemble(request);
 
     expect(first.prompt.includes("## Rules")).toBe(true);
-    expect(first.prompt.includes("## Settings")).toBe(false);
-    expect(first.prompt.includes("## Retrieved")).toBe(false);
+    expect(first.prompt.includes("## Compressed History")).toBe(true);
     expect(first.prompt.includes("## Immediate")).toBe(true);
     expect(first.layers.rules.source[0]).toBe("rules:test");
-    expect("settings" in first.layers).toBe(false);
-    expect("retrieved" in first.layers).toBe(false);
+    expect(first.layers.compressedHistory.source).toContain("compressed-history");
+    expect(first.layers.compressedHistory.compressed).toBe(false);
     expect(first.layers.immediate.source[0]).toBe("immediate:test");
+    expect(first.compressionApplied).toBe(false);
     expect(first.stablePrefixHash.length > 0).toBe(true);
     expect(first.stablePrefixUnchanged).toBe(false);
     expect(second.stablePrefixUnchanged).toBe(true);
     expect(first.tokenCount > 0).toBe(true);
     expect(first.capacityPercent).toBeCloseTo((first.tokenCount / 6000) * 100);
     expect(Array.isArray(first.warnings)).toBe(true);
+  });
+
+  it("超长上下文会在真实 assemble 路径生成 compressed-history", async () => {
+    const service = createContextLayerAssemblyService({
+      rules: async () => ({
+        chunks: [{ source: "rules:test", content: "Rule content" }],
+      }),
+      immediate: async () => ({
+        chunks: [
+          {
+            source: "editor:cursor-window",
+            content: Array.from({ length: 8 }, (_, index) =>
+              `第${index + 1}段：${"林远先观察门缝里的光，再听见门后的脚步声。".repeat(8)}`,
+            ).join("\n"),
+          },
+        ],
+      }),
+    });
+
+    const result = await service.assemble({
+      projectId: "proj-long",
+      documentId: "doc-long",
+      cursorPosition: 4096,
+      skillId: "continue-writing",
+      additionalInput: "林远先观察门缝里的光，再听见门后的脚步声。".repeat(8),
+      conversationMessages: Array.from({ length: 18 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `第${index + 1}轮：${"林远先观察门缝里的光，再听见门后的脚步声。".repeat(6)}`,
+      })),
+    });
+
+    expect(result.compressionApplied).toBe(true);
+    expect(result.layers.compressedHistory.compressed).toBe(true);
+    expect(result.layers.compressedHistory.tokenCount).toBeGreaterThan(0);
+    expect(result.layers.compressedHistory.compressionRatio).toBeLessThan(1);
+    expect(result.prompt).toContain("## Compressed History");
+    expect(result.layers.compressedHistory.source).toContain("compressed-history");
   });
 });

--- a/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
+++ b/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
@@ -178,12 +178,12 @@ describe("createContextLayerAssemblyService contract regression", () => {
       documentId: "doc-long",
       cursorPosition: 4096,
       skillId: "continue-writing",
-      additionalInput: "林远先观察门缝里的光，再听见门后的脚步声。".repeat(8),
-      conversationMessages: Array.from({ length: 18 }, (_, index) => ({
-        role: index % 2 === 0 ? "user" : "assistant",
-        content: `第${index + 1}轮：${"林远先观察门缝里的光，再听见门后的脚步声。".repeat(6)}`,
-      })),
-    });
+        additionalInput: "林远先观察门缝里的光，再听见门后的脚步声。".repeat(8),
+        conversationMessages: Array.from({ length: 18 }, (_, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `第${index + 1}轮：${"林远先观察门缝里的光，再听见门后的脚步声。".repeat(28)}`,
+        })),
+      });
 
     expect(result.compressionApplied).toBe(true);
     expect(result.layers.compressedHistory.compressed).toBe(true);
@@ -191,6 +191,57 @@ describe("createContextLayerAssemblyService contract regression", () => {
     expect(result.layers.compressedHistory.compressionRatio).toBeLessThan(1);
     expect(result.prompt).toContain("## Compressed History");
     expect(result.layers.compressedHistory.source).toContain("compressed-history");
+  });
+
+  it("低 token 多轮对话在 shouldCompress=false 时仍以原文注入 compressed-history", async () => {
+    const service = createContextLayerAssemblyService({
+      rules: async () => ({
+        chunks: [{ source: "rules:test", content: "Rule content" }],
+      }),
+      immediate: async () => ({
+        chunks: [
+          {
+            source: "editor:cursor-window",
+            content: "EDITOR_SURFACE_LOW_TOKEN",
+          },
+        ],
+      }),
+    });
+
+    const conversationMessages = [
+      { role: "user" as const, content: "LOW_TOKEN_USER_1：先别推门。" },
+      { role: "assistant" as const, content: "LOW_TOKEN_ASSISTANT_1：我先记住门轴声。" },
+      { role: "user" as const, content: "LOW_TOKEN_USER_2：再看地上的灰。" },
+      { role: "assistant" as const, content: "LOW_TOKEN_ASSISTANT_2：灰里只有一串脚印。" },
+      { role: "user" as const, content: "LOW_TOKEN_USER_3：窗缝也记下来。" },
+      { role: "assistant" as const, content: "LOW_TOKEN_ASSISTANT_3：窗缝透着冷风。" },
+      { role: "user" as const, content: "LOW_TOKEN_USER_4：最后只写手背发凉。" },
+    ];
+    const rawHistory = conversationMessages.map((message) => message.content).join("\n");
+    const request = {
+      projectId: "proj-low-token-many-rounds",
+      documentId: "doc-low-token-many-rounds",
+      cursorPosition: 96,
+      skillId: "continue-writing",
+      conversationMessages,
+    };
+
+    const assembled = await service.assemble(request);
+    const inspected = await service.inspect(request);
+
+    expect(assembled.compressionApplied).toBe(false);
+    expect(assembled.layers.compressedHistory.compressed).toBe(false);
+    expect(assembled.prompt).toContain("## Compressed History");
+    expect(assembled.prompt).toContain(rawHistory);
+    expect(assembled.prompt).not.toContain("[最近保留的");
+    expect(assembled.prompt).toContain("EDITOR_SURFACE_LOW_TOKEN");
+
+    expect(inspected.layersDetail.compressedHistory.compressed).toBe(false);
+    expect(inspected.layersDetail.compressedHistory.content).toBe(rawHistory);
+    expect(inspected.layersDetail.compressedHistory.content).not.toContain(
+      "[最近保留的",
+    );
+    expect(inspected.layersDetail.immediate.content).toBe("EDITOR_SURFACE_LOW_TOKEN");
   });
 
   it("长对话压缩时仍保留最近 keepRecentRounds 轮原始对话", async () => {
@@ -211,7 +262,7 @@ describe("createContextLayerAssemblyService contract regression", () => {
     const conversationMessages = [
       ...Array.from({ length: 8 }, (_, index) => ({
         role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
-        content: `早期历史第${index + 1}条：${"林远在旧楼里反复核对脚步声。".repeat(10)}`,
+        content: `早期历史第${index + 1}条：${"林远在旧楼里反复核对脚步声。".repeat(80)}`,
       })),
       { role: "user" as const, content: "UNIQUE_RECENT_USER_ROUND_1：别动门把，先记住走廊尽头的滴水声。" },
       { role: "assistant" as const, content: "UNIQUE_RECENT_ASSISTANT_ROUND_1：我会保留滴水声与走廊方位。" },

--- a/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
+++ b/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
@@ -192,4 +192,44 @@ describe("createContextLayerAssemblyService contract regression", () => {
     expect(result.prompt).toContain("## Compressed History");
     expect(result.layers.compressedHistory.source).toContain("compressed-history");
   });
+
+  it("短对话在不压缩时仍以原文注入 compressed-history", async () => {
+    const service = createContextLayerAssemblyService({
+      rules: async () => ({
+        chunks: [{ source: "rules:test", content: "Rule content" }],
+      }),
+      immediate: async () => ({
+        chunks: [{ source: "immediate:test", content: "Immediate content" }],
+      }),
+    });
+
+    const conversationMessages = [
+      { role: "user" as const, content: "第一问：门缝后的风声是不是有人在呼吸？" },
+      { role: "assistant" as const, content: "第一答：像呼吸，但更像旧楼管道里回转的气。 " },
+      { role: "user" as const, content: "第二问：那我先别推门，继续听三秒。" },
+    ];
+    const rawHistory = conversationMessages.map((message) => message.content).join("\n");
+    const request = {
+      projectId: "proj-short",
+      documentId: "doc-short",
+      cursorPosition: 64,
+      skillId: "continue-writing",
+      conversationMessages,
+    };
+
+    const assembled = await service.assemble(request);
+    const inspected = await service.inspect(request);
+
+    expect(assembled.compressionApplied).toBe(false);
+    expect(assembled.layers.compressedHistory.compressed).toBe(false);
+    expect(assembled.prompt).toContain("## Compressed History");
+    expect(assembled.prompt).not.toContain("## Compressed History\n(none)");
+    expect(assembled.prompt).toContain(rawHistory);
+
+    expect(inspected.layersDetail.compressedHistory.compressed).toBe(false);
+    expect(inspected.layersDetail.compressedHistory.content).toBe(rawHistory);
+    expect(inspected.layersDetail.compressedHistory.content).not.toBe("");
+    expect(inspected.layersDetail.compressedHistory.truncated).toBe(false);
+    expect(inspected.layersDetail.compressedHistory.tokenCount).toBeGreaterThan(0);
+  });
 });

--- a/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
+++ b/apps/desktop/main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts
@@ -193,6 +193,74 @@ describe("createContextLayerAssemblyService contract regression", () => {
     expect(result.layers.compressedHistory.source).toContain("compressed-history");
   });
 
+  it("长对话压缩时仍保留最近 keepRecentRounds 轮原始对话", async () => {
+    const service = createContextLayerAssemblyService({
+      rules: async () => ({
+        chunks: [{ source: "rules:test", content: "Rule content" }],
+      }),
+      immediate: async () => ({
+        chunks: [
+          {
+            source: "editor:cursor-window",
+            content: "EDITOR_IMMEDIATE_UNCHANGED",
+          },
+        ],
+      }),
+    });
+
+    const conversationMessages = [
+      ...Array.from({ length: 8 }, (_, index) => ({
+        role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+        content: `早期历史第${index + 1}条：${"林远在旧楼里反复核对脚步声。".repeat(10)}`,
+      })),
+      { role: "user" as const, content: "UNIQUE_RECENT_USER_ROUND_1：别动门把，先记住走廊尽头的滴水声。" },
+      { role: "assistant" as const, content: "UNIQUE_RECENT_ASSISTANT_ROUND_1：我会保留滴水声与走廊方位。" },
+      { role: "user" as const, content: "UNIQUE_RECENT_USER_ROUND_2：把那枚铜钥匙藏进左侧口袋，不要写成右侧。" },
+      { role: "assistant" as const, content: "UNIQUE_RECENT_ASSISTANT_ROUND_2：铜钥匙在左侧口袋，这一细节不会丢。" },
+      { role: "user" as const, content: "UNIQUE_RECENT_USER_ROUND_3：最后一轮暂时没有助手回复，也必须原样保留。" },
+    ];
+
+    const request = {
+      projectId: "proj-recent-rounds",
+      documentId: "doc-recent-rounds",
+      cursorPosition: 2048,
+      skillId: "continue-writing",
+      additionalInput: "林远在门后听见了第二个人的呼吸。".repeat(6),
+      conversationMessages,
+    };
+
+    const assembled = await service.assemble(request);
+    const inspected = await service.inspect(request);
+
+    expect(assembled.compressionApplied).toBe(true);
+    expect(assembled.layers.compressedHistory.compressed).toBe(true);
+    expect(assembled.prompt).toContain("## Compressed History");
+    expect(assembled.prompt).toContain("UNIQUE_RECENT_USER_ROUND_1");
+    expect(assembled.prompt).toContain("UNIQUE_RECENT_ASSISTANT_ROUND_1");
+    expect(assembled.prompt).toContain("UNIQUE_RECENT_USER_ROUND_2");
+    expect(assembled.prompt).toContain("UNIQUE_RECENT_ASSISTANT_ROUND_2");
+    expect(assembled.prompt).toContain("UNIQUE_RECENT_USER_ROUND_3");
+    expect(assembled.prompt).toContain("EDITOR_IMMEDIATE_UNCHANGED");
+    expect(assembled.layers.immediate.source).toContain("editor:cursor-window");
+
+    expect(inspected.layersDetail.compressedHistory.compressed).toBe(true);
+    expect(inspected.layersDetail.compressedHistory.content).toContain(
+      "UNIQUE_RECENT_USER_ROUND_1",
+    );
+    expect(inspected.layersDetail.compressedHistory.content).toContain(
+      "UNIQUE_RECENT_ASSISTANT_ROUND_2",
+    );
+    expect(inspected.layersDetail.compressedHistory.content).toContain(
+      "UNIQUE_RECENT_USER_ROUND_3",
+    );
+    expect(inspected.layersDetail.immediate.content).toContain(
+      "EDITOR_IMMEDIATE_UNCHANGED",
+    );
+    expect(inspected.layersDetail.immediate.content).not.toContain(
+      "UNIQUE_RECENT_USER_ROUND_1",
+    );
+  });
+
   it("短对话在不压缩时仍以原文注入 compressed-history", async () => {
     const service = createContextLayerAssemblyService({
       rules: async () => ({

--- a/apps/desktop/main/src/services/context/compressionEngine.ts
+++ b/apps/desktop/main/src/services/context/compressionEngine.ts
@@ -68,6 +68,8 @@ interface CompressionError extends Error {
   code: string;
 }
 
+const HISTORY_COMPACTION_KEEP_RECENT_ROUNDS = 3;
+
 function makeError(code: string, message: string): CompressionError {
   const err = new Error(message) as CompressionError;
   err.code = code;
@@ -114,16 +116,48 @@ function microCompress(messages: CompressedMessage[]): CompressedMessage[] {
 
 // ─── History compaction: merge older user/assistant pairs ────────────
 
+function splitMessagesByRecentRounds(
+  messages: CompressedMessage[],
+  keepRecentRounds: number,
+): {
+  toCompact: CompressedMessage[];
+  toKeep: CompressedMessage[];
+} {
+  if (messages.length === 0 || keepRecentRounds <= 0) {
+    return { toCompact: [...messages], toKeep: [] };
+  }
+
+  const rounds: CompressedMessage[][] = [];
+
+  for (const message of messages) {
+    const lastRound = rounds.at(-1);
+    if (message.role === "user" || lastRound === undefined) {
+      rounds.push([message]);
+      continue;
+    }
+
+    lastRound.push(message);
+  }
+
+  return {
+    toCompact: rounds
+      .slice(0, Math.max(0, rounds.length - keepRecentRounds))
+      .flat(),
+    toKeep: rounds.slice(-keepRecentRounds).flat(),
+  };
+}
+
 function historyCompact(messages: CompressedMessage[]): CompressedMessage[] {
   if (messages.length <= 3) return messages;
 
   const systemMsgs = messages.filter((m) => m.role === "system");
   const nonSystemMsgs = messages.filter((m) => m.role !== "system");
 
-  if (nonSystemMsgs.length <= 2) return messages;
-
-  const toCompact = nonSystemMsgs.slice(0, -2);
-  const toKeep = nonSystemMsgs.slice(-2);
+  const { toCompact, toKeep } = splitMessagesByRecentRounds(
+    nonSystemMsgs,
+    HISTORY_COMPACTION_KEEP_RECENT_ROUNDS,
+  );
+  if (toCompact.length === 0) return messages;
 
   const compactedContent = toCompact
     .map((m) => `[${m.role}] ${m.content}`)

--- a/apps/desktop/main/src/services/context/layerAssemblyService.ts
+++ b/apps/desktop/main/src/services/context/layerAssemblyService.ts
@@ -11,11 +11,13 @@ import {
   estimateUtf8TokenCount as estimateTokenCount,
   trimUtf8ToTokenBudget as trimTextToTokenBudget,
 } from "@shared/tokenBudget";
+import { createCompressionEngine } from "./compressionEngine";
 import type {
   ContextAssembleRequest,
   ContextBudgetLayerConfig,
   ContextBudgetProfile,
   ContextBudgetUpdateResult,
+  ContextCompressedHistoryDetail,
   ContextConstraintTrimLog,
   ContextLayerAssemblyService,
   ContextLayerChunk,
@@ -100,7 +102,11 @@ export const CONTEXT_CAPACITY_LIMITS = {
 const DEFAULT_TOTAL_BUDGET_TOKENS = 6000;
 const DEFAULT_TOKENIZER_ID = "cn-byte-estimator";
 const DEFAULT_TOKENIZER_VERSION = "1.0.0";
-const PUBLIC_CONTEXT_PROMPT_LAYERS = ["rules", "immediate"] as const;
+const PUBLIC_CONTEXT_PROMPT_LAYERS = [
+  "rules",
+  "compressedHistory",
+  "immediate",
+] as const;
 const NON_DETERMINISTIC_PREFIX_FIELDS = new Set([
   "timestamp",
   "requestId",
@@ -501,10 +507,13 @@ function keyForStablePrefix(args: {
  * inspection and downstream assertions.
  */
 function toLayerPrompt(args: {
-  layer: ContextLayerId;
+  layer: ContextLayerId | "compressedHistory";
   content: string;
 }): string {
-  const title = args.layer[0].toUpperCase() + args.layer.slice(1);
+  const title =
+    args.layer === "compressedHistory"
+      ? "Compressed History"
+      : args.layer[0].toUpperCase() + args.layer.slice(1);
   return `## ${title}\n${args.content.length > 0 ? args.content : "(none)"}`;
 }
 
@@ -740,9 +749,14 @@ function totalLayerTokens(
 
 function totalPublicLayerTokens(layers: {
   rules: ContextLayerDetail;
+  compressedHistory: ContextCompressedHistoryDetail;
   immediate: ContextLayerDetail;
 }): number {
-  return layers.rules.tokenCount + layers.immediate.tokenCount;
+  return (
+    layers.rules.tokenCount +
+    layers.compressedHistory.tokenCount +
+    layers.immediate.tokenCount
+  );
 }
 
 function calculateCapacityPercent(totalTokens: number, maxBudget: number): number {
@@ -871,21 +885,203 @@ function toPublicLayerDetail(
 
 function buildPublicAssembleLayers(layers: {
   rules: ContextLayerDetail;
+  compressedHistory: ContextCompressedHistoryDetail;
   immediate: ContextLayerDetail;
 }) {
   return {
     rules: layerSummary(layers.rules),
+    compressedHistory: {
+      ...layerSummary(layers.compressedHistory),
+      compressed: layers.compressedHistory.compressed,
+      ...(layers.compressedHistory.compressionRatio !== undefined
+        ? { compressionRatio: layers.compressedHistory.compressionRatio }
+        : {}),
+    },
     immediate: layerSummary(layers.immediate),
   };
 }
 
 function buildPublicInspectLayers(layers: {
   rules: ContextLayerDetail;
+  compressedHistory: ContextCompressedHistoryDetail;
   immediate: ContextLayerDetail;
 }) {
   return {
     rules: layers.rules,
+    compressedHistory: layers.compressedHistory,
     immediate: layers.immediate,
+  };
+}
+
+function splitHistorySegments(text: string): string[] {
+  return text
+    .split(/\n+/u)
+    .flatMap((block) =>
+      block
+        .split(/(?<=[。！？!?])/u)
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0),
+    )
+    .filter((segment) => segment.length > 0);
+}
+
+function createDeterministicCompressionEngine() {
+  return createCompressionEngine(
+    {
+      complete: async (params) => {
+        const body = params.messages
+          .map((message) => String(message.content ?? ""))
+          .join("\n")
+          .replace(/\s+/gu, " ")
+          .trim();
+        const summary =
+          body.length <= 240
+            ? body
+            : `${body.slice(0, 120)} … ${body.slice(-100)}`;
+        return { content: summary };
+      },
+    },
+    {
+      circuitBreaker: {
+        failureThreshold: 3,
+        cooldownMs: 1_000,
+      },
+      timeoutMs: 1_000,
+      minTokenThreshold: 500,
+    },
+  );
+}
+
+async function buildCompressedHistoryDetail(args: {
+  request: ContextAssembleRequest;
+  rules: ContextLayerDetail;
+  immediate: ContextLayerDetail;
+  maxBudget: number;
+  compressionEngine: ReturnType<typeof createDeterministicCompressionEngine>;
+}): Promise<{
+  compressedHistory: ContextCompressedHistoryDetail;
+  immediate: ContextLayerDetail;
+  compressionApplied: boolean;
+}> {
+  const emptyCompressedHistory: ContextCompressedHistoryDetail = {
+    content: "",
+    source: ["compressed-history"],
+    tokenCount: 0,
+    truncated: false,
+    compressed: false,
+  };
+
+  const conversationMessages =
+    args.request.conversationMessages?.filter(
+      (message) => message.content.trim().length > 0,
+    ) ?? [];
+
+  const fallbackSegments = splitHistorySegments(args.immediate.content);
+  const sourceMessages =
+    conversationMessages.length > 0
+      ? conversationMessages
+      : fallbackSegments.map((content, index) => ({
+          role: (index % 2 === 0 ? "user" : "assistant") as
+            | "user"
+            | "assistant",
+          content,
+        }));
+  const currentTotal =
+    args.rules.tokenCount +
+    Math.max(
+      args.immediate.tokenCount,
+      estimateTokenCount(sourceMessages.map((message) => message.content).join("\n")),
+    );
+  const shouldCompress =
+    args.compressionEngine.shouldCompress(currentTotal, args.maxBudget) ||
+    conversationMessages.length > 6;
+
+  if (conversationMessages.length === 0 && !shouldCompress) {
+    return {
+      compressedHistory: emptyCompressedHistory,
+      immediate: args.immediate,
+      compressionApplied: false,
+    };
+  }
+
+  if (sourceMessages.length === 0) {
+    return {
+      compressedHistory: emptyCompressedHistory,
+      immediate: args.immediate,
+      compressionApplied: false,
+    };
+  }
+
+  const recentMessages =
+    conversationMessages.length > 0
+      ? sourceMessages.slice(-2)
+      : sourceMessages.slice(-Math.min(2, sourceMessages.length));
+  const historyMessages =
+    sourceMessages.length > recentMessages.length
+      ? sourceMessages.slice(0, sourceMessages.length - recentMessages.length)
+      : sourceMessages;
+
+  if (
+    historyMessages.length === 0 ||
+    !shouldCompress
+  ) {
+    return {
+      compressedHistory: emptyCompressedHistory,
+      immediate: args.immediate,
+      compressionApplied: false,
+    };
+  }
+
+  const compressionResult = await args.compressionEngine.compress({
+    messages: historyMessages.map((message) => ({
+      role: message.role,
+      content: message.content,
+    })),
+    targetTokens: Math.max(80, Math.floor(currentTotal * 0.3)),
+    narrativeContext: {
+      characterNames: [],
+      plotPoints: [],
+      toneMarkers: [],
+      foreshadowingClues: [],
+      timelineMarkers: [],
+      narrativePOV: undefined,
+    },
+    projectId: args.request.projectId,
+    documentId: args.request.documentId,
+  });
+
+  const compressedContent = compressionResult.compressedMessages
+    .map((message) => message.content.trim())
+    .filter((content) => content.length > 0)
+    .join("\n");
+
+  const recentContent =
+    conversationMessages.length > 0
+      ? args.immediate.content
+      : recentMessages
+          .map((message) => message.content.trim())
+          .filter((content) => content.length > 0)
+          .join("\n");
+
+  return {
+    compressedHistory: {
+      content: compressedContent,
+      source: ["compressed-history"],
+      tokenCount: estimateTokenCount(compressedContent),
+      truncated: compressionResult.compressedTokens < compressionResult.originalTokens,
+      compressed: true,
+      compressionRatio: compressionResult.compressionRatio,
+      ...(compressionResult.warnings.length > 0
+        ? { warnings: compressionResult.warnings }
+        : {}),
+    },
+    immediate: {
+      ...args.immediate,
+      content: recentContent,
+      tokenCount: estimateTokenCount(recentContent),
+      truncated: recentContent !== args.immediate.content || args.immediate.truncated,
+    },
+    compressionApplied: true,
   };
 }
 
@@ -912,6 +1108,8 @@ async function buildContextSnapshot(args: {
   onConstraintTrim?: (log: ContextConstraintTrimLog) => void;
 }): Promise<{
   layersDetail: Record<ContextLayerId, ContextLayerDetail>;
+  compressedHistory: ContextCompressedHistoryDetail;
+  compressionApplied: boolean;
   warnings: string[];
   prompt: string;
   tokenCount: number;
@@ -954,11 +1152,22 @@ async function buildContextSnapshot(args: {
     onConstraintTrim: args.onConstraintTrim,
   });
 
+  const compressionEngine = createDeterministicCompressionEngine();
+  const compressed = await buildCompressedHistoryDetail({
+    request: args.request,
+    rules: toPublicLayerDetail(budgetApplied.layers.rules),
+    immediate: toPublicLayerDetail(budgetApplied.layers.immediate),
+    maxBudget: args.budgetProfile.totalBudgetTokens,
+    compressionEngine,
+  });
+  compressionEngine.dispose();
+
   const warnings = uniqueNonEmpty([
     ...(budgetApplied.layers.rules.warnings ?? []),
     ...(budgetApplied.layers.settings.warnings ?? []),
     ...(budgetApplied.layers.retrieved.warnings ?? []),
     ...(budgetApplied.layers.immediate.warnings ?? []),
+    ...(compressed.compressedHistory.warnings ?? []),
     ...budgetApplied.warnings,
   ]);
 
@@ -966,24 +1175,32 @@ async function buildContextSnapshot(args: {
     rules: toPublicLayerDetail(budgetApplied.layers.rules),
     settings: toPublicLayerDetail(budgetApplied.layers.settings),
     retrieved: toPublicLayerDetail(budgetApplied.layers.retrieved),
-    immediate: toPublicLayerDetail(budgetApplied.layers.immediate),
+    immediate: compressed.immediate,
   };
   const prompt = PUBLIC_CONTEXT_PROMPT_LAYERS
     .map((layerId) =>
       toLayerPrompt({
         layer: layerId,
-        content: layersDetail[layerId].content,
+        content:
+          layerId === "compressedHistory"
+            ? compressed.compressedHistory.content
+            : (layerId === "immediate"
+                ? compressed.immediate.content
+                : layersDetail[layerId].content),
       }),
     )
     .join("\n\n");
 
   return {
     layersDetail,
+    compressedHistory: compressed.compressedHistory,
+    compressionApplied: compressed.compressionApplied,
     warnings,
     prompt,
     tokenCount: totalPublicLayerTokens({
       rules: layersDetail.rules,
-      immediate: layersDetail.immediate,
+      compressedHistory: compressed.compressedHistory,
+      immediate: compressed.immediate,
     }),
     stablePrefixHash: hashStablePrefix(budgetApplied.layers.rules.content),
   };
@@ -1107,12 +1324,14 @@ export function createContextLayerAssemblyService(
         stablePrefixHash: snapshot.stablePrefixHash,
         stablePrefixUnchanged,
         warnings: snapshot.warnings,
+        compressionApplied: snapshot.compressionApplied,
         capacityPercent: calculateCapacityPercent(
           snapshot.tokenCount,
           budgetProfile.totalBudgetTokens,
         ),
         layers: buildPublicAssembleLayers({
           rules: snapshot.layersDetail.rules,
+          compressedHistory: snapshot.compressedHistory,
           immediate: snapshot.layersDetail.immediate,
         }),
       };
@@ -1128,6 +1347,7 @@ export function createContextLayerAssemblyService(
       return {
         layersDetail: buildPublicInspectLayers({
           rules: snapshot.layersDetail.rules,
+          compressedHistory: snapshot.compressedHistory,
           immediate: snapshot.layersDetail.immediate,
         }),
         totals: {

--- a/apps/desktop/main/src/services/context/layerAssemblyService.ts
+++ b/apps/desktop/main/src/services/context/layerAssemblyService.ts
@@ -102,6 +102,7 @@ export const CONTEXT_CAPACITY_LIMITS = {
 const DEFAULT_TOTAL_BUDGET_TOKENS = 6000;
 const DEFAULT_TOKENIZER_ID = "cn-byte-estimator";
 const DEFAULT_TOKENIZER_VERSION = "1.0.0";
+const DEFAULT_HISTORY_COMPACTION_KEEP_RECENT_ROUNDS = 3;
 const PUBLIC_CONTEXT_PROMPT_LAYERS = [
   "rules",
   "compressedHistory",
@@ -118,6 +119,8 @@ type InternalContextLayerDetail = ContextLayerDetail & {
   constraintItems?: ContextRuleConstraint[];
   rulesBaseContent?: string;
 };
+type ConversationSurfaceMessage =
+  NonNullable<ContextAssembleRequest["conversationMessages"]>[number];
 
 export type ContextAssemblyErrorCode = "CONTEXT_SCOPE_VIOLATION";
 
@@ -926,12 +929,75 @@ function splitHistorySegments(text: string): string[] {
 }
 
 function formatConversationHistoryContent(
-  messages: ReadonlyArray<{ content: string }>,
+  messages: ReadonlyArray<Pick<ConversationSurfaceMessage, "content">>,
 ): string {
   return messages
     .map((message) => message.content)
     .filter((content) => content.trim().length > 0)
     .join("\n");
+}
+
+function splitConversationByRecentRounds(
+  messages: ReadonlyArray<ConversationSurfaceMessage>,
+  keepRecentRounds: number,
+): {
+  historyMessages: ConversationSurfaceMessage[];
+  recentMessages: ConversationSurfaceMessage[];
+  recentRoundsKept: number;
+} {
+  if (messages.length === 0) {
+    return { historyMessages: [], recentMessages: [], recentRoundsKept: 0 };
+  }
+
+  if (keepRecentRounds <= 0) {
+    return {
+      historyMessages: [...messages],
+      recentMessages: [],
+      recentRoundsKept: 0,
+    };
+  }
+
+  const rounds: ConversationSurfaceMessage[][] = [];
+
+  for (const message of messages) {
+    const lastRound = rounds.at(-1);
+    if (message.role === "user" || lastRound === undefined) {
+      rounds.push([message]);
+      continue;
+    }
+
+    lastRound.push(message);
+  }
+
+  const recentRounds = rounds.slice(-keepRecentRounds);
+  const historyRounds = rounds.slice(0, Math.max(0, rounds.length - keepRecentRounds));
+
+  return {
+    historyMessages: historyRounds.flat(),
+    recentMessages: recentRounds.flat(),
+    recentRoundsKept: recentRounds.length,
+  };
+}
+
+function formatCompressedHistorySurface(args: {
+  compressedContent: string;
+  recentMessages: ReadonlyArray<ConversationSurfaceMessage>;
+  recentRoundsKept: number;
+}): string {
+  const sections: string[] = [];
+  const compressedContent = args.compressedContent.trim();
+  if (compressedContent.length > 0) {
+    sections.push(compressedContent);
+  }
+
+  const recentContent = formatConversationHistoryContent(args.recentMessages);
+  if (recentContent.length > 0) {
+    sections.push(
+      `[最近保留的 ${args.recentRoundsKept} 轮完整对话]\n${recentContent}`,
+    );
+  }
+
+  return sections.join("\n\n");
 }
 
 function createDeterministicCompressionEngine() {
@@ -1021,14 +1087,11 @@ async function buildCompressedHistoryDetail(args: {
     };
   }
 
-  const recentMessages =
-    conversationMessages.length > 0
-      ? sourceMessages.slice(-2)
-      : sourceMessages.slice(-Math.min(2, sourceMessages.length));
-  const historyMessages =
-    sourceMessages.length > recentMessages.length
-      ? sourceMessages.slice(0, sourceMessages.length - recentMessages.length)
-      : sourceMessages;
+  const { historyMessages, recentMessages, recentRoundsKept } =
+    splitConversationByRecentRounds(
+      sourceMessages,
+      DEFAULT_HISTORY_COMPACTION_KEEP_RECENT_ROUNDS,
+    );
 
   if (
     historyMessages.length === 0 ||
@@ -1069,19 +1132,21 @@ async function buildCompressedHistoryDetail(args: {
     .filter((content) => content.length > 0)
     .join("\n");
 
-  const recentContent =
+  const recentContent = formatConversationHistoryContent(recentMessages);
+  const compressedHistoryContent =
     conversationMessages.length > 0
-      ? args.immediate.content
-      : recentMessages
-          .map((message) => message.content.trim())
-          .filter((content) => content.length > 0)
-          .join("\n");
+      ? formatCompressedHistorySurface({
+          compressedContent,
+          recentMessages,
+          recentRoundsKept,
+        })
+      : compressedContent;
 
   return {
     compressedHistory: {
-      content: compressedContent,
+      content: compressedHistoryContent,
       source: ["compressed-history"],
-      tokenCount: estimateTokenCount(compressedContent),
+      tokenCount: estimateTokenCount(compressedHistoryContent),
       truncated: compressionResult.compressedTokens < compressionResult.originalTokens,
       compressed: true,
       compressionRatio: compressionResult.compressionRatio,
@@ -1089,12 +1154,15 @@ async function buildCompressedHistoryDetail(args: {
         ? { warnings: compressionResult.warnings }
         : {}),
     },
-    immediate: {
-      ...args.immediate,
-      content: recentContent,
-      tokenCount: estimateTokenCount(recentContent),
-      truncated: recentContent !== args.immediate.content || args.immediate.truncated,
-    },
+    immediate:
+      conversationMessages.length > 0
+        ? args.immediate
+        : {
+            ...args.immediate,
+            content: recentContent,
+            tokenCount: estimateTokenCount(recentContent),
+            truncated: recentContent !== args.immediate.content || args.immediate.truncated,
+          },
     compressionApplied: true,
   };
 }

--- a/apps/desktop/main/src/services/context/layerAssemblyService.ts
+++ b/apps/desktop/main/src/services/context/layerAssemblyService.ts
@@ -1067,9 +1067,10 @@ async function buildCompressedHistoryDetail(args: {
       args.immediate.tokenCount,
       estimateTokenCount(sourceMessages.map((message) => message.content).join("\n")),
     );
-  const shouldCompress =
-    args.compressionEngine.shouldCompress(currentTotal, args.maxBudget) ||
-    conversationMessages.length > 6;
+  const shouldCompress = args.compressionEngine.shouldCompress(
+    currentTotal,
+    args.maxBudget,
+  );
 
   if (conversationMessages.length === 0 && !shouldCompress) {
     return {

--- a/apps/desktop/main/src/services/context/layerAssemblyService.ts
+++ b/apps/desktop/main/src/services/context/layerAssemblyService.ts
@@ -925,6 +925,15 @@ function splitHistorySegments(text: string): string[] {
     .filter((segment) => segment.length > 0);
 }
 
+function formatConversationHistoryContent(
+  messages: ReadonlyArray<{ content: string }>,
+): string {
+  return messages
+    .map((message) => message.content)
+    .filter((content) => content.trim().length > 0)
+    .join("\n");
+}
+
 function createDeterministicCompressionEngine() {
   return createCompressionEngine(
     {
@@ -1025,8 +1034,13 @@ async function buildCompressedHistoryDetail(args: {
     historyMessages.length === 0 ||
     !shouldCompress
   ) {
+    const rawHistoryContent = formatConversationHistoryContent(sourceMessages);
     return {
-      compressedHistory: emptyCompressedHistory,
+      compressedHistory: {
+        ...emptyCompressedHistory,
+        content: rawHistoryContent,
+        tokenCount: estimateTokenCount(rawHistoryContent),
+      },
       immediate: args.immediate,
       compressionApplied: false,
     };

--- a/apps/desktop/main/src/services/context/types.ts
+++ b/apps/desktop/main/src/services/context/types.ts
@@ -20,6 +20,10 @@ export type ContextAssembleRequest = {
   provider?: string;
   model?: string;
   tokenizerVersion?: string;
+  conversationMessages?: Array<{
+    role: "system" | "user" | "assistant" | "tool";
+    content: string;
+  }>;
 };
 
 export type ContextInspectRequest = ContextAssembleRequest & {
@@ -80,8 +84,19 @@ export type ContextLayerDetail = ContextLayerSummary & {
   content: string;
 };
 
+export type ContextCompressedHistorySummary = ContextLayerSummary & {
+  compressed: boolean;
+  compressionRatio?: number;
+};
+
+export type ContextCompressedHistoryDetail = ContextLayerDetail & {
+  compressed: boolean;
+  compressionRatio?: number;
+};
+
 export type ContextAssembleLayers = {
   rules: ContextLayerSummary;
+  compressedHistory: ContextCompressedHistorySummary;
   immediate: ContextLayerSummary;
 };
 
@@ -93,10 +108,12 @@ export type ContextAssembleResult = {
   warnings: string[];
   capacityPercent: number;
   layers: ContextAssembleLayers;
+  compressionApplied?: boolean;
 };
 
 export type ContextInspectLayerDetails = {
   rules: ContextLayerDetail;
+  compressedHistory: ContextCompressedHistoryDetail;
   immediate: ContextLayerDetail;
 };
 

--- a/apps/desktop/main/src/services/diff/DiffEngine.ts
+++ b/apps/desktop/main/src/services/diff/DiffEngine.ts
@@ -1,16 +1,3 @@
-/**
- * DiffEngine — pure text-to-text diff producing ProseMirror TransactionSpec
- *
- * Algorithm: find longest common prefix & suffix, then treat the
- * differing middle as a single change (insert / delete / replace).
- *
- * Limitation: this prefix/suffix approach produces at most one diff step.
- * For multiple non-contiguous edits (e.g. "foo bar baz" → "FOO bar BAZ"),
- * the entire span from the first change to the last is treated as a single
- * replace. A more granular algorithm (e.g. Myers diff) would be needed to
- * split these into separate steps.
- */
-
 import type {
   DiffError,
   DiffStats,
@@ -19,18 +6,255 @@ import type {
 } from "./types";
 import { DIFF_MAX_CHARS } from "./types";
 
-// ─── Error helper ───────────────────────────────────────────────────
+type DiffOp =
+  | { type: "equal"; value: string }
+  | { type: "delete"; value: string }
+  | { type: "insert"; value: string };
+
+type InternalStep = DiffStep & {
+  afterFrom: number;
+  afterTo: number;
+};
 
 export function makeDiffError(
   code: DiffError["code"],
   message: string,
 ): DiffError {
   const err = new Error(message) as DiffError;
-  (err as { code: DiffError["code"] }).code = code;
+  Object.defineProperty(err, "code", {
+    value: code,
+    enumerable: true,
+    configurable: true,
+  });
   return err;
 }
 
-// ─── Core ───────────────────────────────────────────────────────────
+function toUnits(text: string): string[] {
+  return Array.from(text);
+}
+
+function buildOps(before: readonly string[], after: readonly string[]): DiffOp[] {
+  const n = before.length;
+  const m = after.length;
+  const max = n + m;
+  let frontier = new Map<number, number>();
+  frontier.set(1, 0);
+  const trace: Map<number, number>[] = [];
+
+  for (let d = 0; d <= max; d += 1) {
+    trace.push(new Map(frontier));
+    const nextFrontier = new Map<number, number>();
+
+    for (let k = -d; k <= d; k += 2) {
+      const down = frontier.get(k + 1);
+      const right = frontier.get(k - 1);
+      const moveDown =
+        k === -d || (k !== d && (right ?? Number.NEGATIVE_INFINITY) < (down ?? Number.NEGATIVE_INFINITY));
+      let x = moveDown ? (down ?? 0) : (right ?? 0) + 1;
+      let y = x - k;
+
+      while (x < n && y < m && before[x] === after[y]) {
+        x += 1;
+        y += 1;
+      }
+
+      nextFrontier.set(k, x);
+      if (x >= n && y >= m) {
+        trace.push(new Map(nextFrontier));
+        return backtrack(trace, before, after);
+      }
+    }
+
+    frontier = nextFrontier;
+  }
+
+  return [];
+}
+
+function backtrack(
+  trace: readonly Map<number, number>[],
+  before: readonly string[],
+  after: readonly string[],
+): DiffOp[] {
+  const operations: DiffOp[] = [];
+  let x = before.length;
+  let y = after.length;
+
+  for (let d = trace.length - 1; d > 0; d -= 1) {
+    const frontier = trace[d - 1];
+    const k = x - y;
+    const down = frontier.get(k + 1);
+    const right = frontier.get(k - 1);
+    const moveDown =
+      k === -(d - 1) ||
+      (k !== d - 1 &&
+        (right ?? Number.NEGATIVE_INFINITY) < (down ?? Number.NEGATIVE_INFINITY));
+    const prevK = moveDown ? k + 1 : k - 1;
+    const prevX = frontier.get(prevK) ?? 0;
+    const prevY = prevX - prevK;
+
+    while (x > prevX && y > prevY) {
+      operations.push({ type: "equal", value: before[x - 1] ?? "" });
+      x -= 1;
+      y -= 1;
+    }
+
+    if (d === 1) {
+      continue;
+    }
+
+    if (x === prevX) {
+      operations.push({ type: "insert", value: after[y - 1] ?? "" });
+      y -= 1;
+    } else {
+      operations.push({ type: "delete", value: before[x - 1] ?? "" });
+      x -= 1;
+    }
+  }
+
+  while (x > 0 && y > 0) {
+    operations.push({ type: "equal", value: before[x - 1] ?? "" });
+    x -= 1;
+    y -= 1;
+  }
+  while (x > 0) {
+    operations.push({ type: "delete", value: before[x - 1] ?? "" });
+    x -= 1;
+  }
+  while (y > 0) {
+    operations.push({ type: "insert", value: after[y - 1] ?? "" });
+    y -= 1;
+  }
+
+  return operations.reverse();
+}
+
+function buildSteps(ops: readonly DiffOp[], after: string): DiffStep[] {
+  const steps: InternalStep[] = [];
+  let beforeOffset = 0;
+  let afterOffset = 0;
+  let index = 0;
+
+  while (index < ops.length) {
+    const op = ops[index];
+    if (op.type === "equal") {
+      beforeOffset += op.value.length;
+      afterOffset += op.value.length;
+      index += 1;
+      continue;
+    }
+
+    const start = beforeOffset;
+    const afterStart = afterOffset;
+    let insertedText = "";
+    let deletedChars = 0;
+
+    while (index < ops.length && ops[index]?.type !== "equal") {
+      const current = ops[index];
+      if (current.type === "insert") {
+        insertedText += current.value;
+      } else if (current.type === "delete") {
+        deletedChars += current.value.length;
+        beforeOffset += current.value.length;
+      }
+      index += 1;
+    }
+
+    const end = start + deletedChars;
+    const afterEnd = afterStart + insertedText.length;
+    afterOffset = afterEnd;
+    if (deletedChars === 0) {
+      steps.push({
+        type: "insert",
+        from: start,
+        to: start,
+        text: insertedText,
+        afterFrom: afterStart,
+        afterTo: afterEnd,
+      });
+      continue;
+    }
+    if (insertedText.length === 0) {
+      steps.push({
+        type: "delete",
+        from: start,
+        to: end,
+        afterFrom: afterStart,
+        afterTo: afterEnd,
+      });
+      continue;
+    }
+    steps.push({
+      type: "replace",
+      from: start,
+      to: end,
+      text: insertedText,
+      afterFrom: afterStart,
+      afterTo: afterEnd,
+    });
+  }
+
+  return mergeNearbySteps(steps, after).map(
+    ({ afterFrom: _afterFrom, afterTo: _afterTo, ...step }) => step,
+  );
+}
+
+function mergeNearbySteps(
+  steps: readonly InternalStep[],
+  after: string,
+): InternalStep[] {
+  if (steps.length <= 1) {
+    return [...steps];
+  }
+
+  const merged: InternalStep[] = [];
+  let current = { ...steps[0] };
+
+  for (let index = 1; index < steps.length; index += 1) {
+    const next = steps[index];
+    const gap = next.from - current.to;
+    if (gap > 1) {
+      merged.push(current);
+      current = { ...next };
+      continue;
+    }
+
+    const from = current.from;
+    const to = next.to;
+    const afterFrom = current.afterFrom;
+    const afterTo = next.afterTo;
+    const insertedText = after.slice(afterFrom, afterTo);
+    current =
+      to === from
+        ? {
+            type: "insert",
+            from,
+            to,
+            text: insertedText,
+            afterFrom,
+            afterTo,
+          }
+        : insertedText.length === 0
+          ? {
+              type: "delete",
+              from,
+              to,
+              afterFrom,
+              afterTo,
+            }
+          : {
+              type: "replace",
+              from,
+              to,
+              text: insertedText,
+              afterFrom,
+              afterTo,
+            };
+  }
+
+  merged.push(current);
+  return merged;
+}
 
 export function computeTransaction(
   before: string,
@@ -43,60 +267,13 @@ export function computeTransaction(
     );
   }
 
-  const steps: DiffStep[] = [];
-
   if (before === after) {
-    return buildResult(steps, before, after);
+    return buildResult([], before, after);
   }
 
-  // Find common prefix length
-  const minLen = Math.min(before.length, after.length);
-  let prefixLen = 0;
-  while (prefixLen < minLen && before[prefixLen] === after[prefixLen]) {
-    prefixLen++;
-  }
-
-  // Find common suffix length (not overlapping with prefix)
-  let suffixLen = 0;
-  while (
-    suffixLen < minLen - prefixLen &&
-    before[before.length - 1 - suffixLen] === after[after.length - 1 - suffixLen]
-  ) {
-    suffixLen++;
-  }
-
-  const beforeMiddle = before.slice(prefixLen, before.length - suffixLen);
-  const afterMiddle = after.slice(prefixLen, after.length - suffixLen);
-
-  if (beforeMiddle.length === 0 && afterMiddle.length > 0) {
-    // Pure insertion
-    steps.push({
-      type: "insert",
-      from: prefixLen,
-      to: prefixLen,
-      text: afterMiddle,
-    });
-  } else if (beforeMiddle.length > 0 && afterMiddle.length === 0) {
-    // Pure deletion
-    steps.push({
-      type: "delete",
-      from: prefixLen,
-      to: prefixLen + beforeMiddle.length,
-    });
-  } else if (beforeMiddle.length > 0 && afterMiddle.length > 0) {
-    // Replacement
-    steps.push({
-      type: "replace",
-      from: prefixLen,
-      to: prefixLen + beforeMiddle.length,
-      text: afterMiddle,
-    });
-  }
-
+  const steps = buildSteps(buildOps(toUnits(before), toUnits(after)), after);
   return buildResult(steps, before, after);
 }
-
-// ─── Internals ──────────────────────────────────────────────────────
 
 function buildResult(
   steps: ReadonlyArray<DiffStep>,
@@ -116,15 +293,15 @@ function computeStats(steps: ReadonlyArray<DiffStep>): DiffStats {
   for (const step of steps) {
     switch (step.type) {
       case "insert":
-        insertions++;
+        insertions += 1;
         insertedChars += step.text?.length ?? 0;
         break;
       case "delete":
-        deletions++;
+        deletions += 1;
         deletedChars += step.to - step.from;
         break;
       case "replace":
-        replacements++;
+        replacements += 1;
         insertedChars += step.text?.length ?? 0;
         deletedChars += step.to - step.from;
         break;

--- a/apps/desktop/main/src/services/diff/DiffEngine.ts
+++ b/apps/desktop/main/src/services/diff/DiffEngine.ts
@@ -212,8 +212,22 @@ function mergeNearbySteps(
 
   for (let index = 1; index < steps.length; index += 1) {
     const next = steps[index];
-    const gap = next.from - current.to;
-    if (gap > 1) {
+    const beforeGap = next.from - current.to;
+    const afterGap = next.afterFrom - current.afterTo;
+    const canMergeContiguous = beforeGap === 0 && afterGap === 0;
+    const canMergeSingleAnchorChar =
+      beforeGap === 1 &&
+      afterGap === 1 &&
+      current.type === "replace" &&
+      next.type === "replace" &&
+      !(
+        current.to - current.from === 1 &&
+        (current.text?.length ?? 0) === 1 &&
+        next.to - next.from === 1 &&
+        (next.text?.length ?? 0) === 1
+      );
+
+    if (!canMergeContiguous && !canMergeSingleAnchorChar) {
       merged.push(current);
       current = { ...next };
       continue;

--- a/apps/desktop/main/src/services/diff/DiffEngine.ts
+++ b/apps/desktop/main/src/services/diff/DiffEngine.ts
@@ -215,19 +215,8 @@ function mergeNearbySteps(
     const beforeGap = next.from - current.to;
     const afterGap = next.afterFrom - current.afterTo;
     const canMergeContiguous = beforeGap === 0 && afterGap === 0;
-    const canMergeSingleAnchorChar =
-      beforeGap === 1 &&
-      afterGap === 1 &&
-      current.type === "replace" &&
-      next.type === "replace" &&
-      !(
-        current.to - current.from === 1 &&
-        (current.text?.length ?? 0) === 1 &&
-        next.to - next.from === 1 &&
-        (next.text?.length ?? 0) === 1
-      );
 
-    if (!canMergeContiguous && !canMergeSingleAnchorChar) {
+    if (!canMergeContiguous) {
       merged.push(current);
       current = { ...next };
       continue;

--- a/apps/desktop/main/src/services/diff/__tests__/DiffEngine.test.ts
+++ b/apps/desktop/main/src/services/diff/__tests__/DiffEngine.test.ts
@@ -41,17 +41,24 @@ describe("DiffEngine — computeTransaction", () => {
     expect(result.stats.deletedChars).toBe(11);
   });
 
-  it("混合替换（部分修改）", () => {
+  it("中间保留未改字符的替换 → 拆分为多个 replace", () => {
     const result = computeTransaction("hello world", "hello there");
 
-    expect(result.steps).toHaveLength(1);
-    expect(result.steps[0]).toEqual({
-      type: "replace",
-      from: 6,
-      to: 11,
-      text: "there",
-    });
-    expect(result.stats.replacements).toBe(1);
+    expect(result.steps).toEqual([
+      {
+        type: "replace",
+        from: 6,
+        to: 8,
+        text: "the",
+      },
+      {
+        type: "replace",
+        from: 9,
+        to: 11,
+        text: "e",
+      },
+    ]);
+    expect(result.stats.replacements).toBe(2);
   });
 
   it("相同字符串 → 步骤为空", () => {
@@ -91,16 +98,15 @@ describe("DiffEngine — computeTransaction", () => {
   });
 
   it("stats 正确计算", () => {
-    // Replace: "world" → "there" (delete 5, insert 5)
     const result = computeTransaction("hello world", "hello there");
 
     expect(result.stats).toEqual({
       insertions: 0,
       deletions: 0,
-      replacements: 1,
-      totalChanges: 1,
-      insertedChars: 5,
-      deletedChars: 5,
+      replacements: 2,
+      totalChanges: 2,
+      insertedChars: 4,
+      deletedChars: 4,
     });
   });
 
@@ -140,6 +146,27 @@ describe("DiffEngine — computeTransaction", () => {
         from: 3,
         to: 4,
         text: "Y",
+      },
+    ]);
+    expect(result.stats.replacements).toBe(2);
+    expect(result.stats.totalChanges).toBe(2);
+  });
+
+  it("多字符修改之间隔着 1 个未改字符 → 仍保留边界", () => {
+    const result = computeTransaction("abXXcYYf", "ab11c22f");
+
+    expect(result.steps).toEqual([
+      {
+        type: "replace",
+        from: 2,
+        to: 4,
+        text: "11",
+      },
+      {
+        type: "replace",
+        from: 5,
+        to: 7,
+        text: "22",
       },
     ]);
     expect(result.stats.replacements).toBe(2);

--- a/apps/desktop/main/src/services/diff/__tests__/DiffEngine.test.ts
+++ b/apps/desktop/main/src/services/diff/__tests__/DiffEngine.test.ts
@@ -125,6 +125,27 @@ describe("DiffEngine — computeTransaction", () => {
     expect(result.stats.totalChanges).toBe(2);
   });
 
+  it("两个修改之间隔着未改字符 → 保留为两个 replace step", () => {
+    const result = computeTransaction("abcde", "aXcYe");
+
+    expect(result.steps).toEqual([
+      {
+        type: "replace",
+        from: 1,
+        to: 2,
+        text: "X",
+      },
+      {
+        type: "replace",
+        from: 3,
+        to: 4,
+        text: "Y",
+      },
+    ]);
+    expect(result.stats.replacements).toBe(2);
+    expect(result.stats.totalChanges).toBe(2);
+  });
+
   it("首尾均不变、仅中间修改 → 精确 replace", () => {
     const result = computeTransaction("abc_XYZ_def", "abc_123_def");
 

--- a/apps/desktop/main/src/services/diff/__tests__/DiffEngine.test.ts
+++ b/apps/desktop/main/src/services/diff/__tests__/DiffEngine.test.ts
@@ -104,19 +104,25 @@ describe("DiffEngine — computeTransaction", () => {
     });
   });
 
-  it("多段不连续修改 → 单个 replace（算法局限性）", () => {
-    // "foo bar baz" → "FOO bar BAZ" has two non-contiguous changes,
-    // but the prefix/suffix algorithm collapses them into one replace step.
+  it("多段不连续修改 → 拆分为逐段 replace", () => {
     const result = computeTransaction("foo bar baz", "FOO bar BAZ");
 
-    expect(result.steps).toHaveLength(1);
-    expect(result.steps[0].type).toBe("replace");
-    // The single replace covers the entire span from first diff to last
-    expect(result.steps[0].from).toBe(0);
-    expect(result.steps[0].to).toBe(11);
-    expect(result.steps[0].text).toBe("FOO bar BAZ");
-    expect(result.stats.replacements).toBe(1);
-    expect(result.stats.totalChanges).toBe(1);
+    expect(result.steps).toEqual([
+      {
+        type: "replace",
+        from: 0,
+        to: 3,
+        text: "FOO",
+      },
+      {
+        type: "replace",
+        from: 8,
+        to: 11,
+        text: "BAZ",
+      },
+    ]);
+    expect(result.stats.replacements).toBe(2);
+    expect(result.stats.totalChanges).toBe(2);
   });
 
   it("首尾均不变、仅中间修改 → 精确 replace", () => {

--- a/apps/desktop/main/src/services/skills/__tests__/agentic-tools.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/agentic-tools.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { estimateTokens } from "../../context/tokenEstimation";
 import { createToolRegistry } from "../toolRegistry";
 import type { ToolRegistry } from "../toolRegistry";
 import {
@@ -129,8 +130,11 @@ describe("agenticTools — P2 Read-Only Tools", () => {
       query: "门后",
       truncated: true,
     });
-    expect(JSON.stringify(docToolResult.data)).toContain("门后");
-    expect(JSON.stringify(docToolResult.data)).not.toContain("随后他没有立刻推门");
+    const docToolData = docToolResult.data as { content: string };
+    expect(docToolData.content).toContain("门后");
+    expect(docToolData.content).not.toContain("随后他没有立刻推门");
+    expect(docToolData.content.length).toBeLessThanOrEqual(12);
+    expect(estimateTokens(docToolData.content)).toBeLessThanOrEqual(8);
 
     expect(documentReadResult.success).toBe(true);
     expect(documentReadResult.data).toMatchObject({
@@ -138,8 +142,11 @@ describe("agenticTools — P2 Read-Only Tools", () => {
       query: "林远",
       truncated: true,
     });
-    expect(JSON.stringify(documentReadResult.data)).toContain("林远");
-    expect(JSON.stringify(documentReadResult.data)).not.toContain("随后他没有立刻推门");
+    const documentReadData = documentReadResult.data as { text: string };
+    expect(documentReadData.text).toContain("林远");
+    expect(documentReadData.text).not.toContain("随后他没有立刻推门");
+    expect(documentReadData.text.length).toBeLessThanOrEqual(10);
+    expect(estimateTokens(documentReadData.text)).toBeLessThanOrEqual(8);
     expect(deps.documentReader.readDocument).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/desktop/main/src/services/skills/__tests__/agentic-tools.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/agentic-tools.test.ts
@@ -1,35 +1,32 @@
-/**
- * agenticTools V1 测试
- * Spec: openspec/specs/skill-system/spec.md — V1 Agentic Read-Only Tools
- *
- * 验证三个只读工具的注册、执行、错误处理、阻止列表与清理。
- */
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createToolRegistry } from "../toolRegistry";
 import type { ToolRegistry } from "../toolRegistry";
 import {
-  registerAgenticTools,
+  AGENTIC_TOOL_NAMES,
   isToolBlocked,
-  V1_TOOL_NAMES,
+  registerAgenticTools,
 } from "../agenticTools";
 import type { AgenticToolDeps } from "../agenticTools";
 
-// ─── helpers ────────────────────────────────────────────────────────
-
 function makeDeps(overrides: Partial<AgenticToolDeps> = {}): AgenticToolDeps {
   return {
+    kgTool: {
+      query: vi.fn().mockResolvedValue({
+        name: "林远",
+        traits: ["冷静", "理性"],
+      }),
+    },
+    memTool: {
+      query: vi.fn().mockResolvedValue({
+        memories: [{ id: "mem-1", text: "偏爱冷静克制的动作描写" }],
+      }),
+    },
     documentReader: {
-      readSection: vi.fn().mockResolvedValue({ text: "hello", wordCount: 1 }),
-    },
-    versionSearcher: {
-      searchVersions: vi
-        .fn()
-        .mockResolvedValue([{ versionId: "v1", summary: "init", createdAt: 1000 }]),
-    },
-    wordCounter: {
-      getWordCount: vi.fn().mockResolvedValue({ wordCount: 42, charCount: 200 }),
+      readDocument: vi.fn().mockResolvedValue({
+        documentId: "doc-1",
+        text: "林远先观察门缝里的光，再听见门后的脚步声。随后他没有立刻推门，而是退半步让呼吸平稳。",
+      }),
     },
     ...overrides,
   };
@@ -39,9 +36,7 @@ function makeCtx(extra: Record<string, unknown> = {}) {
   return { documentId: "doc-1", requestId: "req-1", ...extra };
 }
 
-// ─── tests ──────────────────────────────────────────────────────────
-
-describe("agenticTools — V1 Read-Only Tools", () => {
+describe("agenticTools — P2 Read-Only Tools", () => {
   let registry: ToolRegistry;
   let deps: AgenticToolDeps;
 
@@ -50,133 +45,192 @@ describe("agenticTools — V1 Read-Only Tools", () => {
     deps = makeDeps();
   });
 
-  // ── 注册 ──────────────────────────────────────────────────────
-
-  it("registerAgenticTools 注册三个只读工具", () => {
+  it("registerAgenticTools 注册 spec 对齐的四个只读工具", () => {
     registerAgenticTools(registry, deps);
 
-    const names = registry.list().map((t) => t.name).sort();
-    expect(names).toEqual([...V1_TOOL_NAMES].sort());
-    expect(names).toHaveLength(3);
+    const names = registry.list().map((tool) => tool.name).sort();
+    expect(names).toEqual([...AGENTIC_TOOL_NAMES].sort());
   });
 
-  // ── 执行成功 ──────────────────────────────────────────────────
-
-  it("read_document_section 执行成功", async () => {
+  it("kgTool 执行成功并透传 query / entityType", async () => {
     registerAgenticTools(registry, deps);
-    const tool = registry.get("read_document_section")!;
+    const tool = registry.get("kgTool");
 
-    const result = await tool.execute(makeCtx({ args: { from: 0, to: 100 } }));
+    const result = await tool!.execute(
+      makeCtx({
+        args: { query: "林远的性格特点", entityType: "character" },
+      }),
+    );
 
     expect(result.success).toBe(true);
-    expect(result.data).toEqual({ text: "hello", wordCount: 1 });
-    expect(deps.documentReader.readSection).toHaveBeenCalledWith("doc-1", 0, 100);
-  });
-
-  it("search_versions 执行成功", async () => {
-    registerAgenticTools(registry, deps);
-    const tool = registry.get("search_versions")!;
-
-    const result = await tool.execute(makeCtx({ args: { query: "chapter", limit: 5 } }));
-
-    expect(result.success).toBe(true);
-    expect(result.data).toEqual([{ versionId: "v1", summary: "init", createdAt: 1000 }]);
-    expect(deps.versionSearcher.searchVersions).toHaveBeenCalledWith("doc-1", "chapter", 5);
-  });
-
-  it("get_word_count 执行成功", async () => {
-    registerAgenticTools(registry, deps);
-    const tool = registry.get("get_word_count")!;
-
-    const result = await tool.execute(makeCtx());
-
-    expect(result.success).toBe(true);
-    expect(result.data).toEqual({ wordCount: 42, charCount: 200 });
-    expect(deps.wordCounter.getWordCount).toHaveBeenCalledWith("doc-1");
-  });
-
-  // ── 执行失败 ──────────────────────────────────────────────────
-
-  it("read_document_section 执行失败 → 返回错误", async () => {
-    const failingDeps = makeDeps({
-      documentReader: {
-        readSection: vi.fn().mockRejectedValue(new Error("not found")),
-      },
+    expect(result.data).toEqual({
+      name: "林远",
+      traits: ["冷静", "理性"],
     });
-    registerAgenticTools(registry, failingDeps);
-    const tool = registry.get("read_document_section")!;
+    expect(deps.kgTool.query).toHaveBeenCalledWith({
+      documentId: "doc-1",
+      query: "林远的性格特点",
+      entityType: "character",
+      requestId: "req-1",
+    });
+  });
 
-    const result = await tool.execute(makeCtx({ args: { from: 0, to: 50 } }));
+  it("memTool 执行成功并在底层不可用时允许空结果", async () => {
+    registerAgenticTools(registry, deps);
+    const tool = registry.get("memTool");
+
+    const result = await tool!.execute(
+      makeCtx({
+        args: { query: "用户写作风格偏好", memoryType: "style" },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      memories: [{ id: "mem-1", text: "偏爱冷静克制的动作描写" }],
+    });
+    expect(deps.memTool.query).toHaveBeenCalledWith({
+      documentId: "doc-1",
+      query: "用户写作风格偏好",
+      memoryType: "style",
+      requestId: "req-1",
+    });
+  });
+
+  it("docTool / documentRead obey query + maxTokens + snippetChars 语义", async () => {
+    registerAgenticTools(registry, deps);
+    const docTool = registry.get("docTool");
+    const documentRead = registry.get("documentRead");
+
+    const docToolResult = await docTool!.execute(
+      makeCtx({
+        documentId: "doc-current",
+        args: {
+          documentId: "doc-ref",
+          query: "门后",
+          maxTokens: 8,
+          snippetChars: 12,
+        },
+      }),
+    );
+    const documentReadResult = await documentRead!.execute(
+      makeCtx({
+        args: {
+          query: "林远",
+          maxTokens: 8,
+          snippetChars: 10,
+        },
+      }),
+    );
+
+    expect(docToolResult.success).toBe(true);
+    expect(docToolResult.data).toMatchObject({
+      documentId: "doc-ref",
+      query: "门后",
+      truncated: true,
+    });
+    expect(JSON.stringify(docToolResult.data)).toContain("门后");
+    expect(JSON.stringify(docToolResult.data)).not.toContain("随后他没有立刻推门");
+
+    expect(documentReadResult.success).toBe(true);
+    expect(documentReadResult.data).toMatchObject({
+      documentId: "doc-1",
+      query: "林远",
+      truncated: true,
+    });
+    expect(JSON.stringify(documentReadResult.data)).toContain("林远");
+    expect(JSON.stringify(documentReadResult.data)).not.toContain("随后他没有立刻推门");
+    expect(deps.documentReader.readDocument).toHaveBeenCalledTimes(2);
+  });
+
+  it("kgTool 底层失败 → 返回错误", async () => {
+    registerAgenticTools(
+      registry,
+      makeDeps({
+        kgTool: {
+          query: vi.fn().mockRejectedValue(new Error("kg offline")),
+        },
+      }),
+    );
+    const tool = registry.get("kgTool");
+
+    const result = await tool!.execute(makeCtx({ args: { query: "林远" } }));
 
     expect(result.success).toBe(false);
     expect(result.error).toMatchObject({
-      code: "READ_SECTION_FAILED",
-      message: "not found",
+      code: "KG_TOOL_FAILED",
+      message: "kg offline",
     });
   });
 
-  it("search_versions 执行失败 → 返回错误", async () => {
-    const failingDeps = makeDeps({
-      versionSearcher: {
-        searchVersions: vi.fn().mockRejectedValue(new Error("db timeout")),
-      },
-    });
-    registerAgenticTools(registry, failingDeps);
-    const tool = registry.get("search_versions")!;
+  it("memTool 底层失败 → 返回错误", async () => {
+    registerAgenticTools(
+      registry,
+      makeDeps({
+        memTool: {
+          query: vi.fn().mockRejectedValue(new Error("memory unavailable")),
+        },
+      }),
+    );
+    const tool = registry.get("memTool");
 
-    const result = await tool.execute(makeCtx({ args: { query: "chapter", limit: 5 } }));
+    const result = await tool!.execute(makeCtx({ args: { query: "风格" } }));
 
     expect(result.success).toBe(false);
     expect(result.error).toMatchObject({
-      code: "SEARCH_VERSIONS_FAILED",
-      message: "db timeout",
+      code: "MEM_TOOL_FAILED",
+      message: "memory unavailable",
     });
   });
 
-  it("get_word_count 执行失败 → 返回错误", async () => {
-    const failingDeps = makeDeps({
-      wordCounter: {
-        getWordCount: vi.fn().mockRejectedValue(new Error("document missing")),
-      },
+  it("docTool / documentRead 读取失败 → 返回错误", async () => {
+    registerAgenticTools(
+      registry,
+      makeDeps({
+        documentReader: {
+          readDocument: vi.fn().mockRejectedValue(new Error("document missing")),
+        },
+      }),
+    );
+    const docTool = registry.get("docTool");
+    const documentRead = registry.get("documentRead");
+
+    const docToolResult = await docTool!.execute(makeCtx({ args: { query: "门后" } }));
+    const documentReadResult = await documentRead!.execute(
+      makeCtx({ args: { query: "林远" } }),
+    );
+
+    expect(docToolResult.success).toBe(false);
+    expect(docToolResult.error).toMatchObject({
+      code: "DOC_TOOL_FAILED",
+      message: "document missing",
     });
-    registerAgenticTools(registry, failingDeps);
-    const tool = registry.get("get_word_count")!;
-
-    const result = await tool.execute(makeCtx());
-
-    expect(result.success).toBe(false);
-    expect(result.error).toMatchObject({
-      code: "WORD_COUNT_FAILED",
+    expect(documentReadResult.success).toBe(false);
+    expect(documentReadResult.error).toMatchObject({
+      code: "DOCUMENT_READ_FAILED",
       message: "document missing",
     });
   });
 
-  // ── 阻止列表 ─────────────────────────────────────────────────
-
-  it("isToolBlocked 拒绝 documentWrite", () => {
+  it("isToolBlocked 拒绝 documentWrite / versionSnapshot", () => {
     expect(isToolBlocked("documentWrite")).toBe(true);
-    expect(isToolBlocked("document_write")).toBe(true);
-    expect(isToolBlocked("read_document_section")).toBe(false);
+    expect(isToolBlocked("versionSnapshot")).toBe(true);
+    expect(isToolBlocked("kgTool")).toBe(false);
   });
-
-  // ── cleanup ───────────────────────────────────────────────────
 
   it("cleanup 函数取消注册所有工具", () => {
     const cleanup = registerAgenticTools(registry, deps);
 
-    expect(registry.list()).toHaveLength(3);
-
+    expect(registry.list()).toHaveLength(4);
     cleanup();
-
     expect(registry.list()).toHaveLength(0);
-    for (const name of V1_TOOL_NAMES) {
+
+    for (const name of AGENTIC_TOOL_NAMES) {
       expect(registry.get(name)).toBeUndefined();
     }
   });
 
-  // ── concurrency-safe ──────────────────────────────────────────
-
-  it("工具是 concurrency-safe", () => {
+  it("工具都是 concurrency-safe", () => {
     registerAgenticTools(registry, deps);
 
     for (const tool of registry.list()) {

--- a/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/orchestrator-agentic-loop.test.ts
@@ -21,6 +21,7 @@ import { createWritingOrchestrator } from "../orchestrator";
 import { createToolRegistry, buildTool, type ToolRegistry } from "../toolRegistry";
 import type { ToolCallInfo } from "../../ai/streaming";
 import { createToolUseHandler, type ToolUseHandler } from "../toolUseHandler";
+import { createCostTracker } from "../../ai/costTracker";
 
 // ─── helpers ────────────────────────────────────────────────────────
 
@@ -303,6 +304,94 @@ describe("WritingOrchestrator P2 — Agentic Loop 集成测试", () => {
 
       expect(callCount).toBe(3);
       expect(types).toContain("ai-done");
+    });
+
+    it("两轮 agentic AI 调用逐轮记录费用，并按同一 requestId 累计预算", async () => {
+      const tracker = createCostTracker({
+        pricingTable: {
+          currency: "USD",
+          lastUpdated: "2025-01-01T00:00:00.000Z",
+          prices: {
+            default: {
+              modelId: "default",
+              displayName: "Default",
+              inputPricePer1K: 0.001,
+              outputPricePer1K: 0.002,
+              effectiveDate: "2025-01-01",
+            },
+          },
+        },
+        budgetPolicy: {
+          warningThreshold: 10,
+          hardStopLimit: 20,
+          enabled: true,
+        },
+        estimateTokens: (text) => text.length,
+      });
+      const checkBudget = vi.fn(() => tracker.checkBudget());
+
+      let callCount = 0;
+      const generateText = vi.fn().mockImplementation(async (args: {
+        messages?: Array<{ role: string; content: string }>;
+        emitChunk: (delta: string, tokens: number) => void;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          args.emitChunk("第一轮", 3);
+          return {
+            fullText: "第一轮",
+            usage: { promptTokens: 12, completionTokens: 3, totalTokens: 15 },
+            finishReason: "tool_use" as const,
+            toolCalls: [makeToolCallInfo("kgTool", { query: "林远" }, "call-usage-r1")],
+          };
+        }
+
+        const toolMsg = args.messages?.find((message) => message.role === "tool");
+        expect(toolMsg).toBeDefined();
+        args.emitChunk("最终续写", 7);
+        return {
+          fullText: "最终续写",
+          usage: { promptTokens: 18, completionTokens: 7, totalTokens: 25 },
+          finishReason: "stop" as const,
+          toolCalls: [],
+        };
+      });
+
+      const orchestrator = createWritingOrchestrator({
+        aiService: { async *streamChat() { return; }, estimateTokens: () => 10, abort: vi.fn() },
+        toolRegistry: writeRegistry,
+        toolUseHandler: agenticHandler,
+        permissionGate,
+        postWritingHooks: [],
+        defaultTimeoutMs: 30_000,
+        generateText,
+        costTracker: {
+          recordUsage: tracker.recordUsage,
+          getSessionCost: tracker.getSessionCost,
+          checkBudget,
+        },
+      });
+
+      const events = await collectEvents(orchestrator.execute(makeRequest({
+        requestId: "req-agentic-cost-001",
+      })));
+      const costEvents = events.filter((event) => event.type === "cost-recorded");
+      const requestCost = tracker.getRequestCost("req-agentic-cost-001");
+      const sessionCost = tracker.getSessionCost();
+
+      expect(callCount).toBe(2);
+      expect(costEvents).toHaveLength(2);
+      expect(checkBudget.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(requestCost).toMatchObject({
+        requestId: "req-agentic-cost-001",
+        inputTokens: 30,
+        outputTokens: 10,
+      });
+      expect(sessionCost).toMatchObject({
+        totalRequests: 1,
+        totalInputTokens: 30,
+        totalOutputTokens: 10,
+      });
     });
   });
 

--- a/apps/desktop/main/src/services/skills/__tests__/skillOutputValidation.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/skillOutputValidation.test.ts
@@ -458,6 +458,12 @@ describe("skillOutputValidation inflation guards", () => {
         capacityPercent: (contextPrompt.length / 6000) * 100,
         layers: {
           rules: { source: [], tokenCount: 0, truncated: false },
+          compressedHistory: {
+            source: ["compressed-history"],
+            tokenCount: 0,
+            truncated: false,
+            compressed: false,
+          },
           immediate: {
             source: ["immediate:ai_panel_input"],
             tokenCount: contextPrompt.length,
@@ -513,6 +519,12 @@ describe("skillOutputValidation inflation guards", () => {
         capacityPercent: 12 / 6000 * 100,
         layers: {
           rules: { source: [], tokenCount: 0, truncated: false },
+          compressedHistory: {
+            source: ["compressed-history"],
+            tokenCount: 0,
+            truncated: false,
+            compressed: false,
+          },
           immediate: {
             source: ["editor:cursor-window"],
             tokenCount: 4,
@@ -564,6 +576,12 @@ describe("skillOutputValidation inflation guards", () => {
         capacityPercent: 12 / 6000 * 100,
         layers: {
           rules: { source: [], tokenCount: 0, truncated: false },
+          compressedHistory: {
+            source: ["compressed-history"],
+            tokenCount: 0,
+            truncated: false,
+            compressed: false,
+          },
           immediate: {
             source: ["editor:cursor-window"],
             tokenCount: 5,
@@ -615,6 +633,12 @@ describe("skillOutputValidation inflation guards", () => {
         capacityPercent: 2 / 6000 * 100,
         layers: {
           rules: { source: [], tokenCount: 0, truncated: false },
+          compressedHistory: {
+            source: ["compressed-history"],
+            tokenCount: 0,
+            truncated: false,
+            compressed: false,
+          },
           immediate: {
             source: ["editor:selection"],
             tokenCount: 2,

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -16,6 +16,14 @@ import type {
 } from "../orchestrator";
 import { createWritingOrchestrator } from "../orchestrator";
 import { createToolRegistry } from "../toolRegistry";
+import type {
+  BudgetAlert,
+  BudgetPolicy,
+  CostTracker,
+  ModelPricingTable,
+  RequestCost,
+  SessionCostSummary,
+} from "../../ai/costTracker";
 
 // ─── helpers ────────────────────────────────────────────────────────
 
@@ -113,6 +121,54 @@ function createMockHook(name: string) {
   };
 }
 
+function createMockCostTracker(
+  overrides: Partial<CostTracker> = {},
+): CostTracker {
+  return {
+    recordUsage: vi.fn().mockReturnValue({
+      requestId: "req-001",
+      modelId: "default",
+      inputTokens: 10,
+      outputTokens: 6,
+      cachedTokens: 0,
+      cost: 0.012,
+      skillId: "polish",
+      timestamp: Date.now(),
+    } satisfies RequestCost),
+    getSessionCost: vi.fn().mockReturnValue({
+      totalCost: 0.012,
+      totalRequests: 1,
+      totalInputTokens: 10,
+      totalOutputTokens: 6,
+      totalCachedTokens: 0,
+      costByModel: { default: { cost: 0.012, requests: 1 } },
+      costBySkill: { polish: { cost: 0.012, requests: 1 } },
+      sessionStartedAt: 1000,
+    } satisfies SessionCostSummary),
+    getRequestCost: vi.fn().mockReturnValue(null),
+    getPricingTable: vi.fn().mockReturnValue({
+      currency: "USD",
+      lastUpdated: "2025-01-01T00:00:00.000Z",
+      prices: {},
+    } satisfies ModelPricingTable),
+    getBudgetPolicy: vi.fn().mockReturnValue({
+      warningThreshold: 1,
+      hardStopLimit: 5,
+      enabled: true,
+    } satisfies BudgetPolicy),
+    listRecords: vi.fn().mockReturnValue([]),
+    checkBudget: vi.fn().mockReturnValue(null as BudgetAlert | null),
+    estimateCost: vi.fn().mockReturnValue(0.012),
+    onBudgetAlert: vi.fn().mockReturnValue(() => {}),
+    onCostRecorded: vi.fn().mockReturnValue(() => {}),
+    updatePricingTable: vi.fn().mockImplementation((_table: ModelPricingTable) => {}),
+    updateBudgetPolicy: vi.fn().mockImplementation((_policy: BudgetPolicy) => {}),
+    resetSession: vi.fn(),
+    dispose: vi.fn(),
+    ...overrides,
+  };
+}
+
 /** Build OrchestratorConfig with mocks */
 function buildConfig(
   overrides: Partial<OrchestratorConfig> = {},
@@ -144,6 +200,7 @@ function buildConfig(
     permissionGate: createMockPermissionGate(),
     postWritingHooks: [createMockHook("auto-save-version")],
     defaultTimeoutMs: 30_000,
+    costTracker: createMockCostTracker(),
     ...overrides,
   };
 }
@@ -181,6 +238,7 @@ describe("WritingOrchestrator", () => {
         "ai-chunk",
         "ai-chunk",
         "ai-done",
+        "cost-recorded",
         "permission-requested",
         "permission-granted",
         "write-back-done",
@@ -220,6 +278,28 @@ describe("WritingOrchestrator", () => {
         promptTokens: expect.any(Number),
         completionTokens: expect.any(Number),
         totalTokens: expect.any(Number),
+      });
+    });
+
+    it("ai-done 后记录费用并产出 cost-recorded", async () => {
+      const tracker = createMockCostTracker();
+      orchestrator = createWritingOrchestrator(
+        buildConfig({ costTracker: tracker }),
+      );
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const costEvent = events.find((event) => event.type === "cost-recorded");
+
+      expect(tracker.recordUsage).toHaveBeenCalledWith(
+        { promptTokens: 10, completionTokens: 6, totalTokens: 16 },
+        "default",
+        "req-001",
+        "polish",
+      );
+      expect(costEvent).toMatchObject({
+        type: "cost-recorded",
+        requestCost: 0.012,
+        sessionTotalCost: 0.012,
       });
     });
 
@@ -266,6 +346,30 @@ describe("WritingOrchestrator", () => {
           }),
         }),
       );
+    });
+
+    it("预算硬停时在 call-ai 前 fail-closed，并产出 budget-exceeded", async () => {
+      const tracker = createMockCostTracker({
+        checkBudget: vi.fn().mockReturnValue({
+          kind: "hard-stop",
+          currentCost: 5.01,
+          threshold: 5,
+          message: "budget exceeded",
+          timestamp: Date.now(),
+        } satisfies BudgetAlert),
+      });
+      const aiService = createMockAIService();
+      orchestrator = createWritingOrchestrator(
+        buildConfig({
+          aiService,
+          costTracker: tracker,
+        }),
+      );
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      expect(eventTypes(events)).toContain("budget-exceeded");
+      expect(eventTypes(events)).toContain("error");
+      expect(aiService.streamChat).not.toHaveBeenCalled();
     });
 
     it("continue 无 selection 但有 cursorPosition 时，会把光标位置透传给 documentWrite", async () => {

--- a/apps/desktop/main/src/services/skills/__tests__/writingTooling.agentic-registry.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writingTooling.agentic-registry.test.ts
@@ -6,6 +6,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { Logger } from "../../../logging/logger";
+import { estimateTokens } from "../../context/tokenEstimation";
 import { createDocumentService } from "../../documents/documentService";
 import { createKnowledgeGraphService } from "../../kg/kgService";
 import { createMemoryService } from "../../memory/memoryService";
@@ -194,8 +195,11 @@ describe("createAgenticToolRegistry", () => {
       documentId: currentDocumentId,
       query: "林远",
     });
-    expect(JSON.stringify(docToolResult.data)).toContain("林远");
-    expect(JSON.stringify(docToolResult.data)).not.toContain("随后他没有立刻推门");
+    const docToolData = docToolResult.data as { content: string };
+    expect(docToolData.content).toContain("林远");
+    expect(docToolData.content).not.toContain("随后他没有立刻推门");
+    expect(docToolData.content.length).toBeLessThanOrEqual(18);
+    expect(estimateTokens(docToolData.content)).toBeLessThanOrEqual(12);
 
     const documentReadResult = await documentRead!.execute({
       documentId: currentDocumentId,
@@ -211,8 +215,11 @@ describe("createAgenticToolRegistry", () => {
     expect(documentReadResult.data).toMatchObject({
       documentId: currentDocumentId,
     });
-    expect(JSON.stringify(documentReadResult.data)).toContain("门后");
-    expect(JSON.stringify(documentReadResult.data)).not.toContain("随后他没有立刻推门");
+    const documentReadData = documentReadResult.data as { text: string };
+    expect(documentReadData.text).toContain("门后");
+    expect(documentReadData.text).not.toContain("随后他没有立刻推门");
+    expect(documentReadData.text.length).toBeLessThanOrEqual(12);
+    expect(estimateTokens(documentReadData.text)).toBeLessThanOrEqual(12);
   });
 
   it("kgTool / memTool 在有数据时返回真实查询结果，而不是永久空壳", async () => {

--- a/apps/desktop/main/src/services/skills/__tests__/writingTooling.agentic-registry.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writingTooling.agentic-registry.test.ts
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { Logger } from "../../../logging/logger";
 import { createDocumentService } from "../../documents/documentService";
+import { createKnowledgeGraphService } from "../../kg/kgService";
+import { createMemoryService } from "../../memory/memoryService";
 import { createAgenticToolRegistry } from "../writingTooling";
 
 const MIGRATIONS_DIR = path.resolve(
@@ -211,5 +213,101 @@ describe("createAgenticToolRegistry", () => {
     });
     expect(JSON.stringify(documentReadResult.data)).toContain("门后");
     expect(JSON.stringify(documentReadResult.data)).not.toContain("随后他没有立刻推门");
+  });
+
+  it("kgTool / memTool 在有数据时返回真实查询结果，而不是永久空壳", async () => {
+    const db = new Database(":memory:");
+    opened.push(db);
+    db.pragma("foreign_keys = ON");
+    applyAllMigrations(db);
+
+    const projectId = "proj-kg-mem";
+    const documentId = createProjectAndDocument({
+      db,
+      projectId,
+      title: "当前章节",
+      text: "林远站在门前，想起自己一贯偏好的冷静克制语气。",
+    });
+
+    const kgService = createKnowledgeGraphService({
+      db,
+      logger: createLogger(),
+    });
+    const entity = kgService.entityCreate({
+      projectId,
+      type: "character",
+      name: "林远",
+      description: "冷静理性，偶尔冷幽默",
+      attributes: {
+        traits: "冷静, 理性, 冷幽默",
+      },
+    });
+    if (!entity.ok) {
+      throw new Error(entity.error.message);
+    }
+
+    const memoryService = createMemoryService({
+      db,
+      logger: createLogger(),
+    });
+    const memory = memoryService.create({
+      type: "preference",
+      scope: "project",
+      projectId,
+      content: "偏好短句、冷调、克制描写",
+    });
+    if (!memory.ok) {
+      throw new Error(memory.error.message);
+    }
+
+    const registry = createAgenticToolRegistry({
+      db,
+      logger: createLogger(),
+    });
+    const kgTool = registry.get("kgTool");
+    const memTool = registry.get("memTool");
+
+    expect(kgTool).toBeDefined();
+    expect(memTool).toBeDefined();
+
+    const kgToolResult = await kgTool!.execute({
+      documentId,
+      requestId: "req-kg-real",
+      projectId,
+      args: {
+        query: "林远的性格特点",
+        entityType: "character",
+      },
+    });
+    expect(kgToolResult.success).toBe(true);
+    expect(kgToolResult.data).toMatchObject({
+      query: "林远的性格特点",
+      entities: [
+        expect.objectContaining({
+          name: "林远",
+          type: "character",
+        }),
+      ],
+    });
+
+    const memToolResult = await memTool!.execute({
+      documentId,
+      requestId: "req-mem-real",
+      projectId,
+      args: {
+        query: "冷调短句偏好",
+        memoryType: "preference",
+      },
+    });
+    expect(memToolResult.success).toBe(true);
+    expect(memToolResult.data).toMatchObject({
+      query: "冷调短句偏好",
+      memories: [
+        expect.objectContaining({
+          type: "preference",
+          content: "偏好短句、冷调、克制描写",
+        }),
+      ],
+    });
   });
 });

--- a/apps/desktop/main/src/services/skills/agenticTools.ts
+++ b/apps/desktop/main/src/services/skills/agenticTools.ts
@@ -5,6 +5,7 @@ import type { ToolContext, ToolRegistry, ToolResult, WritingTool } from "./toolR
 type AgenticArgs = Record<string, unknown>;
 
 export interface KgToolQuery {
+  projectId?: string;
   documentId: string;
   query: string;
   entityType?: "character" | "location" | "worldSetting";
@@ -12,6 +13,7 @@ export interface KgToolQuery {
 }
 
 export interface MemToolQuery {
+  projectId?: string;
   documentId: string;
   query: string;
   memoryType?: "preference" | "style" | "rule";
@@ -142,6 +144,7 @@ function buildKgTool(deps: AgenticToolDeps): WritingTool {
         return {
           success: true,
           data: await deps.kgTool.query({
+            projectId: readProjectId(ctx),
             documentId: ctx.documentId,
             query,
             ...(entityType ? { entityType } : {}),
@@ -178,6 +181,7 @@ function buildMemTool(deps: AgenticToolDeps): WritingTool {
         return {
           success: true,
           data: await deps.memTool.query({
+            projectId: readProjectId(ctx),
             documentId: ctx.documentId,
             query,
             ...(memoryType ? { memoryType } : {}),

--- a/apps/desktop/main/src/services/skills/agenticTools.ts
+++ b/apps/desktop/main/src/services/skills/agenticTools.ts
@@ -77,51 +77,98 @@ function sliceSnippet(args: {
   maxTokens?: number;
   snippetChars?: number;
 }): { snippet: string; truncated: boolean } {
+  function buildWindow(limit: number): { start: number; end: number; queryStart?: number; queryEnd?: number } {
+    if (query.length === 0) {
+      return { start: 0, end: limit };
+    }
+
+    const hitIndex = normalized.indexOf(query);
+    if (hitIndex < 0) {
+      return { start: 0, end: limit };
+    }
+
+    const leftBudget = Math.max(0, Math.floor((limit - query.length) / 2));
+    const start = Math.max(0, hitIndex - leftBudget);
+    const end = Math.min(normalized.length, start + limit);
+    const alignedStart = Math.max(0, end - limit);
+    return {
+      start: alignedStart,
+      end,
+      queryStart: hitIndex,
+      queryEnd: hitIndex + query.length,
+    };
+  }
+
+  function shrinkWindowToTokenBudget(window: {
+    start: number;
+    end: number;
+    queryStart?: number;
+    queryEnd?: number;
+  }): { start: number; end: number } {
+    if (tokenBudget === undefined) {
+      return { start: window.start, end: window.end };
+    }
+
+    let start = window.start;
+    let end = window.end;
+    while (start < end && estimateTokens(normalized.slice(start, end)) > tokenBudget) {
+      const canTrimLeft =
+        typeof window.queryStart === "number" ? start < window.queryStart : false;
+      const canTrimRight =
+        typeof window.queryEnd === "number" ? end > window.queryEnd : true;
+
+      if (canTrimLeft && canTrimRight && typeof window.queryStart === "number" && typeof window.queryEnd === "number") {
+        const leftContext = window.queryStart - start;
+        const rightContext = end - window.queryEnd;
+        if (rightContext > leftContext) {
+          end--;
+        } else {
+          start++;
+        }
+        continue;
+      }
+
+      if (canTrimRight) {
+        end--;
+        continue;
+      }
+
+      if (canTrimLeft) {
+        start++;
+        continue;
+      }
+
+      end--;
+    }
+
+    return { start, end };
+  }
+
   const normalized = args.text.trim();
   if (normalized.length === 0) {
     return { snippet: "", truncated: false };
   }
 
-  const tokenBound =
+  const tokenBudget =
     typeof args.maxTokens === "number" &&
     Number.isFinite(args.maxTokens) &&
     args.maxTokens > 0
-      ? Math.max(1, Math.floor(args.maxTokens) * 4)
-      : normalized.length;
+      ? Math.max(1, Math.floor(args.maxTokens))
+      : undefined;
   const charBound =
     typeof args.snippetChars === "number" &&
     Number.isFinite(args.snippetChars) &&
     args.snippetChars > 0
       ? Math.max(1, Math.floor(args.snippetChars))
       : normalized.length;
-  const limit = Math.min(normalized.length, tokenBound, charBound);
+  const limit = Math.min(normalized.length, charBound);
   const query = args.query.trim();
-
-  if (query.length === 0) {
-    const snippet = normalized.slice(0, limit);
-    return {
-      snippet,
-      truncated: estimateTokens(normalized) > estimateTokens(snippet),
-    };
-  }
-
-  const hitIndex = normalized.indexOf(query);
-  if (hitIndex < 0) {
-    const snippet = normalized.slice(0, limit);
-    return {
-      snippet,
-      truncated: estimateTokens(normalized) > estimateTokens(snippet),
-    };
-  }
-
-  const leftBudget = Math.max(0, Math.floor((limit - query.length) / 2));
-  const start = Math.max(0, hitIndex - leftBudget);
-  const end = Math.min(normalized.length, start + limit);
-  const alignedStart = Math.max(0, end - limit);
-  const snippet = normalized.slice(alignedStart, end);
+  const initialWindow = buildWindow(limit);
+  const finalWindow = shrinkWindowToTokenBudget(initialWindow);
+  const snippet = normalized.slice(finalWindow.start, finalWindow.end);
   return {
     snippet,
-    truncated: estimateTokens(normalized) > estimateTokens(snippet),
+    truncated: finalWindow.start > 0 || finalWindow.end < normalized.length,
   };
 }
 

--- a/apps/desktop/main/src/services/skills/agenticTools.ts
+++ b/apps/desktop/main/src/services/skills/agenticTools.ts
@@ -1,133 +1,299 @@
-/**
- * V1 Agentic Read-Only Tools
- *
- * read_document_section — 读取文档片段
- * search_versions — 搜索版本历史
- * get_word_count — 获取字数统计
- *
- * 这些工具仅限只读操作。documentWrite 不暴露给 AI 自主调用。
- */
-
+import { estimateTokens } from "../context/tokenEstimation";
 import { buildTool } from "./toolRegistry";
-import type { WritingTool, ToolContext, ToolResult, ToolRegistry } from "./toolRegistry";
+import type { ToolContext, ToolRegistry, ToolResult, WritingTool } from "./toolRegistry";
 
-// ─── Tool names ─────────────────────────────────────────────────────
+type AgenticArgs = Record<string, unknown>;
 
-const TOOL_NAME_READ_SECTION = "read_document_section";
-const TOOL_NAME_SEARCH_VERSIONS = "search_versions";
-const TOOL_NAME_GET_WORD_COUNT = "get_word_count";
+export interface KgToolQuery {
+  documentId: string;
+  query: string;
+  entityType?: "character" | "location" | "worldSetting";
+  requestId: string;
+}
 
-/** Blocked tool names — never registered in the agentic tool registry */
-const BLOCKED_TOOLS = new Set(["documentWrite", "document_write"]);
+export interface MemToolQuery {
+  documentId: string;
+  query: string;
+  memoryType?: "preference" | "style" | "rule";
+  requestId: string;
+}
+
+export interface ReadDocumentArgs {
+  projectId?: string;
+  documentId: string;
+  requestId: string;
+}
+
+export interface AgenticToolDeps {
+  kgTool: {
+    query(args: KgToolQuery): Promise<unknown>;
+  };
+  memTool: {
+    query(args: MemToolQuery): Promise<unknown>;
+  };
+  documentReader: {
+    readDocument(args: ReadDocumentArgs): Promise<{
+      documentId: string;
+      text: string;
+    }>;
+  };
+}
+
+const BLOCKED_TOOLS = new Set(["documentWrite", "document_write", "versionSnapshot"]);
+
+export const AGENTIC_TOOL_NAMES = [
+  "kgTool",
+  "memTool",
+  "docTool",
+  "documentRead",
+] as const;
 
 export function isToolBlocked(name: string): boolean {
   return BLOCKED_TOOLS.has(name);
 }
 
-// ─── Service interfaces ─────────────────────────────────────────────
-
-export interface DocumentReader {
-  readSection(documentId: string, from: number, to: number): Promise<{ text: string; wordCount: number }>;
+function readAgenticArgs(ctx: ToolContext): AgenticArgs {
+  const args = ctx["args"];
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return {};
+  }
+  return args as AgenticArgs;
 }
 
-export interface VersionSearcher {
-  searchVersions(
-    documentId: string,
-    query: string,
-    limit: number,
-  ): Promise<ReadonlyArray<{ versionId: string; summary: string; createdAt: number }>>;
+function readProjectId(ctx: ToolContext): string | undefined {
+  const projectId = ctx["projectId"];
+  if (typeof projectId !== "string") {
+    return undefined;
+  }
+  const normalized = projectId.trim();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
-export interface WordCounter {
-  getWordCount(documentId: string): Promise<{ wordCount: number; charCount: number }>;
+function sliceSnippet(args: {
+  text: string;
+  query: string;
+  maxTokens?: number;
+  snippetChars?: number;
+}): { snippet: string; truncated: boolean } {
+  const normalized = args.text.trim();
+  if (normalized.length === 0) {
+    return { snippet: "", truncated: false };
+  }
+
+  const tokenBound =
+    typeof args.maxTokens === "number" &&
+    Number.isFinite(args.maxTokens) &&
+    args.maxTokens > 0
+      ? Math.max(1, Math.floor(args.maxTokens) * 4)
+      : normalized.length;
+  const charBound =
+    typeof args.snippetChars === "number" &&
+    Number.isFinite(args.snippetChars) &&
+    args.snippetChars > 0
+      ? Math.max(1, Math.floor(args.snippetChars))
+      : normalized.length;
+  const limit = Math.min(normalized.length, tokenBound, charBound);
+  const query = args.query.trim();
+
+  if (query.length === 0) {
+    const snippet = normalized.slice(0, limit);
+    return {
+      snippet,
+      truncated: estimateTokens(normalized) > estimateTokens(snippet),
+    };
+  }
+
+  const hitIndex = normalized.indexOf(query);
+  if (hitIndex < 0) {
+    const snippet = normalized.slice(0, limit);
+    return {
+      snippet,
+      truncated: estimateTokens(normalized) > estimateTokens(snippet),
+    };
+  }
+
+  const leftBudget = Math.max(0, Math.floor((limit - query.length) / 2));
+  const start = Math.max(0, hitIndex - leftBudget);
+  const end = Math.min(normalized.length, start + limit);
+  const alignedStart = Math.max(0, end - limit);
+  const snippet = normalized.slice(alignedStart, end);
+  return {
+    snippet,
+    truncated: estimateTokens(normalized) > estimateTokens(snippet),
+  };
 }
 
-export interface AgenticToolDeps {
-  documentReader: DocumentReader;
-  versionSearcher: VersionSearcher;
-  wordCounter: WordCounter;
-}
-
-// ─── Tool factories ─────────────────────────────────────────────────
-
-function createReadDocumentSectionTool(deps: AgenticToolDeps): WritingTool {
+function buildKgTool(deps: AgenticToolDeps): WritingTool {
   return buildTool({
-    name: TOOL_NAME_READ_SECTION,
-    description: "Read a section of the current document by character offset range",
+    name: "kgTool",
+    description: "Query the knowledge graph for character traits, locations, and world settings",
     isConcurrencySafe: true,
-    execute: async (ctx: ToolContext): Promise<ToolResult> => {
-      const args = (ctx as { args?: Record<string, unknown> }).args ?? {};
-      const from = typeof args.from === "number" ? args.from : 0;
-      const to = typeof args.to === "number" ? args.to : 1000;
-
-      try {
-        const result = await deps.documentReader.readSection(ctx.documentId, from, to);
-        return { success: true, data: result };
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: { code: "READ_SECTION_FAILED", message } };
-      }
-    },
-  });
-}
-
-function createSearchVersionsTool(deps: AgenticToolDeps): WritingTool {
-  return buildTool({
-    name: TOOL_NAME_SEARCH_VERSIONS,
-    description: "Search the version history of the current document",
-    isConcurrencySafe: true,
-    execute: async (ctx: ToolContext): Promise<ToolResult> => {
-      const args = (ctx as { args?: Record<string, unknown> }).args ?? {};
+    execute: async (ctx): Promise<ToolResult> => {
+      const args = readAgenticArgs(ctx);
       const query = typeof args.query === "string" ? args.query : "";
-      const limit = typeof args.limit === "number" ? args.limit : 10;
+      const entityType =
+        args.entityType === "character" ||
+        args.entityType === "location" ||
+        args.entityType === "worldSetting"
+          ? args.entityType
+          : undefined;
 
       try {
-        const results = await deps.versionSearcher.searchVersions(ctx.documentId, query, limit);
-        return { success: true, data: results };
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: { code: "SEARCH_VERSIONS_FAILED", message } };
+        return {
+          success: true,
+          data: await deps.kgTool.query({
+            documentId: ctx.documentId,
+            query,
+            ...(entityType ? { entityType } : {}),
+            requestId: ctx.requestId,
+          }),
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          success: false,
+          error: { code: "KG_TOOL_FAILED", message },
+        };
       }
     },
   });
 }
 
-function createGetWordCountTool(deps: AgenticToolDeps): WritingTool {
+function buildMemTool(deps: AgenticToolDeps): WritingTool {
   return buildTool({
-    name: TOOL_NAME_GET_WORD_COUNT,
-    description: "Get the current word count and character count of the document",
+    name: "memTool",
+    description: "Query user writing preferences and semantic memory",
     isConcurrencySafe: true,
-    execute: async (ctx: ToolContext): Promise<ToolResult> => {
+    execute: async (ctx): Promise<ToolResult> => {
+      const args = readAgenticArgs(ctx);
+      const query = typeof args.query === "string" ? args.query : "";
+      const memoryType =
+        args.memoryType === "preference" ||
+        args.memoryType === "style" ||
+        args.memoryType === "rule"
+          ? args.memoryType
+          : undefined;
+
       try {
-        const result = await deps.wordCounter.getWordCount(ctx.documentId);
-        return { success: true, data: result };
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: { code: "WORD_COUNT_FAILED", message } };
+        return {
+          success: true,
+          data: await deps.memTool.query({
+            documentId: ctx.documentId,
+            query,
+            ...(memoryType ? { memoryType } : {}),
+            requestId: ctx.requestId,
+          }),
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          success: false,
+          error: { code: "MEM_TOOL_FAILED", message },
+        };
       }
     },
   });
 }
 
-// ─── Registration ───────────────────────────────────────────────────
+async function executeDocumentRead(args: {
+  ctx: ToolContext;
+  deps: AgenticToolDeps;
+  targetDocumentId: string;
+  responseKey: "content" | "text";
+}): Promise<ToolResult> {
+  const toolArgs = readAgenticArgs(args.ctx);
+  const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
+  const maxTokens =
+    typeof toolArgs.maxTokens === "number" ? toolArgs.maxTokens : undefined;
+  const snippetChars =
+    typeof toolArgs.snippetChars === "number" ? toolArgs.snippetChars : undefined;
 
-/**
- * Register all V1 read-only tools into the given registry.
- * Returns a cleanup function that unregisters all tools.
- */
+  try {
+    const result = await args.deps.documentReader.readDocument({
+      projectId: readProjectId(args.ctx),
+      documentId: args.targetDocumentId,
+      requestId: args.ctx.requestId,
+    });
+    const { snippet, truncated } = sliceSnippet({
+      text: result.text,
+      query,
+      maxTokens,
+      snippetChars,
+    });
+
+    return {
+      success: true,
+      data: {
+        [args.responseKey]: snippet,
+        documentId: args.targetDocumentId,
+        query,
+        truncated,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: {
+        code:
+          args.responseKey === "content" ? "DOC_TOOL_FAILED" : "DOCUMENT_READ_FAILED",
+        message,
+      },
+    };
+  }
+}
+
+function buildDocTool(deps: AgenticToolDeps): WritingTool {
+  return buildTool({
+    name: "docTool",
+    description: "Read a snippet of another document or chapter for context",
+    isConcurrencySafe: true,
+    execute: async (ctx) => {
+      const args = readAgenticArgs(ctx);
+      const documentId =
+        typeof args.documentId === "string" && args.documentId.trim().length > 0
+          ? args.documentId.trim()
+          : ctx.documentId;
+      return await executeDocumentRead({
+        ctx,
+        deps,
+        targetDocumentId: documentId,
+        responseKey: "content",
+      });
+    },
+  });
+}
+
+function buildDocumentReadTool(deps: AgenticToolDeps): WritingTool {
+  return buildTool({
+    name: "documentRead",
+    description: "Read the current document text with snippet budgeting",
+    isConcurrencySafe: true,
+    execute: async (ctx) =>
+      await executeDocumentRead({
+        ctx,
+        deps,
+        targetDocumentId: ctx.documentId,
+        responseKey: "text",
+      }),
+  });
+}
+
 export function registerAgenticTools(
   registry: ToolRegistry,
   deps: AgenticToolDeps,
 ): () => void {
   const tools = [
-    createReadDocumentSectionTool(deps),
-    createSearchVersionsTool(deps),
-    createGetWordCountTool(deps),
+    buildKgTool(deps),
+    buildMemTool(deps),
+    buildDocTool(deps),
+    buildDocumentReadTool(deps),
   ];
 
   for (const tool of tools) {
-    if (isToolBlocked(tool.name)) continue;
-    registry.register(tool);
+    if (!isToolBlocked(tool.name)) {
+      registry.register(tool);
+    }
   }
 
   return () => {
@@ -136,10 +302,3 @@ export function registerAgenticTools(
     }
   };
 }
-
-/** Names of all V1 agentic tools (for documentation/validation) */
-export const V1_TOOL_NAMES = [
-  TOOL_NAME_READ_SECTION,
-  TOOL_NAME_SEARCH_VERSIONS,
-  TOOL_NAME_GET_WORD_COUNT,
-] as const;

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -10,6 +10,7 @@
 
 import type { ToolRegistry } from "./toolRegistry";
 import type { StreamChunk, ToolCallInfo } from "../ai/streaming";
+import type { CostTracker } from "../ai/costTracker";
 import type { ToolUseHandler } from "./toolUseHandler";
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -53,6 +54,8 @@ export type WritingEventType =
   | "hooks-done"
   | "aborted"
   | "error"
+  | "budget-exceeded"
+  | "cost-recorded"
   // P2 Agentic Loop events
   | "tool-use-started"
   | "tool-use-completed"
@@ -121,6 +124,7 @@ export interface OrchestratorConfig {
   permissionGate: PermissionGate;
   postWritingHooks: PostWritingHook[];
   defaultTimeoutMs: number;
+  costTracker?: Pick<CostTracker, "checkBudget" | "recordUsage" | "getSessionCost">;
   /** P2: handler for Agentic Loop tool execution (read-only registry) */
   toolUseHandler?: ToolUseHandler;
   prepareRequest?: (request: WritingRequest) => Promise<PreparedRequest>;
@@ -282,7 +286,30 @@ export function createWritingOrchestrator(
           return;
         }
 
-         // Stage 4: AI streaming
+        const checkBudgetGuard = (): WritingEvent | null => {
+          const alert = config.costTracker?.checkBudget();
+          if (!alert || alert.kind !== "hard-stop") {
+            return null;
+          }
+          return makeEvent("budget-exceeded", requestId, {
+            currentCost: alert.currentCost,
+            hardStopLimit: alert.threshold,
+          });
+        };
+
+        const budgetExceeded = checkBudgetGuard();
+        if (budgetExceeded) {
+          taskStates.set(requestId, "failed");
+          yield budgetExceeded;
+          yield makeFailureEvent({
+            requestId,
+            code: "BUDGET_EXCEEDED",
+            message: "Budget hard-stop reached before AI execution",
+          });
+          return;
+        }
+
+          // Stage 4: AI streaming
         let fullText = "";
         let lastTokens = 0;
         let aiError: unknown = null;
@@ -523,6 +550,12 @@ export function createWritingOrchestrator(
               return;
             }
 
+            const roundBudgetExceeded = checkBudgetGuard();
+            if (roundBudgetExceeded) {
+              yield roundBudgetExceeded;
+              break;
+            }
+
             // Re-call AI with injected messages
             const nextChunkQueue: Array<{ delta: string; accumulatedTokens: number }> = [];
             let nextResult: GeneratedTextResult | undefined;
@@ -628,6 +661,27 @@ export function createWritingOrchestrator(
             totalTokens: tokenCount + lastTokens,
           },
         });
+
+        if (config.costTracker) {
+          const usage = {
+            promptTokens: tokenCount,
+            completionTokens: lastTokens,
+            totalTokens: tokenCount + lastTokens,
+          };
+          const requestCost = config.costTracker.recordUsage(
+            usage,
+            prepared.modelId,
+            requestId,
+            normalizeSkillId(request.skillId),
+          );
+          const summary = config.costTracker.getSessionCost();
+          const budgetAlert = config.costTracker.checkBudget() ?? undefined;
+          yield makeEvent("cost-recorded", requestId, {
+            requestCost: requestCost.cost,
+            sessionTotalCost: summary.totalCost,
+            ...(budgetAlert ? { budgetAlert } : {}),
+          });
+        }
 
         if (abortController.signal.aborted) {
           taskStates.set(requestId, "killed");

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -297,6 +297,36 @@ export function createWritingOrchestrator(
           });
         };
 
+        let totalPromptTokens = 0;
+        let totalCompletionTokens = 0;
+        const pendingCostEvents: WritingEvent[] = [];
+        const recordUsage = (usage: {
+          promptTokens: number;
+          completionTokens: number;
+          totalTokens: number;
+        }): void => {
+          totalPromptTokens += usage.promptTokens;
+          totalCompletionTokens += usage.completionTokens;
+
+          if (!config.costTracker) {
+            return;
+          }
+
+          const requestCost = config.costTracker.recordUsage(
+            usage,
+            prepared.modelId,
+            requestId,
+            normalizeSkillId(request.skillId),
+          );
+          const summary = config.costTracker.getSessionCost();
+          const budgetAlert = config.costTracker.checkBudget() ?? undefined;
+          pendingCostEvents.push(makeEvent("cost-recorded", requestId, {
+            requestCost: requestCost.cost,
+            sessionTotalCost: summary.totalCost,
+            ...(budgetAlert ? { budgetAlert } : {}),
+          }));
+        };
+
         const budgetExceeded = checkBudgetGuard();
         if (budgetExceeded) {
           taskStates.set(requestId, "failed");
@@ -318,6 +348,7 @@ export function createWritingOrchestrator(
         let aiSuccess = false;
         let lastFinishReason: "stop" | "tool_use" | null = null;
         let lastToolCalls: ToolCallInfo[] = [];
+        let lastPromptTokens = tokenCount;
 
         while (aiAttempt <= MAX_AI_RETRIES && !aiSuccess) {
           try {
@@ -400,6 +431,7 @@ export function createWritingOrchestrator(
               }
 
               fullText = generatedResult.fullText;
+              lastPromptTokens = generatedResult.usage.promptTokens;
               lastTokens = generatedResult.usage.completionTokens;
               lastFinishReason = generatedResult.finishReason ?? null;
               lastToolCalls = generatedResult.toolCalls ?? [];
@@ -433,6 +465,7 @@ export function createWritingOrchestrator(
                 });
               }
               lastFinishReason = streamFinishReason;
+              lastPromptTokens = tokenCount;
             }
 
             aiSuccess = true;
@@ -466,6 +499,12 @@ export function createWritingOrchestrator(
           });
           return;
         }
+
+        recordUsage({
+          promptTokens: lastPromptTokens,
+          completionTokens: lastTokens,
+          totalTokens: lastPromptTokens + lastTokens,
+        });
 
         // Stage 4.5 (P2): Agentic tool-use loop
         // Only runs when request.agenticLoop is true AND toolUseHandler is configured
@@ -618,9 +657,16 @@ export function createWritingOrchestrator(
             }
 
             fullText = nextResult.fullText || roundFullText;
+            lastPromptTokens = nextResult.usage.promptTokens;
             lastTokens = nextResult.usage.completionTokens;
             lastFinishReason = nextResult.finishReason ?? null;
             lastToolCalls = nextResult.toolCalls ?? [];
+
+            recordUsage({
+              promptTokens: lastPromptTokens,
+              completionTokens: lastTokens,
+              totalTokens: lastPromptTokens + lastTokens,
+            });
 
             const hasNextRound =
               lastFinishReason === "tool_use" && agenticRound < AGENTIC_MAX_ROUNDS;
@@ -656,31 +702,13 @@ export function createWritingOrchestrator(
         yield makeEvent("ai-done", requestId, {
           fullText,
           usage: {
-            promptTokens: tokenCount,
-            completionTokens: lastTokens,
-            totalTokens: tokenCount + lastTokens,
+            promptTokens: totalPromptTokens,
+            completionTokens: totalCompletionTokens,
+            totalTokens: totalPromptTokens + totalCompletionTokens,
           },
         });
-
-        if (config.costTracker) {
-          const usage = {
-            promptTokens: tokenCount,
-            completionTokens: lastTokens,
-            totalTokens: tokenCount + lastTokens,
-          };
-          const requestCost = config.costTracker.recordUsage(
-            usage,
-            prepared.modelId,
-            requestId,
-            normalizeSkillId(request.skillId),
-          );
-          const summary = config.costTracker.getSessionCost();
-          const budgetAlert = config.costTracker.checkBudget() ?? undefined;
-          yield makeEvent("cost-recorded", requestId, {
-            requestCost: requestCost.cost,
-            sessionTotalCost: summary.totalCost,
-            ...(budgetAlert ? { budgetAlert } : {}),
-          });
+        for (const costEvent of pendingCostEvents) {
+          yield costEvent;
         }
 
         if (abortController.signal.aborted) {

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -3,6 +3,10 @@ import type Database from "better-sqlite3";
 import type { Logger } from "../../logging/logger";
 import { createDocumentService } from "../documents/documentService";
 import type { VersionSnapshotReason } from "../documents/documentService";
+import { createKnowledgeGraphService } from "../kg/kgService";
+import type { KnowledgeGraphService } from "../kg/types";
+import { createMemoryService } from "../memory/memoryService";
+import type { MemoryService } from "../memory/memoryService";
 import { registerAgenticTools } from "./agenticTools";
 import { appendSuggestionToDocument } from "./documentWriteback";
 import { buildTool, createToolRegistry, type ToolRegistry } from "./toolRegistry";
@@ -11,6 +15,8 @@ import { applySuggestionToSelection } from "./selectionWriteback";
 type WritingToolingArgs = {
   db: Database.Database;
   logger: Logger;
+  kgService?: Pick<KnowledgeGraphService, "queryRelevant">;
+  memoryService?: Pick<MemoryService, "previewInjection">;
 };
 
 export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistry {
@@ -211,28 +217,91 @@ export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistr
 export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistry {
   const registry = createToolRegistry();
   const service = createDocumentService({ db: args.db, logger: args.logger });
+  const kgService =
+    args.kgService ??
+    createKnowledgeGraphService({
+      db: args.db,
+      logger: args.logger,
+    });
+  const memoryService =
+    args.memoryService ??
+    createMemoryService({
+      db: args.db,
+      logger: args.logger,
+    });
 
   registerAgenticTools(registry, {
     kgTool: {
-      query: async ({ query, entityType, requestId, documentId }) => {
+      query: async ({ query, entityType, requestId, documentId, projectId }) => {
         args.logger.info("agentic_tool_kg_query", {
           query,
           entityType,
           requestId,
           documentId,
         });
-        return { entities: [], query };
+        const scopedProjectId =
+          typeof projectId === "string" ? projectId.trim() : "";
+        if (scopedProjectId.length === 0 || query.trim().length === 0) {
+          return { entities: [], query };
+        }
+
+        const relevant = kgService.queryRelevant({
+          projectId: scopedProjectId,
+          excerpt: query,
+        });
+        if (!relevant.ok) {
+          args.logger.info("agentic_tool_kg_query_degraded", {
+            query,
+            entityType,
+            requestId,
+            documentId,
+            code: relevant.error.code,
+          });
+          return { entities: [], query };
+        }
+
+        const entities =
+          entityType === "character" || entityType === "location"
+            ? relevant.data.items.filter((item) => item.type === entityType)
+            : relevant.data.items;
+        return { entities, query };
       },
     },
     memTool: {
-      query: async ({ query, memoryType, requestId, documentId }) => {
+      query: async ({ query, memoryType, requestId, documentId, projectId }) => {
         args.logger.info("agentic_tool_mem_query", {
           query,
           memoryType,
           requestId,
           documentId,
         });
-        return { memories: [], query };
+        const scopedProjectId =
+          typeof projectId === "string" ? projectId.trim() : "";
+        if (scopedProjectId.length === 0) {
+          return { memories: [], query };
+        }
+
+        const preview = memoryService.previewInjection({
+          projectId: scopedProjectId,
+          documentId,
+          queryText: query,
+        });
+        if (!preview.ok) {
+          args.logger.info("agentic_tool_mem_query_degraded", {
+            query,
+            memoryType,
+            requestId,
+            documentId,
+            code: preview.error.code,
+          });
+          return { memories: [], query };
+        }
+
+        const memories =
+          memoryType === "preference"
+            ? preview.data.items.filter((item) => item.type === "preference")
+            : preview.data.items;
+        return { memories, query };
       },
     },
     documentReader: {

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -1,9 +1,9 @@
 import type Database from "better-sqlite3";
 
 import type { Logger } from "../../logging/logger";
-import { estimateTokens } from "../context/tokenEstimation";
 import { createDocumentService } from "../documents/documentService";
 import type { VersionSnapshotReason } from "../documents/documentService";
+import { registerAgenticTools } from "./agenticTools";
 import { appendSuggestionToDocument } from "./documentWriteback";
 import { buildTool, createToolRegistry, type ToolRegistry } from "./toolRegistry";
 import { applySuggestionToSelection } from "./selectionWriteback";
@@ -12,55 +12,6 @@ type WritingToolingArgs = {
   db: Database.Database;
   logger: Logger;
 };
-
-function readAgenticArgs(ctx: Record<string, unknown>): Record<string, unknown> {
-  const args = ctx.args;
-  if (!args || typeof args !== "object" || Array.isArray(args)) {
-    return {};
-  }
-  return args as Record<string, unknown>;
-}
-
-function sliceSnippet(args: {
-  text: string;
-  query?: string;
-  snippetChars?: number;
-  maxTokens?: number;
-}): string {
-  const normalized = args.text.trim();
-  if (normalized.length === 0) {
-    return "";
-  }
-
-  const tokenBound =
-    typeof args.maxTokens === "number" &&
-    Number.isFinite(args.maxTokens) &&
-    args.maxTokens > 0
-      ? Math.max(1, Math.floor(args.maxTokens) * 4)
-      : normalized.length;
-  const charBound =
-    typeof args.snippetChars === "number" &&
-    Number.isFinite(args.snippetChars) &&
-    args.snippetChars > 0
-      ? Math.max(1, Math.floor(args.snippetChars))
-      : normalized.length;
-  const limit = Math.min(normalized.length, tokenBound, charBound);
-  const query = args.query?.trim() ?? "";
-  if (query.length === 0) {
-    return normalized.slice(0, limit);
-  }
-
-  const hitIndex = normalized.indexOf(query);
-  if (hitIndex < 0) {
-    return normalized.slice(0, limit);
-  }
-
-  const leftBudget = Math.max(0, Math.floor((limit - query.length) / 2));
-  const start = Math.max(0, hitIndex - leftBudget);
-  const end = Math.min(normalized.length, start + limit);
-  const alignedStart = Math.max(0, end - limit);
-  return normalized.slice(alignedStart, end);
-}
 
 export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistry {
   const registry = createToolRegistry();
@@ -261,169 +212,52 @@ export function createAgenticToolRegistry(args: WritingToolingArgs): ToolRegistr
   const registry = createToolRegistry();
   const service = createDocumentService({ db: args.db, logger: args.logger });
 
-  // kgTool: query knowledge graph
-  // P2 stub — returns empty result when KG data is unavailable
-  registry.register(
-    buildTool({
-      name: "kgTool",
-      description: "Query the knowledge graph for character traits, locations, and world settings",
-      isConcurrencySafe: true,
-      execute: async (ctx) => {
-        const toolArgs = readAgenticArgs(ctx);
-        const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
-        args.logger.info("agentic_tool_kg_query", { query, requestId: ctx.requestId });
-        // P2 stub: KG module not yet implemented, return empty
-        return {
-          success: true,
-          data: { entities: [], query },
-        };
+  registerAgenticTools(registry, {
+    kgTool: {
+      query: async ({ query, entityType, requestId, documentId }) => {
+        args.logger.info("agentic_tool_kg_query", {
+          query,
+          entityType,
+          requestId,
+          documentId,
+        });
+        return { entities: [], query };
       },
-    }),
-  );
-
-  // memTool: query writing memory
-  // P2 stub — returns empty memories when Memory module is unavailable
-  registry.register(
-    buildTool({
-      name: "memTool",
-      description: "Query writing memory for style preferences and past writing patterns",
-      isConcurrencySafe: true,
-      execute: async (ctx) => {
-        const toolArgs = readAgenticArgs(ctx);
-        const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
-        args.logger.info("agentic_tool_mem_query", { query, requestId: ctx.requestId });
-        // P2 stub: Memory module not yet fully implemented, return empty
-        return {
-          success: true,
-          data: { memories: [], query },
-        };
+    },
+    memTool: {
+      query: async ({ query, memoryType, requestId, documentId }) => {
+        args.logger.info("agentic_tool_mem_query", {
+          query,
+          memoryType,
+          requestId,
+          documentId,
+        });
+        return { memories: [], query };
       },
-    }),
-  );
-
-  // docTool: read document content
-  registry.register(
-    buildTool({
-      name: "docTool",
-      description: "Read the content of a document or chapter for context",
-      isConcurrencySafe: true,
-      execute: async (ctx) => {
-        const toolArgs = readAgenticArgs(ctx);
-        const targetDocId =
-          typeof toolArgs.documentId === "string" && toolArgs.documentId.trim().length > 0
-            ? toolArgs.documentId.trim()
-            : ctx.documentId;
-        const projectId =
-          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
-        const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
-        const maxTokens =
-          typeof toolArgs.maxTokens === "number" ? toolArgs.maxTokens : undefined;
-        const snippetChars =
-          typeof toolArgs.snippetChars === "number"
-            ? toolArgs.snippetChars
-            : undefined;
-
+    },
+    documentReader: {
+      readDocument: async ({ projectId, documentId, requestId }) => {
         if (!projectId) {
-          return {
-            success: true,
-            data: { content: "", documentId: targetDocId, query, truncated: false },
-          };
+          return { documentId, text: "" };
         }
 
-        const result = service.read({ projectId, documentId: targetDocId });
+        const result = service.read({ projectId, documentId });
         if (!result.ok) {
-          return {
-            success: false,
-            error: { code: result.error.code, message: result.error.message },
-          };
+          throw new Error(result.error.message);
         }
 
+        args.logger.info("agentic_tool_doc_read", {
+          documentId,
+          projectId,
+          requestId,
+        });
         return {
-          success: true,
-          data: {
-            content: sliceSnippet({
-              text: result.data.contentText,
-              query,
-              maxTokens,
-              snippetChars,
-            }),
-            documentId: targetDocId,
-            query,
-            truncated:
-              estimateTokens(result.data.contentText) >
-              estimateTokens(
-                sliceSnippet({
-                  text: result.data.contentText,
-                  query,
-                  maxTokens,
-                  snippetChars,
-                }),
-              ),
-          },
+          documentId,
+          text: result.data.contentText,
         };
       },
-    }),
-  );
-
-  // documentRead: read document text (P1 built-in, agentic-accessible)
-  registry.register(
-    buildTool({
-      name: "documentRead",
-      description: "Read the raw text of the current document",
-      isConcurrencySafe: true,
-      execute: async (ctx) => {
-        const projectId =
-          typeof ctx["projectId"] === "string" ? ctx["projectId"].trim() : "";
-        const toolArgs = readAgenticArgs(ctx);
-        const query = typeof toolArgs.query === "string" ? toolArgs.query : "";
-        const maxTokens =
-          typeof toolArgs.maxTokens === "number" ? toolArgs.maxTokens : undefined;
-        const snippetChars =
-          typeof toolArgs.snippetChars === "number"
-            ? toolArgs.snippetChars
-            : undefined;
-
-        if (!projectId) {
-          return {
-            success: true,
-            data: { text: "", documentId: ctx.documentId, query, truncated: false },
-          };
-        }
-
-        const result = service.read({ projectId, documentId: ctx.documentId });
-        if (!result.ok) {
-          return {
-            success: false,
-            error: { code: result.error.code, message: result.error.message },
-          };
-        }
-
-        return {
-          success: true,
-          data: {
-            text: sliceSnippet({
-              text: result.data.contentText,
-              query,
-              maxTokens,
-              snippetChars,
-            }),
-            documentId: ctx.documentId,
-            query,
-            truncated:
-              estimateTokens(result.data.contentText) >
-              estimateTokens(
-                sliceSnippet({
-                  text: result.data.contentText,
-                  query,
-                  maxTokens,
-                  snippetChars,
-                }),
-              ),
-          },
-        };
-      },
-    }),
-  );
+    },
+  });
 
   return registry;
 }

--- a/apps/desktop/preload/src/aiStreamBridge.ts
+++ b/apps/desktop/preload/src/aiStreamBridge.ts
@@ -13,6 +13,7 @@ import {
   type JudgeResultEvent,
 } from "@shared/types/judge";
 import type { IpcResponse } from "@shared/types/ipc-generated";
+import { COST_ALERT_CHANNEL, type CostAlertEvent } from "@shared/types/cost";
 import { createAiStreamSubscriptionRegistry } from "./aiStreamSubscriptions";
 
 type UnknownRecord = Record<string, unknown>;
@@ -138,6 +139,20 @@ function isJudgeResultEvent(x: unknown): x is JudgeResultEvent {
   );
 }
 
+function isCostAlertEvent(x: unknown): x is CostAlertEvent {
+  if (!isRecord(x)) {
+    return false;
+  }
+
+  return (
+    (x.kind === "warning" || x.kind === "hard-stop") &&
+    typeof x.currentCost === "number" &&
+    typeof x.threshold === "number" &&
+    typeof x.message === "string" &&
+    typeof x.timestamp === "number"
+  );
+}
+
 
 export type AiStreamBridgeApi = {
   registerAiStreamConsumer: () => IpcResponse<{ subscriptionId: string }>;
@@ -217,12 +232,27 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
       }),
     );
   };
+  const onCostAlert = (_evt: unknown, payload: unknown) => {
+    if (subscriptions.count() === 0) {
+      return;
+    }
+    if (!isCostAlertEvent(payload)) {
+      return;
+    }
+
+    window.dispatchEvent(
+      new CustomEvent<CostAlertEvent>(COST_ALERT_CHANNEL, {
+        detail: payload,
+      }),
+    );
+  };
 
   ipcRenderer.on(SKILL_STREAM_CHUNK_CHANNEL, onSkillStreamChunk);
   ipcRenderer.on(SKILL_STREAM_DONE_CHANNEL, onSkillStreamDone);
   ipcRenderer.on(SKILL_QUEUE_STATUS_CHANNEL, onSkillQueueStatus);
   ipcRenderer.on(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
   ipcRenderer.on(JUDGE_RESULT_CHANNEL, onJudgeResult);
+  ipcRenderer.on(COST_ALERT_CHANNEL, onCostAlert);
 
   return {
     registerAiStreamConsumer: () => subscriptions.register(),
@@ -241,6 +271,7 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
       );
       ipcRenderer.removeListener(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
       ipcRenderer.removeListener(JUDGE_RESULT_CHANNEL, onJudgeResult);
+      ipcRenderer.removeListener(COST_ALERT_CHANNEL, onCostAlert);
     },
   };
 }

--- a/apps/desktop/tests/integration/context/context-backpressure-redaction.test.ts
+++ b/apps/desktop/tests/integration/context/context-backpressure-redaction.test.ts
@@ -100,6 +100,12 @@ function createDeferred<T>(): Deferred<T> {
         capacityPercent: 0.2,
         layers: {
           rules: { source: ["kg:entities"], tokenCount: 3, truncated: false },
+          compressedHistory: {
+            source: ["compressed-history"],
+            tokenCount: 0,
+            truncated: false,
+            compressed: false,
+          },
           immediate: {
             source: ["editor:cursor-window"],
             tokenCount: 9,
@@ -117,6 +123,13 @@ function createDeferred<T>(): Deferred<T> {
           source: [],
           tokenCount: 0,
           truncated: false,
+        },
+        compressedHistory: {
+          content: "",
+          source: ["compressed-history"],
+          tokenCount: 0,
+          truncated: false,
+          compressed: false,
         },
         immediate: {
           content: "",

--- a/packages/shared/types/cost.ts
+++ b/packages/shared/types/cost.ts
@@ -1,0 +1,9 @@
+export const COST_ALERT_CHANNEL = "cost:alert" as const;
+
+export type CostAlertEvent = {
+  kind: "warning" | "hard-stop";
+  currentCost: number;
+  threshold: number;
+  message: string;
+  timestamp: number;
+};

--- a/packages/shared/types/ipc-generated.ts
+++ b/packages/shared/types/ipc-generated.ts
@@ -173,6 +173,10 @@ export const IPC_CHANNELS = [
   "context:settings:read",
   "context:watch:start",
   "context:watch:stop",
+  "cost:budget:get",
+  "cost:budget:update",
+  "cost:pricing:get",
+  "cost:pricing:update",
   "cost:usage:list",
   "cost:usage:summary",
   "db:debug:tablenames",
@@ -889,7 +893,16 @@ export type IpcChannelSpec = {
     };
     response: {
       capacityPercent: number;
+      compressionApplied?: boolean;
       layers: {
+        compressedHistory: {
+          compressed: boolean;
+          compressionRatio?: number;
+          source: Array<string>;
+          tokenCount: number;
+          truncated: boolean;
+          warnings?: Array<string>;
+        };
         immediate: {
           source: Array<string>;
           tokenCount: number;
@@ -931,6 +944,15 @@ export type IpcChannelSpec = {
         requestedBy: string;
       };
       layersDetail: {
+        compressedHistory: {
+          compressed: boolean;
+          compressionRatio?: number;
+          content: string;
+          source: Array<string>;
+          tokenCount: number;
+          truncated: boolean;
+          warnings?: Array<string>;
+        };
         immediate: {
           content: string;
           source: Array<string>;
@@ -1024,6 +1046,76 @@ export type IpcChannelSpec = {
     };
     response: {
       watching: false;
+    };
+  };
+  "cost:budget:get": {
+    request: Record<string, never>;
+    response: {
+      enabled: boolean;
+      hardStopLimit: number;
+      warningThreshold: number;
+    };
+  };
+  "cost:budget:update": {
+    request: {
+      enabled: boolean;
+      hardStopLimit: number;
+      warningThreshold: number;
+    };
+    response: {
+      enabled: boolean;
+      hardStopLimit: number;
+      warningThreshold: number;
+    };
+  };
+  "cost:pricing:get": {
+    request: Record<string, never>;
+    response: {
+      currency: "USD";
+      lastUpdated: string;
+      prices: Record<
+        string,
+        {
+          cachedInputPricePer1K?: number;
+          displayName: string;
+          effectiveDate: string;
+          inputPricePer1K: number;
+          modelId: string;
+          outputPricePer1K: number;
+        }
+      >;
+    };
+  };
+  "cost:pricing:update": {
+    request: {
+      currency: "USD";
+      lastUpdated: string;
+      prices: Record<
+        string,
+        {
+          cachedInputPricePer1K?: number;
+          displayName: string;
+          effectiveDate: string;
+          inputPricePer1K: number;
+          modelId: string;
+          outputPricePer1K: number;
+        }
+      >;
+    };
+    response: {
+      currency: "USD";
+      lastUpdated: string;
+      prices: Record<
+        string,
+        {
+          cachedInputPricePer1K?: number;
+          displayName: string;
+          effectiveDate: string;
+          inputPricePer1K: number;
+          modelId: string;
+          outputPricePer1K: number;
+        }
+      >;
     };
   };
   "cost:usage:list": {


### PR DESCRIPTION
## Summary
- replace DiffEngine prefix/suffix single-block logic with granular multi-hunk diff steps
- wire spec-aligned `kgTool` / `memTool` / `docTool` / `documentRead` into the production agentic registry path
- integrate `compressed-history` + `compressionApplied` into real context assembly and close cost tracking runtime + IPC surfaces

Closes #66

## Validation Evidence
- `pnpm typecheck`
- `pnpm contract:check`
- `pnpm -C apps/desktop test:run`
- Focused: `pnpm -C apps/desktop exec vitest run --config vitest.config.core.ts main/src/services/diff/__tests__/DiffEngine.test.ts main/src/services/skills/__tests__/agentic-tools.test.ts main/src/services/context/__tests__/layerAssemblyService.contract-regression.test.ts main/src/services/skills/__tests__/writing-orchestrator.test.ts main/src/ipc/__tests__/cost-ipc.test.ts main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts`

## Visual Evidence
### Embedded Screenshots
N/A

### Storybook Artifact / Link
- Link: N/A
- Visual acceptance note: N/A

## Risk & Rollback
- Risk: context assembly now emits a new `compressedHistory` surface and cost IPC adds new channels; downstream callers that mocked the old shape had to be updated in tests.
- Rollback: revert this PR to restore the previous P1-only context surface, old diff behavior, and the read-only cost-query implementation.

## Audit Gate
- `scripts/agent_pr_preflight.sh`: PASS
- Required checks: GREEN (4/4 successful via `gh pr checks 67`)
- No renderer/storybook changes in this PR; the preflight N/A branch applies.
