### PR TITLE
feat(ai/compact): narrative-aware AutoCompact (INV-5)

### DIFF
--- a/apps/desktop/main/src/__tests__/preload/aiStreamBridge.context-compact-circuit-breaker.test.ts
+++ b/apps/desktop/main/src/__tests__/preload/aiStreamBridge.context-compact-circuit-breaker.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL } from "@shared/types/ai";
+
+const listeners = new Map<string, (event: unknown, payload: unknown) => void>();
+const dispatchEvent = vi.fn();
+
+vi.mock("electron", () => ({
+  ipcRenderer: {
+    on: vi.fn((channel: string, listener: (event: unknown, payload: unknown) => void) => {
+      listeners.set(channel, listener);
+    }),
+    removeListener: vi.fn((channel: string) => {
+      listeners.delete(channel);
+    }),
+  },
+}));
+
+describe("registerAiStreamBridge context compact circuit-breaker bridge", () => {
+  beforeEach(() => {
+    listeners.clear();
+    dispatchEvent.mockReset();
+    Object.defineProperty(globalThis, "window", {
+      value: { dispatchEvent },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "CustomEvent", {
+      value: class CustomEvent<T> {
+        type: string;
+        detail: T;
+        constructor(type: string, init: { detail: T }) {
+          this.type = type;
+          this.detail = init.detail;
+        }
+      },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "process", {
+      value: { pid: 1003 },
+      configurable: true,
+    });
+  });
+
+  it("将 main 发出的 context compact circuit-breaker 事件校验后转发到 renderer CustomEvent", async () => {
+    const { registerAiStreamBridge } = await import("../../../../preload/src/aiStreamBridge");
+    const bridge = registerAiStreamBridge();
+    const registered = bridge.registerAiStreamConsumer();
+    expect(registered.ok).toBe(true);
+
+    const event = {
+      open: true,
+      consecutiveFailures: 3,
+      openedAt: 1_735_000_000_000,
+      cooldownMs: 300_000,
+      reason: "threshold-reached",
+    };
+
+    listeners.get(CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL)?.({}, event);
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0]?.[0]?.type).toBe(
+      CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
+    );
+    expect(dispatchEvent.mock.calls[0]?.[0]?.detail).toEqual(event);
+
+    bridge.dispose();
+  });
+});

--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -455,6 +455,23 @@ function registerIpcHandlers(deps: {
     secretStorage,
     projectSessionBinding,
     costTracker,
+    onAutoCompactCircuitBreakerStateChange: (payload) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        try {
+          win.webContents.send(payload.channel, {
+            open: payload.open,
+            consecutiveFailures: payload.consecutiveFailures,
+            openedAt: payload.openedAt,
+            cooldownMs: payload.cooldownMs,
+            reason: payload.reason,
+          });
+        } catch (error) {
+          deps.logger.error("context_compact_circuit_breaker_notify_failed", {
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    },
   });
 
   registerAiProxyIpcHandlers({

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts
@@ -191,7 +191,7 @@ describe("ai:skill:run cursor propagation regression", () => {
     vi.restoreAllMocks();
   });
 
-  it("builtin:continue 显式 cursorPosition 会同时透传给 prepareRequest 与 skillExecutor 的 context assembly", async () => {
+  it("builtin:continue 显式 cursorPosition 会透传给 prepareRequest 的 context assembly", async () => {
     const harness = createHarness();
     opened.push(harness.db);
     const { projectId, documentId } = createProjectAndDocument({
@@ -217,23 +217,11 @@ describe("ai:skill:run cursor propagation regression", () => {
 
     expect(run.ok).toBe(true);
     expect(run.data?.status).toBe("preview");
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     expect(assembleSpy.mock.calls.map(([request]) => request.cursorPosition)).toEqual([
-      3,
       3,
     ]);
     expect(assembleSpy.mock.calls).toEqual([
-      [
-        expect.objectContaining({
-          projectId,
-          documentId,
-          cursorPosition: 3,
-          skillId: "builtin:continue",
-          additionalInput: "甲乙丙丁",
-          provider: "ai-service",
-          model: "gpt-5.2",
-        }),
-      ],
       [
         expect.objectContaining({
           projectId,
@@ -272,8 +260,7 @@ describe("ai:skill:run cursor propagation regression", () => {
     });
 
     // PM pos 3 in single-para doc "甲乙丙丁" → text offset 2 (after 乙)
-    // Both calls (prepareRequest + skillExecutor) must receive textOffset=2
-    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([2, 2]);
+    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([2]);
   });
 
   it("builtin:continue 保留 leading whitespace 的 anchor：PM pos 4 → textOffset 3", async () => {
@@ -296,7 +283,7 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3, 3]);
+    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3]);
   });
 
   it("builtin:continue 跨段落时会把 deriveContent 的换行计入 textOffset", async () => {
@@ -333,7 +320,7 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3, 3]);
+    expect(assembleSpy.mock.calls.map(([request]) => request.textOffset)).toEqual([3]);
   });
 
   // RED→GREEN regression: Audit-B BLOCKING FINDING — selection skills (polish/rewrite) must
@@ -419,11 +406,9 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    // Both prepareRequest and generateText/skillExecutor assemble calls must use precedingText
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     const additionalInputs = assembleSpy.mock.calls.map((args: unknown[]) => (args[0] as { additionalInput: unknown }).additionalInput);
     expect(additionalInputs).toEqual([
-      "夜幕降临，街灯次第亮起。",
       "夜幕降临，街灯次第亮起。",
     ]);
   });
@@ -457,7 +442,7 @@ describe("ai:skill:run cursor propagation regression", () => {
     });
 
     // Selection skill: additionalInput must come from `input`, not `precedingText`
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     const additionalInputs = assembleSpy.mock.calls.map((args: unknown[]) => (args[0] as { additionalInput: unknown }).additionalInput);
     expect(additionalInputs.every((ai: unknown) => ai === selectionText)).toBe(true);
   });
@@ -486,7 +471,7 @@ describe("ai:skill:run cursor propagation regression", () => {
       stream: false,
     });
 
-    expect(assembleSpy).toHaveBeenCalledTimes(2);
+    expect(assembleSpy).toHaveBeenCalledTimes(1);
     // Neither call may receive empty-string additionalInput when precedingText is non-empty
     const additionalInputs = assembleSpy.mock.calls.map((args: unknown[]) => (args[0] as { additionalInput: unknown }).additionalInput);
     expect(additionalInputs.every((ai: unknown) => typeof ai === "string" && ai.length > 0)).toBe(true);

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
@@ -65,7 +65,11 @@ vi.mock("../../services/stats/statsService", () => ({
   })),
 }));
 
-import { prepareWritingRequest, registerAiIpcHandlers } from "../ai";
+import {
+  containsNarrativeSummaryTokenLimitMarker,
+  prepareWritingRequest,
+  registerAiIpcHandlers,
+} from "../ai";
 
 type Handler = (event: { sender: { id: number; send: (channel: string, payload: unknown) => void } }, payload: unknown) => Promise<unknown>;
 
@@ -78,6 +82,22 @@ function createLogger() {
 }
 
 describe("ai:skill:run selection contract", () => {
+  it("detects narrative summary token limit marker by deterministic prefix only", () => {
+    expect(
+      containsNarrativeSummaryTokenLimitMarker(
+        "history\n[NARRATIVE_SUMMARY_TOKEN_LIMIT]:220 任意后缀文案",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when marker prefix is absent", () => {
+    expect(
+      containsNarrativeSummaryTokenLimitMarker(
+        "history\n请将摘要控制在约 220 tokens 以内。",
+      ),
+    ).toBe(false);
+  });
+
   it("escapes selection prompt delimiters on the first-round ai.ts assembly path", async () => {
     const prepared = await prepareWritingRequest({
       ctx: {

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import type { IpcMain } from "electron";
 import type Database from "better-sqlite3";
 
-const { orchestratorExecuteSpy } = vi.hoisted(() => ({
+const {
+  orchestratorExecuteSpy,
+  createWritingOrchestratorSpy,
+  createKnowledgeGraphServiceSpy,
+} = vi.hoisted(() => ({
   orchestratorExecuteSpy: vi.fn(),
+  createWritingOrchestratorSpy: vi.fn(),
+  createKnowledgeGraphServiceSpy: vi.fn(),
 }));
 
 vi.mock("../../services/skills/skillExecutor", () => ({
@@ -14,7 +20,7 @@ vi.mock("../../services/skills/skillExecutor", () => ({
 
 vi.mock("../../services/skills/orchestrator", () => ({
   AGENTIC_MAX_ROUNDS: 5,
-  createWritingOrchestrator: vi.fn(() => ({
+  createWritingOrchestrator: createWritingOrchestratorSpy.mockImplementation(() => ({
     execute: orchestratorExecuteSpy,
     abort: vi.fn(),
     dispose: vi.fn(),
@@ -50,7 +56,7 @@ vi.mock("../../services/context/layerAssemblyService", () => ({
 }));
 
 vi.mock("../../services/kg/kgService", () => ({
-  createKnowledgeGraphService: vi.fn(() => ({})),
+  createKnowledgeGraphService: createKnowledgeGraphServiceSpy,
 }));
 
 vi.mock("../../services/stats/statsService", () => ({
@@ -167,6 +173,7 @@ describe("ai:skill:run selection contract", () => {
 
     expect(prepared.ok).toBe(true);
     if (prepared.ok) {
+      expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("LIMIT 200"));
       expect(prepared.data.messages).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -179,6 +186,67 @@ describe("ai:skill:run selection contract", () => {
           }),
         ]),
       );
+    }
+  });
+
+  it("prepareWritingRequest trims history by token budget while keeping system+current user", async () => {
+    vi.stubEnv("CREONOW_AI_CHAT_HISTORY_TOKEN_BUDGET", "1");
+    const db = {
+      prepare: vi.fn().mockReturnValue({
+        all: vi.fn().mockReturnValue([
+          { role: "assistant", content: "非常长的历史消息".repeat(40) },
+          { role: "user", content: "更长的历史消息".repeat(40) },
+        ]),
+      }),
+    } as unknown as Database.Database;
+
+    try {
+      const prepared = await prepareWritingRequest({
+        ctx: {
+          deps: {
+            db,
+            logger: createLogger(),
+          },
+          contextAssemblyService: {
+            assemble: vi.fn(),
+          },
+          skillServiceFactory: () => ({
+            resolveForRun: () => ({
+              ok: false,
+              error: { code: "NOT_FOUND", message: "missing", retryable: false },
+            }),
+          }),
+        } as never,
+        payload: {
+          skillId: "builtin:rewrite",
+          hasSelection: true,
+          input: "旧 input",
+          userInstruction: "保持文风",
+          mode: "ask",
+          model: "gpt-4.1-mini",
+          context: {
+            projectId: "proj-1",
+            documentId: "doc-1",
+            sessionId: "sess-1",
+          },
+          selection: {
+            from: 1,
+            to: 3,
+            text: "正文",
+            selectionTextHash: "hash",
+          },
+          stream: false,
+        },
+      });
+
+      expect(prepared.ok).toBe(true);
+      if (prepared.ok) {
+        expect(prepared.data.messages).toHaveLength(2);
+        expect(prepared.data.messages[0]?.role).toBe("system");
+        expect(prepared.data.messages[1]?.role).toBe("user");
+      }
+    } finally {
+      vi.unstubAllEnvs();
     }
   });
 
@@ -283,5 +351,122 @@ describe("ai:skill:run selection contract", () => {
         selection,
       }),
     );
+  });
+
+  it("getAutoCompactSnapshot returns deduped narrative snapshot from KG service", async () => {
+    createWritingOrchestratorSpy.mockClear();
+    createKnowledgeGraphServiceSpy.mockReturnValue({
+      entityList: vi.fn().mockReturnValue({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: "e1",
+              projectId: "proj-1",
+              type: "character",
+              name: "林远",
+              description: "守塔人",
+              attributes: {
+                trait: "谨慎",
+                tone: "冷峻",
+                narrativePOV: "第一人称",
+                timeline: "入夜",
+              },
+              lastSeenState: "三天后揭示真相",
+              aiContextLevel: "always",
+              aliases: [],
+              version: 1,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+            {
+              id: "e2",
+              projectId: "proj-1",
+              type: "location",
+              name: "白塔",
+              description: "",
+              attributes: {},
+              lastSeenState: "",
+              aiContextLevel: "always",
+              aliases: [],
+              version: 1,
+              createdAt: "2024-01-01",
+              updatedAt: "2024-01-01",
+            },
+          ],
+          totalCount: 2,
+        },
+      }),
+      relationList: vi.fn().mockReturnValue({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: "r1",
+              projectId: "proj-1",
+              sourceEntityId: "e1",
+              targetEntityId: "e2",
+              relationType: "守护",
+              description: "白塔钟声来源未揭示",
+              createdAt: "2024-01-01",
+            },
+          ],
+          totalCount: 1,
+        },
+      }),
+    });
+
+    const handlers = new Map<string, Handler>();
+    const ipcMain = {
+      handle: (channel: string, listener: Handler) => {
+        handlers.set(channel, listener);
+      },
+    } as unknown as IpcMain;
+
+    registerAiIpcHandlers({
+      ipcMain,
+      db: {} as Database.Database,
+      userDataDir: "<test-user-data>",
+      builtinSkillsDir: "<test-skills>",
+      logger: createLogger(),
+      env: process.env,
+    });
+
+    const orchestratorConfig = createWritingOrchestratorSpy.mock.calls[0]?.[0] as
+      | {
+          getAutoCompactSnapshot?: (args: {
+            request: { projectId?: string; documentId?: string; requestId?: string };
+          }) => Promise<{
+            entities: string[];
+            relations: string[];
+            characterSettings: string[];
+            unresolvedPlotPoints: string[];
+            toneMarkers?: string[];
+            narrativePOV?: string;
+            foreshadowingClues?: string[];
+            timelineMarkers?: string[];
+            userConstraints?: string[];
+          }>;
+        }
+      | undefined;
+    expect(orchestratorConfig?.getAutoCompactSnapshot).toBeDefined();
+
+    const snapshot = await orchestratorConfig!.getAutoCompactSnapshot!({
+      request: { projectId: "proj-1", documentId: "doc-1", requestId: "req-1" },
+    });
+    expect(snapshot).toEqual({
+      entities: ["林远", "白塔"],
+      relations: ["林远 -> 白塔: 守护 (白塔钟声来源未揭示)"],
+      characterSettings: ["林远: 守塔人；trait=谨慎；tone=冷峻；narrativePOV=第一人称；timeline=入夜"],
+      unresolvedPlotPoints: ["林远: 三天后揭示真相"],
+      toneMarkers: ["冷峻"],
+      narrativePOV: "第一人称",
+      foreshadowingClues: [
+        "林远: 三天后揭示真相",
+        "林远 -> 白塔: 守护 (白塔钟声来源未揭示)",
+      ],
+      timelineMarkers: ["入夜", "三天后揭示真相"],
+      userConstraints: [],
+    });
   });
 });

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
@@ -117,6 +117,71 @@ describe("ai:skill:run selection contract", () => {
     }
   });
 
+  it("prepareWritingRequest includes prior session messages when sessionId is provided", async () => {
+    const db = {
+      prepare: vi.fn().mockReturnValue({
+        all: vi.fn().mockReturnValue([
+          { role: "user", content: "上一轮：描述白塔城" },
+          { role: "assistant", content: "上一轮回答：白塔城终年雾海" },
+        ]),
+      }),
+    } as unknown as Database.Database;
+
+    const prepared = await prepareWritingRequest({
+      ctx: {
+        deps: {
+          db,
+          logger: createLogger(),
+        },
+        contextAssemblyService: {
+          assemble: vi.fn(),
+        },
+        skillServiceFactory: () => ({
+          resolveForRun: () => ({
+            ok: false,
+            error: { code: "NOT_FOUND", message: "missing", retryable: false },
+          }),
+        }),
+      } as never,
+      payload: {
+        skillId: "builtin:rewrite",
+        hasSelection: true,
+        input: "旧 input",
+        userInstruction: "保持文风",
+        mode: "ask",
+        model: "gpt-4.1-mini",
+        context: {
+          projectId: "proj-1",
+          documentId: "doc-1",
+          sessionId: "sess-1",
+        },
+        selection: {
+          from: 1,
+          to: 3,
+          text: "正文",
+          selectionTextHash: "hash",
+        },
+        stream: false,
+      },
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (prepared.ok) {
+      expect(prepared.data.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: "上一轮：描述白塔城",
+          }),
+          expect.objectContaining({
+            role: "assistant",
+            content: "上一轮回答：白塔城终年雾海",
+          }),
+        ]),
+      );
+    }
+  });
+
   it("forwards full SelectionRef into the main-process execution seam", async () => {
     orchestratorExecuteSpy.mockReset();
     orchestratorExecuteSpy.mockImplementation(async function* () {

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
@@ -461,10 +461,7 @@ describe("ai:skill:run selection contract", () => {
       unresolvedPlotPoints: ["林远: 三天后揭示真相"],
       toneMarkers: ["冷峻"],
       narrativePOV: "第一人称",
-      foreshadowingClues: [
-        "林远: 三天后揭示真相",
-        "林远 -> 白塔: 守护 (白塔钟声来源未揭示)",
-      ],
+      foreshadowingClues: ["林远 -> 白塔: 守护 (白塔钟声来源未揭示)"],
       timelineMarkers: ["入夜", "三天后揭示真相"],
       userConstraints: [],
     });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1582,7 +1582,10 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         });
 
         const narrativeCompact = createNarrativeCompact({
-          invokeSkillSummary: async ({ skillId, modelId, input }) => {
+          invokeSkillSummary: async (request) => {
+            const { skillId, modelId, input } = request;
+            // summaryMaxTokens is enforced in narrativeCompact prompt instructions
+            // because runSkill does not expose an output maxTokens parameter.
             const result = await aiService.runSkill({
               skillId,
               input,

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -18,6 +18,7 @@ import type { Logger } from "../logging/logger";
 import { createIpcPushBackpressureGate } from "./pushBackpressure";
 import { createAiService } from "../services/ai/aiService";
 import { createAiServiceBridge } from "../services/ai/aiServiceBridge";
+import { createModelConfigService } from "../services/ai/modelConfig";
 import { createSqliteTraceStore } from "../services/ai/traceStore";
 import { resolveRuntimeGovernanceFromEnv } from "../config/runtimeGovernance";
 import {
@@ -74,6 +75,11 @@ import { createDocumentCoreService } from "../services/documents/documentCoreSer
 import { createVersionWorkflowService } from "../services/documents/versionService";
 import { editorSchema } from "../services/editor/prosemirrorSchema";
 import type { CostTracker } from "../services/ai/costTracker";
+import {
+  createAutoCompact,
+  createCompactConfig,
+  createNarrativeCompact,
+} from "../services/ai/compact";
 
 /**
  * Convert a ProseMirror document position to a plain-text character offset.
@@ -1509,6 +1515,63 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       }
     }
   }
+
+  const autoCompactService =
+    deps.db !== null &&
+    typeof (deps.db as { prepare?: unknown }).prepare === "function"
+    ? (() => {
+        const modelConfigService = createModelConfigService({
+          db: deps.db,
+          logger: deps.logger,
+        });
+        const resolvedModelConfig = modelConfigService.resolve();
+        if (!resolvedModelConfig.ok) {
+          deps.logger.info("auto_compact_disabled_model_config", {
+            reason: resolvedModelConfig.error.message,
+          });
+          return undefined;
+        }
+
+        const narrativeCompact = createNarrativeCompact({
+          invokeSkillSummary: async ({ skillId, modelId, input }) => {
+            const result = await aiService.runSkill({
+              skillId,
+              input,
+              mode: "ask",
+              model: modelId,
+              stream: false,
+              ts: nowTs(),
+              emitEvent: () => {},
+            });
+
+            if (!result.ok) {
+              const error = Object.assign(new Error(result.error.message), {
+                code: result.error.code,
+                ...(result.error.details === undefined
+                  ? {}
+                  : { details: result.error.details }),
+              });
+              throw error;
+            }
+
+            return {
+              summary: result.data.outputText ?? "",
+            };
+          },
+          ...(deps.costTracker ? { costTracker: deps.costTracker } : {}),
+        });
+
+        return createAutoCompact({
+          config: createCompactConfig({
+            modelConfig: resolvedModelConfig.data,
+          }),
+          narrativeCompact,
+          logger: {
+            warn: (event, data) => deps.logger.info(event, data),
+          },
+        });
+      })()
+    : undefined;
   const writingOrchestrator = createWritingOrchestrator({
     aiService: (() => {
       const legacyActiveAbortControllers = new Set<AbortController>();
@@ -1713,6 +1776,10 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
     ],
     defaultTimeoutMs: 30_000,
     costTracker: deps.costTracker,
+    autoCompact: autoCompactService,
+    logger: {
+      warn: (event, data) => deps.logger.info(event, data),
+    },
     prepareRequest: async (request) => {
       const prepared = await prepareWritingRequest({
         ctx: {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1908,7 +1908,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
 
       const entityResult = kgServiceForContext.entityList({
         projectId,
-        limit: 500,
+        limit: 500, // Snapshot safety cap: most novel projects stay well below 500 entities; bounds prompt size for AutoCompact context.
         offset: 0,
       });
       if (!entityResult.ok) {
@@ -1916,7 +1916,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       }
       const relationResult = kgServiceForContext.relationList({
         projectId,
-        limit: 500,
+        limit: 500, // Snapshot safety cap mirrors entity limit to avoid oversized relation payloads in compaction prompts.
         offset: 0,
       });
       if (!relationResult.ok) {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -427,6 +427,39 @@ function resolveSkillPermissionLevel(args: {
   return normalizeLevel(fallback?.permissionLevel);
 }
 
+function loadSessionHistoryMessages(args: {
+  db: Database.Database | null;
+  projectId: string;
+  sessionId: string;
+}): Array<{ role: "user" | "assistant"; content: string }> {
+  if (
+    args.db === null ||
+    args.projectId.trim().length === 0 ||
+    args.sessionId.trim().length === 0
+  ) {
+    return [];
+  }
+  const rows = args.db
+    .prepare<
+      [string, string],
+      { role: "user" | "assistant" | string; content: string }
+    >(
+      "SELECT role, content FROM chat_messages WHERE project_id = ? AND session_id = ? ORDER BY timestamp ASC",
+    )
+    .all(args.projectId, args.sessionId);
+  return rows
+    .filter(
+      (row): row is { role: "user" | "assistant"; content: string } =>
+        (row.role === "user" || row.role === "assistant") &&
+        typeof row.content === "string" &&
+        row.content.trim().length > 0,
+    )
+    .map((row) => ({
+      role: row.role,
+      content: row.content,
+    }));
+}
+
 export async function prepareWritingRequest(args: {
   ctx: AiIpcContext;
   payload: SkillRunPayload;
@@ -501,6 +534,7 @@ export async function prepareWritingRequest(args: {
   let contextPrompt = "";
   const projectId = args.payload.context?.projectId?.trim() ?? "";
   const documentId = args.payload.context?.documentId?.trim() ?? "";
+  const sessionId = args.payload.context?.sessionId?.trim() ?? "";
   const cursorPosition = resolveCursorPosition(args.payload);
 
   // Compute plain-text cursor offset for context assembly: PM positions include node
@@ -568,15 +602,30 @@ export async function prepareWritingRequest(args: {
     },
   });
 
+  const historyMessages = loadSessionHistoryMessages({
+    db: args.ctx.deps.db,
+    projectId,
+    sessionId,
+  });
+  const latestHistoryMessage = historyMessages.at(-1);
+  const includeCurrentUserPrompt =
+    !latestHistoryMessage ||
+    latestHistoryMessage.role !== "user" ||
+    latestHistoryMessage.content !== userPrompt;
   const messages = [
     {
       role: "system",
       content: [systemPrompt, contextPrompt].filter(Boolean).join("\n\n"),
     },
-    {
-      role: "user",
-      content: userPrompt,
-    },
+    ...historyMessages,
+    ...(includeCurrentUserPrompt
+      ? [
+          {
+            role: "user" as const,
+            content: userPrompt,
+          },
+        ]
+      : []),
   ];
 
   const tokenCount = estimateTokens(
@@ -1524,13 +1573,13 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           db: deps.db,
           logger: deps.logger,
         });
-        const resolvedModelConfig = modelConfigService.resolve();
-        if (!resolvedModelConfig.ok) {
-          deps.logger.info("auto_compact_disabled_model_config", {
-            reason: resolvedModelConfig.error.message,
-          });
-          return undefined;
-        }
+        let latestConfig = createCompactConfig({
+          modelConfig: {
+            primaryModel: "fallback-model",
+            auxiliaryModel: "fallback-model",
+            sharedModel: true,
+          },
+        });
 
         const narrativeCompact = createNarrativeCompact({
           invokeSkillSummary: async ({ skillId, modelId, input }) => {
@@ -1562,9 +1611,19 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         });
 
         return createAutoCompact({
-          config: createCompactConfig({
-            modelConfig: resolvedModelConfig.data,
-          }),
+          getConfig: () => {
+            const resolvedModelConfig = modelConfigService.resolve();
+            if (!resolvedModelConfig.ok) {
+              deps.logger.info("auto_compact_model_config_degraded", {
+                reason: resolvedModelConfig.error.message,
+              });
+              return latestConfig;
+            }
+            latestConfig = createCompactConfig({
+              modelConfig: resolvedModelConfig.data,
+            });
+            return latestConfig;
+          },
           narrativeCompact,
           logger: {
             warn: (event, data) => deps.logger.info(event, data),
@@ -1813,6 +1872,9 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           context: {
             projectId: request.projectId,
             documentId: request.documentId,
+            ...(request.sessionId === undefined
+              ? {}
+              : { sessionId: request.sessionId }),
           },
           selection: request.selection,
           stream: true,
@@ -1828,6 +1890,71 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         throw err;
       }
       return prepared.data;
+    },
+    getAutoCompactSnapshot: async ({ request }) => {
+      const emptySnapshot = {
+        entities: [],
+        relations: [],
+        characterSettings: [],
+        unresolvedPlotPoints: [],
+      };
+      const projectId = request.projectId?.trim() ?? "";
+      if (!kgServiceForContext || projectId.length === 0) {
+        return emptySnapshot;
+      }
+
+      const entityResult = kgServiceForContext.entityList({
+        projectId,
+        limit: 500,
+        offset: 0,
+      });
+      if (!entityResult.ok) {
+        throw new Error(entityResult.error.message);
+      }
+      const relationResult = kgServiceForContext.relationList({
+        projectId,
+        limit: 500,
+        offset: 0,
+      });
+      if (!relationResult.ok) {
+        throw new Error(relationResult.error.message);
+      }
+
+      const entities = entityResult.data.items;
+      const entityNameById = new Map(entities.map((entity) => [entity.id, entity.name]));
+      const dedupe = (values: string[]): string[] =>
+        [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
+      const relations = relationResult.data.items.map((relation) => {
+        const sourceName =
+          entityNameById.get(relation.sourceEntityId) ?? relation.sourceEntityId;
+        const targetName =
+          entityNameById.get(relation.targetEntityId) ?? relation.targetEntityId;
+        const base = `${sourceName} -> ${targetName}: ${relation.relationType}`;
+        return relation.description.trim().length > 0
+          ? `${base} (${relation.description})`
+          : base;
+      });
+      const characterSettings = entities
+        .filter((entity) => entity.type === "character")
+        .map((entity) => {
+          const attrs = Object.entries(entity.attributes)
+            .map(([key, value]) => `${key}=${value}`)
+            .join("；");
+          const details = [entity.description, attrs].filter((part) => part.length > 0);
+          return details.length > 0
+            ? `${entity.name}: ${details.join("；")}`
+            : entity.name;
+        });
+      const unresolvedPlotPoints = entities
+        .filter((entity) => entity.lastSeenState && entity.lastSeenState.trim().length > 0)
+        .map((entity) => `${entity.name}: ${entity.lastSeenState?.trim() ?? ""}`);
+
+      return {
+        entities: dedupe(entities.map((entity) => entity.name)),
+        relations: dedupe(relations),
+        characterSettings: dedupe(characterSettings),
+        unresolvedPlotPoints: dedupe(unresolvedPlotPoints),
+      };
     },
     generateText: async ({
       request,

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -267,8 +267,13 @@ type ChatClearResponse = {
 
 const SESSION_HISTORY_MESSAGE_LIMIT = 200;
 const KG_SNAPSHOT_LIST_LIMIT = 500;
+const NARRATIVE_SUMMARY_TOKEN_LIMIT_PREFIX = `${NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER}:`;
 function buildSummaryTokenLimitInstruction(summaryMaxTokens: number): string {
   return `${NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER}:${summaryMaxTokens} 请将摘要控制在约 ${summaryMaxTokens} tokens 以内。`;
+}
+
+export function containsNarrativeSummaryTokenLimitMarker(input: string): boolean {
+  return input.includes(NARRATIVE_SUMMARY_TOKEN_LIMIT_PREFIX);
 }
 
 function resolvePrepareWritingTokenBudget(): number {
@@ -1738,7 +1743,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           invokeSkillSummary: async (request) => {
             const { skillId, modelId, input, summaryMaxTokens } = request;
             const summaryTokenLimitInstruction = buildSummaryTokenLimitInstruction(summaryMaxTokens);
-            const summaryBoundedInput = input.includes(summaryTokenLimitInstruction)
+            const summaryBoundedInput = containsNarrativeSummaryTokenLimitMarker(input)
               ? input
               : `${input}\n\n${summaryTokenLimitInstruction}`;
             // TODO(@leeky 2025-07): Forward summaryMaxTokens via a dedicated

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -76,6 +76,7 @@ import { createVersionWorkflowService } from "../services/documents/versionServi
 import { editorSchema } from "../services/editor/prosemirrorSchema";
 import type { CostTracker } from "../services/ai/costTracker";
 import {
+  type NarrativeKnowledgeSnapshot,
   createAutoCompact,
   createCompactConfig,
   createNarrativeCompact,
@@ -261,20 +262,9 @@ type ChatClearResponse = {
   removed: number;
 };
 
-type AutoCompactSnapshot = {
-  entities: string[];
-  relations: string[];
-  characterSettings: string[];
-  unresolvedPlotPoints: string[];
-  toneMarkers?: string[];
-  narrativePOV?: string;
-  foreshadowingClues?: string[];
-  timelineMarkers?: string[];
-  userConstraints?: string[];
-};
-
 const SESSION_HISTORY_MESSAGE_LIMIT = 200;
 const KG_SNAPSHOT_LIST_LIMIT = 500;
+const CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL = "context:compact:circuit-breaker";
 
 function resolvePrepareWritingTokenBudget(): number {
   return parseChatHistoryTokenBudget(process.env);
@@ -492,8 +482,8 @@ export function getAutoCompactSnapshot(args: {
   request: {
     projectId?: string;
   };
-}): AutoCompactSnapshot {
-  const emptySnapshot: AutoCompactSnapshot = {
+}): NarrativeKnowledgeSnapshot {
+  const emptySnapshot: NarrativeKnowledgeSnapshot = {
     entities: [],
     relations: [],
     characterSettings: [],
@@ -591,11 +581,13 @@ export function getAutoCompactSnapshot(args: {
       return [...attrTimeline, ...stateTimeline];
     }),
   );
+  const unresolvedPlotPointSet = new Set(dedupe(unresolvedPlotPoints));
   const foreshadowingClues = dedupe(
-    [
-      ...unresolvedPlotPoints,
-      ...relations.filter((relation) => /(伏笔|线索|悬念|未揭示|未解)/.test(relation)),
-    ],
+    relations.filter(
+      (relation) =>
+        !unresolvedPlotPointSet.has(relation) &&
+        /(伏笔|线索|悬念|未揭示|未解)/.test(relation),
+    ),
   );
 
   return {
@@ -1178,6 +1170,14 @@ type AiIpcDeps = {
   secretStorage?: SecretStorageAdapter;
   projectSessionBinding?: ProjectSessionBindingRegistry;
   costTracker?: CostTracker;
+  onAutoCompactCircuitBreakerStateChange?: (payload: {
+    channel: typeof CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL;
+    open: boolean;
+    consecutiveFailures: number;
+    openedAt: number | null;
+    cooldownMs: number;
+    reason: "threshold-reached" | "half-open-probe-failed" | "half-open-probe-succeeded" | "manual-reset";
+  }) => void;
 };
 
 type AiIpcContext = {
@@ -1731,12 +1731,15 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
 
         const narrativeCompact = createNarrativeCompact({
           invokeSkillSummary: async (request) => {
-            const { skillId, modelId, input } = request;
-            // summaryMaxTokens is enforced in narrativeCompact prompt instructions
-            // because runSkill does not expose an output maxTokens parameter.
+            const { skillId, modelId, input, summaryMaxTokens } = request;
+            const summaryBoundedInput = input.includes("tokens")
+              ? input
+              : `${input}\n\n请将摘要控制在约 ${summaryMaxTokens} tokens 以内。`;
+            // TODO(@leeky 2025-07): Forward summaryMaxTokens via a dedicated
+            // maxOutputTokens field once aiService.runSkill exposes that option.
             const result = await aiService.runSkill({
               skillId,
-              input,
+              input: summaryBoundedInput,
               mode: "ask",
               model: modelId,
               stream: false,
@@ -1776,6 +1779,17 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
             return latestConfig;
           },
           narrativeCompact,
+          onCircuitBreakerStateChange: (state) => {
+            // Renderer status-bar handler is tracked as a follow-up task.
+            deps.onAutoCompactCircuitBreakerStateChange?.({
+              channel: CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
+              open: state.open,
+              consecutiveFailures: state.consecutiveFailures,
+              openedAt: state.openedAt,
+              cooldownMs: state.cooldownMs,
+              reason: state.reason,
+            });
+          },
           logger: {
             warn: (event, data) => deps.logger.info(event, data),
           },

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -80,6 +80,9 @@ import {
   createCompactConfig,
   createNarrativeCompact,
 } from "../services/ai/compact";
+import { buildLLMMessages } from "../services/ai/buildLLMMessages";
+import { parseChatHistoryTokenBudget } from "../services/ai/runtimeConfig";
+import type { KnowledgeGraphService } from "../services/kg/types";
 
 /**
  * Convert a ProseMirror document position to a plain-text character offset.
@@ -257,6 +260,25 @@ type ChatClearResponse = {
   cleared: true;
   removed: number;
 };
+
+type AutoCompactSnapshot = {
+  entities: string[];
+  relations: string[];
+  characterSettings: string[];
+  unresolvedPlotPoints: string[];
+  toneMarkers?: string[];
+  narrativePOV?: string;
+  foreshadowingClues?: string[];
+  timelineMarkers?: string[];
+  userConstraints?: string[];
+};
+
+const SESSION_HISTORY_MESSAGE_LIMIT = 200;
+const KG_SNAPSHOT_LIST_LIMIT = 500;
+
+function resolvePrepareWritingTokenBudget(): number {
+  return parseChatHistoryTokenBudget(process.env);
+}
 
 type ChatSession = {
   sessionId: string;
@@ -444,7 +466,12 @@ function loadSessionHistoryMessages(args: {
       [string, string],
       { role: "user" | "assistant" | string; content: string }
     >(
-      "SELECT role, content FROM chat_messages WHERE project_id = ? AND session_id = ? ORDER BY timestamp ASC",
+      // Safety cap: bound history fan-in at source so restored sessions never grow unbounded.
+      `SELECT role, content
+       FROM chat_messages
+       WHERE project_id = ? AND session_id = ?
+       ORDER BY timestamp ASC
+       LIMIT ${SESSION_HISTORY_MESSAGE_LIMIT}`,
     )
     .all(args.projectId, args.sessionId);
   return rows
@@ -458,6 +485,130 @@ function loadSessionHistoryMessages(args: {
       role: row.role,
       content: row.content,
     }));
+}
+
+export function getAutoCompactSnapshot(args: {
+  kgServiceForContext: Pick<KnowledgeGraphService, "entityList" | "relationList"> | null;
+  request: {
+    projectId?: string;
+  };
+}): AutoCompactSnapshot {
+  const emptySnapshot: AutoCompactSnapshot = {
+    entities: [],
+    relations: [],
+    characterSettings: [],
+    unresolvedPlotPoints: [],
+    toneMarkers: [],
+    narrativePOV: undefined,
+    foreshadowingClues: [],
+    timelineMarkers: [],
+    // Planned work: persist explicit user writing constraints into KG/context rules
+    // so compaction can pin them structurally instead of relying on prompt guidance.
+    userConstraints: [],
+  };
+  const projectId = args.request.projectId?.trim() ?? "";
+  if (!args.kgServiceForContext || projectId.length === 0) {
+    return emptySnapshot;
+  }
+  const dedupe = (values: string[]): string[] =>
+    [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
+
+  const entityResult = args.kgServiceForContext.entityList({
+    projectId,
+    limit: KG_SNAPSHOT_LIST_LIMIT, // Snapshot safety cap keeps compaction context bounded.
+    offset: 0,
+  });
+  if (!entityResult.ok) {
+    throw new Error(entityResult.error.message);
+  }
+  const relationResult = args.kgServiceForContext.relationList({
+    projectId,
+    limit: KG_SNAPSHOT_LIST_LIMIT, // Mirror entity cap to avoid relation payload blow-up.
+    offset: 0,
+  });
+  if (!relationResult.ok) {
+    throw new Error(relationResult.error.message);
+  }
+
+  const entities = entityResult.data.items;
+  const entityNameById = new Map(entities.map((entity) => [entity.id, entity.name]));
+  const relations = relationResult.data.items.map((relation) => {
+    const sourceName =
+      entityNameById.get(relation.sourceEntityId) ?? relation.sourceEntityId;
+    const targetName =
+      entityNameById.get(relation.targetEntityId) ?? relation.targetEntityId;
+    const base = `${sourceName} -> ${targetName}: ${relation.relationType}`;
+    return relation.description.trim().length > 0
+      ? `${base} (${relation.description})`
+      : base;
+  });
+  const characterSettings = entities
+    .filter((entity) => entity.type === "character")
+    .map((entity) => {
+      const attrs = Object.entries(entity.attributes)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("；");
+      const details = [entity.description, attrs].filter((part) => part.length > 0);
+      return details.length > 0 ? `${entity.name}: ${details.join("；")}` : entity.name;
+    });
+  const unresolvedPlotPoints = entities
+    .filter((entity) => entity.lastSeenState && entity.lastSeenState.trim().length > 0)
+    .map((entity) => `${entity.name}: ${entity.lastSeenState?.trim() ?? ""}`);
+
+  const toneAttributeKeys = ["tone", "mood", "atmosphere", "voice", "style"] as const;
+  const povAttributeKeys = [
+    "pov",
+    "pointOfView",
+    "narrativePOV",
+    "perspective",
+    "narrator",
+  ] as const;
+  const timelineAttributeKeys = ["timeline", "time", "era", "phase", "stage"] as const;
+  const toneMarkers = dedupe(
+    entities.flatMap((entity) =>
+      toneAttributeKeys
+        .map((key) => entity.attributes[key]?.trim() ?? "")
+        .filter((value) => value.length > 0),
+    ),
+  );
+  const narrativePOV =
+    dedupe(
+      entities.flatMap((entity) =>
+        povAttributeKeys
+          .map((key) => entity.attributes[key]?.trim() ?? "")
+          .filter((value) => value.length > 0),
+      ),
+    )[0] ?? undefined;
+  const timelineMarkers = dedupe(
+    entities.flatMap((entity) => {
+      const attrTimeline = timelineAttributeKeys
+        .map((key) => entity.attributes[key]?.trim() ?? "")
+        .filter((value) => value.length > 0);
+      const stateTimeline =
+        entity.lastSeenState && /(后|前|夜|晨|午|黄昏|黎明|次日|翌日|当晚|清晨|黄昏)/.test(entity.lastSeenState)
+          ? [entity.lastSeenState.trim()]
+          : [];
+      return [...attrTimeline, ...stateTimeline];
+    }),
+  );
+  const foreshadowingClues = dedupe(
+    [
+      ...unresolvedPlotPoints,
+      ...relations.filter((relation) => /(伏笔|线索|悬念|未揭示|未解)/.test(relation)),
+    ],
+  );
+
+  return {
+    entities: dedupe(entities.map((entity) => entity.name)),
+    relations: dedupe(relations),
+    characterSettings: dedupe(characterSettings),
+    unresolvedPlotPoints: dedupe(unresolvedPlotPoints),
+    toneMarkers,
+    narrativePOV,
+    foreshadowingClues,
+    timelineMarkers,
+    userConstraints: [],
+  };
 }
 
 export async function prepareWritingRequest(args: {
@@ -612,21 +763,18 @@ export async function prepareWritingRequest(args: {
     !latestHistoryMessage ||
     latestHistoryMessage.role !== "user" ||
     latestHistoryMessage.content !== userPrompt;
-  const messages = [
-    {
-      role: "system",
-      content: [systemPrompt, contextPrompt].filter(Boolean).join("\n\n"),
-    },
-    ...historyMessages,
-    ...(includeCurrentUserPrompt
-      ? [
-          {
-            role: "user" as const,
-            content: userPrompt,
-          },
-        ]
-      : []),
-  ];
+  const historyForBudget = includeCurrentUserPrompt
+    ? historyMessages
+    : historyMessages.slice(0, -1);
+  const messages = buildLLMMessages({
+    systemPrompt: [systemPrompt, contextPrompt].filter(Boolean).join("\n\n"),
+    history: historyForBudget,
+    currentUserMessage: userPrompt,
+    maxTokenBudget: resolvePrepareWritingTokenBudget(),
+  }).map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
 
   const tokenCount = estimateTokens(
     messages.map((message) => message.content).join("\n\n"),
@@ -1895,69 +2043,12 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       return prepared.data;
     },
     getAutoCompactSnapshot: async ({ request }) => {
-      const emptySnapshot = {
-        entities: [],
-        relations: [],
-        characterSettings: [],
-        unresolvedPlotPoints: [],
-      };
-      const projectId = request.projectId?.trim() ?? "";
-      if (!kgServiceForContext || projectId.length === 0) {
-        return emptySnapshot;
-      }
-
-      const entityResult = kgServiceForContext.entityList({
-        projectId,
-        limit: 500, // Snapshot safety cap: most novel projects stay well below 500 entities; bounds prompt size for AutoCompact context.
-        offset: 0,
+      return getAutoCompactSnapshot({
+        kgServiceForContext: kgServiceForContext ?? null,
+        request: {
+          projectId: request.projectId,
+        },
       });
-      if (!entityResult.ok) {
-        throw new Error(entityResult.error.message);
-      }
-      const relationResult = kgServiceForContext.relationList({
-        projectId,
-        limit: 500, // Snapshot safety cap mirrors entity limit to avoid oversized relation payloads in compaction prompts.
-        offset: 0,
-      });
-      if (!relationResult.ok) {
-        throw new Error(relationResult.error.message);
-      }
-
-      const entities = entityResult.data.items;
-      const entityNameById = new Map(entities.map((entity) => [entity.id, entity.name]));
-      const dedupe = (values: string[]): string[] =>
-        [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
-      const relations = relationResult.data.items.map((relation) => {
-        const sourceName =
-          entityNameById.get(relation.sourceEntityId) ?? relation.sourceEntityId;
-        const targetName =
-          entityNameById.get(relation.targetEntityId) ?? relation.targetEntityId;
-        const base = `${sourceName} -> ${targetName}: ${relation.relationType}`;
-        return relation.description.trim().length > 0
-          ? `${base} (${relation.description})`
-          : base;
-      });
-      const characterSettings = entities
-        .filter((entity) => entity.type === "character")
-        .map((entity) => {
-          const attrs = Object.entries(entity.attributes)
-            .map(([key, value]) => `${key}=${value}`)
-            .join("；");
-          const details = [entity.description, attrs].filter((part) => part.length > 0);
-          return details.length > 0
-            ? `${entity.name}: ${details.join("；")}`
-            : entity.name;
-        });
-      const unresolvedPlotPoints = entities
-        .filter((entity) => entity.lastSeenState && entity.lastSeenState.trim().length > 0)
-        .map((entity) => `${entity.name}: ${entity.lastSeenState?.trim() ?? ""}`);
-
-      return {
-        entities: dedupe(entities.map((entity) => entity.name)),
-        relations: dedupe(relations),
-        characterSettings: dedupe(characterSettings),
-        unresolvedPlotPoints: dedupe(unresolvedPlotPoints),
-      };
     },
     generateText: async ({
       request,

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -6,12 +6,14 @@ import { Node as ProseMirrorNode } from "prosemirror-model";
 import type { IpcError, IpcResponse } from "@shared/types/ipc-generated";
 import { nowTs } from "@shared/timeUtils";
 import {
+  CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
   SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
   type AiCompletionResult,
+  type ContextCompactCircuitBreakerReason,
   type AiTokenUsage,
 } from "@shared/types/ai";
 import type { Logger } from "../logging/logger";
@@ -80,6 +82,7 @@ import {
   createAutoCompact,
   createCompactConfig,
   createNarrativeCompact,
+  NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER,
 } from "../services/ai/compact";
 import { buildLLMMessages } from "../services/ai/buildLLMMessages";
 import { parseChatHistoryTokenBudget } from "../services/ai/runtimeConfig";
@@ -264,7 +267,9 @@ type ChatClearResponse = {
 
 const SESSION_HISTORY_MESSAGE_LIMIT = 200;
 const KG_SNAPSHOT_LIST_LIMIT = 500;
-const CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL = "context:compact:circuit-breaker";
+function buildSummaryTokenLimitInstruction(summaryMaxTokens: number): string {
+  return `${NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER}:${summaryMaxTokens} 请将摘要控制在约 ${summaryMaxTokens} tokens 以内。`;
+}
 
 function resolvePrepareWritingTokenBudget(): number {
   return parseChatHistoryTokenBudget(process.env);
@@ -1176,7 +1181,7 @@ type AiIpcDeps = {
     consecutiveFailures: number;
     openedAt: number | null;
     cooldownMs: number;
-    reason: "threshold-reached" | "half-open-probe-failed" | "half-open-probe-succeeded" | "manual-reset";
+    reason: ContextCompactCircuitBreakerReason;
   }) => void;
 };
 
@@ -1732,9 +1737,10 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         const narrativeCompact = createNarrativeCompact({
           invokeSkillSummary: async (request) => {
             const { skillId, modelId, input, summaryMaxTokens } = request;
-            const summaryBoundedInput = input.includes("tokens")
+            const summaryTokenLimitInstruction = buildSummaryTokenLimitInstruction(summaryMaxTokens);
+            const summaryBoundedInput = input.includes(summaryTokenLimitInstruction)
               ? input
-              : `${input}\n\n请将摘要控制在约 ${summaryMaxTokens} tokens 以内。`;
+              : `${input}\n\n${summaryTokenLimitInstruction}`;
             // TODO(@leeky 2025-07): Forward summaryMaxTokens via a dedicated
             // maxOutputTokens field once aiService.runSkill exposes that option.
             const result = await aiService.runSkill({

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -4,7 +4,10 @@ import {
   createAutoCompact,
   estimateConversationTokens,
 } from "../autoCompact";
-import { createCompactConfig } from "../compactConfig";
+import {
+  CIRCUIT_BREAKER_COOLDOWN_MS,
+  createCompactConfig,
+} from "../compactConfig";
 import {
   createNarrativeCompact,
   type CompactMessage,
@@ -421,6 +424,235 @@ describe("AutoCompact / NarrativeCompact", () => {
       "auto_compact_failed",
       expect.objectContaining({
         reason: "narrative_compact_error",
+      }),
+    );
+  });
+
+  it("allows one half-open probe after cooldown and closes breaker on probe success", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    try {
+      const messages = makeMessages();
+      const compactedMessages: CompactMessage[] = [
+        { id: "sys", role: "system", content: "系统提示", compactable: false },
+        { id: "summary", role: "assistant", content: "压缩摘要", compactable: false },
+      ];
+      const narrativeCompact = {
+        compact: vi
+          .fn()
+          .mockRejectedValueOnce(new Error("llm unavailable-1"))
+          .mockRejectedValueOnce(new Error("llm unavailable-2"))
+          .mockRejectedValueOnce(new Error("llm unavailable-3"))
+          .mockResolvedValueOnce({ compactedMessages }),
+      };
+      const onCircuitBreakerStateChange = vi.fn();
+      const autoCompact = createAutoCompact({
+        config: {
+          minTokenThreshold: 10,
+          triggerThresholdPercent: 0.2,
+          preserveRecentRounds: 1,
+          maxConsecutiveFailures: 3,
+          contextBudget: 200,
+          summaryMaxTokens: 120,
+        },
+        narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+        onCircuitBreakerStateChange,
+      });
+
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      const blocked = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(blocked.reason).toBe("circuit-open");
+
+      vi.advanceTimersByTime(CIRCUIT_BREAKER_COOLDOWN_MS + 1);
+      const probe = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+
+      expect(probe.reason).toBe("compacted");
+      expect(autoCompact.getConsecutiveFailures()).toBe(0);
+      expect(narrativeCompact.compact).toHaveBeenCalledTimes(4);
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          open: true,
+          reason: "threshold-reached",
+        }),
+      );
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          open: false,
+          reason: "half-open-probe-succeeded",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-opens breaker when the half-open probe fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    try {
+      const messages = makeMessages();
+      const narrativeCompact = {
+        compact: vi.fn().mockRejectedValue(new Error("llm unavailable")),
+      };
+      const onCircuitBreakerStateChange = vi.fn();
+      const autoCompact = createAutoCompact({
+        config: {
+          minTokenThreshold: 10,
+          triggerThresholdPercent: 0.2,
+          preserveRecentRounds: 1,
+          maxConsecutiveFailures: 3,
+          contextBudget: 200,
+          summaryMaxTokens: 120,
+        },
+        narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+        onCircuitBreakerStateChange,
+      });
+
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      vi.advanceTimersByTime(CIRCUIT_BREAKER_COOLDOWN_MS + 1);
+
+      const probeFailure = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(probeFailure.reason).toBe("compact-failed");
+
+      const afterProbeFailure = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(afterProbeFailure.reason).toBe("circuit-open");
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          open: true,
+          reason: "threshold-reached",
+        }),
+      );
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          open: true,
+          reason: "half-open-probe-failed",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resetCircuitBreaker closes breaker and allows subsequent compaction attempts", async () => {
+    const messages = makeMessages();
+    const compactedMessages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      { id: "summary", role: "assistant", content: "压缩摘要", compactable: false },
+    ];
+    const narrativeCompact = {
+      compact: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("llm unavailable-1"))
+        .mockRejectedValueOnce(new Error("llm unavailable-2"))
+        .mockRejectedValueOnce(new Error("llm unavailable-3"))
+        .mockResolvedValueOnce({ compactedMessages }),
+    };
+    const onCircuitBreakerStateChange = vi.fn();
+    const autoCompact = createAutoCompact({
+      config: {
+        minTokenThreshold: 10,
+        triggerThresholdPercent: 0.2,
+        preserveRecentRounds: 1,
+        maxConsecutiveFailures: 3,
+        contextBudget: 200,
+        summaryMaxTokens: 120,
+      },
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+      onCircuitBreakerStateChange,
+    });
+
+    await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    const blocked = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    expect(blocked.reason).toBe("circuit-open");
+
+    autoCompact.resetCircuitBreaker();
+    expect(autoCompact.getConsecutiveFailures()).toBe(0);
+
+    const afterReset = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    expect(afterReset.reason).toBe("compacted");
+    expect(narrativeCompact.compact).toHaveBeenCalledTimes(4);
+    expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        open: true,
+        reason: "threshold-reached",
+      }),
+    );
+    expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        open: false,
+        reason: "manual-reset",
       }),
     );
   });

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -45,7 +45,8 @@ describe("AutoCompact / NarrativeCompact", () => {
     };
     const autoCompact = createAutoCompact({
       config: {
-        triggerThresholdPercent: 0.85,
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.87,
         preserveRecentRounds: 3,
         maxConsecutiveFailures: 3,
         contextBudget: 20_000,
@@ -92,6 +93,7 @@ describe("AutoCompact / NarrativeCompact", () => {
     };
     const autoCompact = createAutoCompact({
       config: {
+        minTokenThreshold: 10,
         triggerThresholdPercent: 0.5,
         preserveRecentRounds: 2,
         maxConsecutiveFailures: 3,
@@ -137,6 +139,7 @@ describe("AutoCompact / NarrativeCompact", () => {
     };
     const autoCompact = createAutoCompact({
       config: {
+        minTokenThreshold: 10,
         triggerThresholdPercent: 0.2,
         preserveRecentRounds: 2,
         maxConsecutiveFailures: 3,
@@ -177,7 +180,8 @@ describe("AutoCompact / NarrativeCompact", () => {
     });
     const autoCompact = createAutoCompact({
       config: {
-        triggerThresholdPercent: 0.85,
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.87,
         preserveRecentRounds: 2,
         maxConsecutiveFailures: 3,
         contextBudget: 120,
@@ -200,6 +204,8 @@ describe("AutoCompact / NarrativeCompact", () => {
       expect.objectContaining({
         skillId: "builtin:summarize",
         modelId: "gpt-4o-mini",
+        summaryMaxTokens: 300,
+        input: expect.stringContaining("请将摘要控制在约 300 tokens 以内。"),
       }),
     );
   });
@@ -372,6 +378,8 @@ describe("AutoCompact / NarrativeCompact", () => {
       },
     });
     expect(config.contextBudget).toBe(1_000_000);
+    expect(config.minTokenThreshold).toBe(500);
+    expect(config.triggerThresholdPercent).toBe(0.87);
   });
 
   it("falls back when configured model is unknown", () => {
@@ -423,7 +431,8 @@ describe("AutoCompact / NarrativeCompact", () => {
     });
     const autoCompact = createAutoCompact({
       config: {
-        triggerThresholdPercent: 0.85,
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.87,
         preserveRecentRounds: 1,
         maxConsecutiveFailures: 3,
         contextBudget: 100,
@@ -458,17 +467,19 @@ describe("AutoCompact / NarrativeCompact", () => {
     };
     const autoCompact = createAutoCompact({
       config: {
-        triggerThresholdPercent: 0.85,
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.87,
         preserveRecentRounds: 2,
         maxConsecutiveFailures: 3,
-        contextBudget: 1_000_000,
+        contextBudget: 10_000,
         summaryMaxTokens: 200,
       },
       narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
     });
     const messages: CompactMessage[] = [
       { id: "sys", role: "system", content: "系统提示", compactable: false },
-      { id: "u1", role: "user", content: "长".repeat(80_000) },
+      { id: "u1", role: "user", content: "长".repeat(5_000) },
+      { id: "a1", role: "assistant", content: "长".repeat(5_000) },
     ];
 
     const result = await autoCompact.maybeCompact({
@@ -479,7 +490,7 @@ describe("AutoCompact / NarrativeCompact", () => {
       requestId: "req-small-window",
     });
 
-    expect(result.thresholdTokens).toBe(108_800);
+    expect(result.thresholdTokens).toBe(8_700);
     expect(result.reason).toBe("compacted");
     expect(result.compacted).toBe(true);
     expect(narrativeCompact.compact).toHaveBeenCalledTimes(1);
@@ -499,7 +510,8 @@ describe("AutoCompact / NarrativeCompact", () => {
     const getConfig = vi
       .fn()
       .mockReturnValueOnce({
-        triggerThresholdPercent: 0.85,
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.87,
         preserveRecentRounds: 1,
         maxConsecutiveFailures: 3,
         contextBudget: 100,
@@ -507,7 +519,8 @@ describe("AutoCompact / NarrativeCompact", () => {
         auxiliaryModel: "gpt-4o-mini",
       })
       .mockReturnValueOnce({
-        triggerThresholdPercent: 0.85,
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.87,
         preserveRecentRounds: 1,
         maxConsecutiveFailures: 3,
         contextBudget: 1_000_000,
@@ -534,5 +547,36 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(second.reason).toBe("below-threshold");
     expect(getConfig).toHaveBeenCalledTimes(2);
     expect(narrativeCompact.compact).toHaveBeenCalledTimes(1);
+  });
+  it("does not trigger when below minimum absolute token threshold", async () => {
+    const narrativeCompact = {
+      compact: vi.fn(),
+    };
+    const autoCompact = createAutoCompact({
+      config: {
+        minTokenThreshold: 500,
+        triggerThresholdPercent: 0.2,
+        preserveRecentRounds: 2,
+        maxConsecutiveFailures: 3,
+        contextBudget: 100,
+        summaryMaxTokens: 200,
+      },
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+    });
+    const messages: CompactMessage[] = [
+      { id: "u1", role: "user", content: "长".repeat(30) },
+      { id: "a1", role: "assistant", content: "答".repeat(30) },
+    ];
+
+    const result = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-min-token-threshold",
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("below-threshold");
+    expect(narrativeCompact.compact).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -170,6 +170,57 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(autoCompact.getConsecutiveFailures()).toBe(0);
   });
 
+  it("returns compacted-insufficient when reduced tokens still exceed threshold and increments failures", async () => {
+    const messages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      { id: "u1", role: "user", content: "长".repeat(60) },
+      { id: "a1", role: "assistant", content: "答".repeat(60) },
+    ];
+    const compactedMessages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      { id: "summary", role: "assistant", content: "压缩".repeat(40) },
+    ];
+    const warn = vi.fn();
+    const narrativeCompact = {
+      compact: vi.fn().mockResolvedValue({
+        compactedMessages,
+      }),
+    };
+    const autoCompact = createAutoCompact({
+      config: {
+        minTokenThreshold: 10,
+        triggerThresholdPercent: 0.9,
+        preserveRecentRounds: 1,
+        maxConsecutiveFailures: 3,
+        contextBudget: 100,
+        summaryMaxTokens: 120,
+      },
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+      logger: { warn },
+    });
+
+    const result = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-insufficient",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted-insufficient");
+    expect(result.insufficientCompaction).toBe(true);
+    expect(result.messages).toEqual(compactedMessages);
+    expect(result.totalTokensAfter).toBeLessThan(result.totalTokensBefore);
+    expect(result.totalTokensAfter).toBeGreaterThan(result.thresholdTokens);
+    expect(autoCompact.getConsecutiveFailures()).toBe(1);
+    expect(warn).toHaveBeenCalledWith(
+      "auto_compact_insufficient",
+      expect.objectContaining({
+        consecutiveFailures: 1,
+      }),
+    );
+  });
+
   it("above threshold triggers compaction and produces summary via skill pattern", async () => {
     const invokeSkillSummary = vi.fn().mockResolvedValue({
       summary: "## Narrative Summary\n林远调查白塔钟声。",
@@ -184,7 +235,7 @@ describe("AutoCompact / NarrativeCompact", () => {
         triggerThresholdPercent: 0.87,
         preserveRecentRounds: 2,
         maxConsecutiveFailures: 3,
-        contextBudget: 120,
+        contextBudget: 700,
         summaryMaxTokens: 300,
       },
       narrativeCompact,
@@ -198,7 +249,7 @@ describe("AutoCompact / NarrativeCompact", () => {
     });
 
     expect(result.compacted).toBe(true);
-    expect(result.reason).toBe("compacted");
+    expect(["compacted", "compacted-insufficient"]).toContain(result.reason);
     expect(result.messages.some((m) => m.id.startsWith("compact-summary-"))).toBe(true);
     expect(invokeSkillSummary).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -514,7 +565,7 @@ describe("AutoCompact / NarrativeCompact", () => {
         triggerThresholdPercent: 0.87,
         preserveRecentRounds: 1,
         maxConsecutiveFailures: 3,
-        contextBudget: 100,
+        contextBudget: 700,
         summaryMaxTokens: 200,
         auxiliaryModel: "gpt-4o-mini",
       })

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createAutoCompact,
+  estimateConversationTokens,
+} from "../autoCompact";
+import { createCompactConfig } from "../compactConfig";
+import {
+  createNarrativeCompact,
+  type CompactMessage,
+  type NarrativeKnowledgeSnapshot,
+} from "../narrativeCompact";
+
+function makeMessages(): CompactMessage[] {
+  return [
+    { id: "sys", role: "system", content: "你是小说写作助手。", compactable: false },
+    { id: "u1", role: "user", content: "第一轮提问：描写白塔城。".repeat(8) },
+    { id: "a1", role: "assistant", content: "第一轮回答：白塔城终年雾海。".repeat(8) },
+    {
+      id: "pinned",
+      role: "assistant",
+      content: "角色设定：林远是白塔守护者。",
+      compactable: false,
+    },
+    { id: "u2", role: "user", content: "第二轮提问：补充冲突。".repeat(8) },
+    { id: "a2", role: "assistant", content: "第二轮回答：冲突升级。".repeat(8) },
+    { id: "u3", role: "user", content: "第三轮提问：推进伏笔。".repeat(8) },
+    { id: "a3", role: "assistant", content: "第三轮回答：伏笔尚未揭晓。".repeat(8) },
+  ];
+}
+
+function makeKg(): NarrativeKnowledgeSnapshot {
+  return {
+    entities: ["林远", "白塔"],
+    relations: ["林远->白塔守护者"],
+    characterSettings: ["林远寡言谨慎"],
+    unresolvedPlotPoints: ["白塔钟声来源未揭示"],
+  };
+}
+
+describe("AutoCompact / NarrativeCompact", () => {
+  it("below threshold does not trigger compaction", async () => {
+    const narrativeCompact = {
+      compact: vi.fn(),
+    };
+    const autoCompact = createAutoCompact({
+      config: {
+        triggerThresholdPercent: 0.85,
+        preserveRecentRounds: 3,
+        maxConsecutiveFailures: 3,
+        contextBudget: 20_000,
+        summaryMaxTokens: 400,
+      },
+      narrativeCompact,
+    });
+    const messages = [
+      { id: "u1", role: "user", content: "你好" },
+    ] satisfies CompactMessage[];
+
+    const result = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("below-threshold");
+    expect(narrativeCompact.compact).not.toHaveBeenCalled();
+    expect(result.messages).toEqual(messages);
+  });
+
+  it("above threshold triggers compaction and produces summary via skill pattern", async () => {
+    const invokeSkillSummary = vi.fn().mockResolvedValue({
+      summary: "## Narrative Summary\n林远调查白塔钟声。",
+      usage: { promptTokens: 120, completionTokens: 40 },
+    });
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary,
+    });
+    const autoCompact = createAutoCompact({
+      config: {
+        triggerThresholdPercent: 0.85,
+        preserveRecentRounds: 2,
+        maxConsecutiveFailures: 3,
+        contextBudget: 120,
+        summaryMaxTokens: 300,
+      },
+      narrativeCompact,
+    });
+
+    const result = await autoCompact.maybeCompact({
+      messages: makeMessages(),
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-compact-1",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted");
+    expect(result.messages.some((m) => m.id.startsWith("compact-summary-"))).toBe(true);
+    expect(invokeSkillSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skillId: "builtin:narrative-compact-summary",
+        modelId: "gpt-4o-mini",
+      }),
+    );
+  });
+
+  it("preserves compactable:false messages", async () => {
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary: vi.fn().mockResolvedValue({
+        summary: "压缩摘要。",
+      }),
+    });
+
+    const result = await narrativeCompact.compact({
+      messages: makeMessages(),
+      preserveRecentRounds: 1,
+      summaryMaxTokens: 200,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-pinned",
+    });
+
+    const ids = result.compactedMessages.map((message) => message.id);
+    expect(ids).toContain("pinned");
+  });
+
+  it("uses CJK-aware token estimation accuracy", () => {
+    const tokens = estimateConversationTokens([
+      { id: "cjk", role: "user", content: "你好世界" },
+    ]);
+    expect(tokens).toBe(6);
+  });
+
+  it("records compaction call cost", async () => {
+    const recordUsage = vi.fn();
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary: vi.fn().mockResolvedValue({
+        summary: "## Narrative Summary\n完成压缩。",
+        usage: { promptTokens: 88, completionTokens: 22 },
+      }),
+      costTracker: {
+        recordUsage,
+      },
+    });
+
+    await narrativeCompact.compact({
+      messages: makeMessages(),
+      preserveRecentRounds: 1,
+      summaryMaxTokens: 200,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-cost",
+    });
+
+    expect(recordUsage).toHaveBeenCalledWith(
+      { promptTokens: 88, completionTokens: 22 },
+      "gpt-4o-mini",
+      "req-cost",
+      "builtin:narrative-compact",
+    );
+  });
+
+  it("preserves KG entities and relations in summary", async () => {
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary: vi.fn().mockResolvedValue({
+        summary: "## Narrative Summary\n林远继续调查。",
+      }),
+    });
+
+    const result = await narrativeCompact.compact({
+      messages: makeMessages(),
+      preserveRecentRounds: 1,
+      summaryMaxTokens: 200,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-kg",
+    });
+
+    expect(result.summaryMessage.content).toContain("林远");
+    expect(result.summaryMessage.content).toContain("林远->白塔守护者");
+    expect(result.summaryMessage.content).toContain("白塔钟声来源未揭示");
+  });
+
+  it("preserves recent N rounds", async () => {
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary: vi.fn().mockResolvedValue({
+        summary: "## Narrative Summary\n历史已压缩。",
+      }),
+    });
+
+    const result = await narrativeCompact.compact({
+      messages: makeMessages(),
+      preserveRecentRounds: 2,
+      summaryMaxTokens: 200,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-rounds",
+    });
+
+    const ids = result.compactedMessages.map((message) => message.id);
+    expect(ids).toContain("u2");
+    expect(ids).toContain("a2");
+    expect(ids).toContain("u3");
+    expect(ids).toContain("a3");
+  });
+
+  it("returns original messages when compaction fails and trips circuit breaker", async () => {
+    const config = createCompactConfig({
+      modelConfig: {
+        primaryModel: "gpt-4o",
+        auxiliaryModel: "gpt-4o-mini",
+        sharedModel: false,
+      },
+      overrides: {
+        contextBudget: 100,
+        summaryMaxTokens: 120,
+        preserveRecentRounds: 1,
+      },
+    });
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary: vi.fn().mockRejectedValue(new Error("llm unavailable")),
+    });
+    const autoCompact = createAutoCompact({
+      config,
+      narrativeCompact,
+    });
+    const messages = makeMessages();
+
+    const first = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    const second = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    const third = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+    const fourth = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+    });
+
+    expect(first.reason).toBe("compact-failed");
+    expect(second.reason).toBe("compact-failed");
+    expect(third.reason).toBe("compact-failed");
+    expect(fourth.reason).toBe("circuit-open");
+    expect(fourth.messages).toEqual(messages);
+  });
+});

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -259,6 +259,11 @@ describe("AutoCompact / NarrativeCompact", () => {
         input: expect.stringContaining("请将摘要控制在约 300 tokens 以内。"),
       }),
     );
+    const prompt = invokeSkillSummary.mock.calls[0]?.[0]?.input ?? "";
+    expect(prompt).toContain("Narrative tone markers and current POV");
+    expect(prompt).toContain("Foreshadowing clues and suspense threads");
+    expect(prompt).toContain("Timeline markers and sequence constraints");
+    expect(prompt).toContain("Explicit user writing constraints");
   });
 
   it("preserves compactable:false messages", async () => {

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -69,6 +69,51 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(result.messages).toEqual(messages);
   });
 
+  it("returns no-change when threshold exceeded but compaction output is unchanged", async () => {
+    const messages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      {
+        id: "pinned-1",
+        role: "assistant",
+        content: "角色设定：苏岚是守门人。".repeat(8),
+        compactable: false,
+      },
+      {
+        id: "pinned-2",
+        role: "user",
+        content: "未解伏笔：钟楼密室钥匙下落。".repeat(8),
+        compactable: false,
+      },
+    ];
+    const narrativeCompact = {
+      compact: vi.fn().mockResolvedValue({
+        compactedMessages: messages,
+      }),
+    };
+    const autoCompact = createAutoCompact({
+      config: {
+        triggerThresholdPercent: 0.5,
+        preserveRecentRounds: 2,
+        maxConsecutiveFailures: 3,
+        contextBudget: 80,
+        summaryMaxTokens: 200,
+      },
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+    });
+
+    const result = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-no-change",
+    });
+
+    expect(narrativeCompact.compact).toHaveBeenCalledTimes(1);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("no-change");
+    expect(result.messages).toEqual(messages);
+  });
+
   it("above threshold triggers compaction and produces summary via skill pattern", async () => {
     const invokeSkillSummary = vi.fn().mockResolvedValue({
       summary: "## Narrative Summary\n林远调查白塔钟声。",

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -114,6 +114,59 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(result.messages).toEqual(messages);
   });
 
+  it("rejects compaction output when token count expands and resets failure counter", async () => {
+    const messages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      { id: "u1", role: "user", content: "白塔夜色。".repeat(12) },
+      { id: "a1", role: "assistant", content: "林远巡塔。".repeat(12) },
+    ];
+    const narrativeCompact = {
+      compact: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("llm unavailable"))
+        .mockResolvedValueOnce({
+          compactedMessages: [
+            ...messages,
+            {
+              id: "summary",
+              role: "assistant",
+              content: "冗长摘要".repeat(120),
+            },
+          ] satisfies CompactMessage[],
+        }),
+    };
+    const autoCompact = createAutoCompact({
+      config: {
+        triggerThresholdPercent: 0.2,
+        preserveRecentRounds: 2,
+        maxConsecutiveFailures: 3,
+        contextBudget: 100,
+        summaryMaxTokens: 200,
+      },
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+    });
+
+    const first = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-fail-then-expand-1",
+    });
+    const second = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-fail-then-expand-2",
+    });
+
+    expect(first.reason).toBe("compact-failed");
+    expect(second.reason).toBe("expansion-rejected");
+    expect(second.compacted).toBe(false);
+    expect(second.messages).toEqual(messages);
+    expect(second.totalTokensAfter).toBeGreaterThanOrEqual(second.totalTokensBefore);
+    expect(autoCompact.getConsecutiveFailures()).toBe(0);
+  });
+
   it("above threshold triggers compaction and produces summary via skill pattern", async () => {
     const invokeSkillSummary = vi.fn().mockResolvedValue({
       summary: "## Narrative Summary\n林远调查白塔钟声。",
@@ -392,6 +445,44 @@ describe("AutoCompact / NarrativeCompact", () => {
         modelId: "gpt-4o-mini",
       }),
     );
+  });
+
+  it("uses the smaller request-model context window for threshold calculation", async () => {
+    const narrativeCompact = {
+      compact: vi.fn().mockResolvedValue({
+        compactedMessages: [
+          { id: "sys", role: "system", content: "系统提示", compactable: false },
+          { id: "summary", role: "assistant", content: "压缩摘要", compactable: false },
+        ] satisfies CompactMessage[],
+      }),
+    };
+    const autoCompact = createAutoCompact({
+      config: {
+        triggerThresholdPercent: 0.85,
+        preserveRecentRounds: 2,
+        maxConsecutiveFailures: 3,
+        contextBudget: 1_000_000,
+        summaryMaxTokens: 200,
+      },
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+    });
+    const messages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      { id: "u1", role: "user", content: "长".repeat(80_000) },
+    ];
+
+    const result = await autoCompact.maybeCompact({
+      messages,
+      auxiliaryModel: "gpt-4.1-mini",
+      requestModelId: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-small-window",
+    });
+
+    expect(result.thresholdTokens).toBe(108_800);
+    expect(result.reason).toBe("compacted");
+    expect(result.compacted).toBe(true);
+    expect(narrativeCompact.compact).toHaveBeenCalledTimes(1);
   });
 
   it("resolves compact config lazily per request", async () => {

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -312,9 +312,91 @@ describe("AutoCompact / NarrativeCompact", () => {
 
     expect(result.summaryMessage.content).toBe("无需压缩：历史中没有可压缩内容。");
     expect(invokeSkillSummary).not.toHaveBeenCalled();
-    const ids = result.compactedMessages.map((message) => message.id);
-    expect(ids).toContain("pinned-history");
-    expect(ids).toContain("u-recent");
-    expect(ids).toContain("a-recent");
+    expect(result.compactedMessages).toEqual(messages);
+    expect(result.compactedMessages.some((message) => message.id.startsWith("compact-summary-"))).toBe(false);
+  });
+
+  it("uses configured auxiliary model before request fallback model", async () => {
+    const invokeSkillSummary = vi.fn().mockResolvedValue({
+      summary: "## Narrative Summary\n使用辅助模型进行压缩。",
+    });
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary,
+    });
+    const autoCompact = createAutoCompact({
+      config: {
+        triggerThresholdPercent: 0.85,
+        preserveRecentRounds: 1,
+        maxConsecutiveFailures: 3,
+        contextBudget: 100,
+        summaryMaxTokens: 200,
+        auxiliaryModel: "gpt-4o-mini",
+      },
+      narrativeCompact,
+    });
+
+    await autoCompact.maybeCompact({
+      messages: makeMessages(),
+      auxiliaryModel: "gpt-4o",
+      kgSnapshot: makeKg(),
+      requestId: "req-aux-priority",
+    });
+
+    expect(invokeSkillSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: "gpt-4o-mini",
+      }),
+    );
+  });
+
+  it("resolves compact config lazily per request", async () => {
+    const narrativeCompact = {
+      compact: vi.fn().mockResolvedValue({
+        compactedMessages: [
+          { id: "sys", role: "system", content: "系统提示", compactable: false },
+          { id: "summary", role: "assistant", content: "压缩摘要", compactable: false },
+          { id: "u3", role: "user", content: "第三轮提问：推进伏笔。".repeat(8) },
+          { id: "a3", role: "assistant", content: "第三轮回答：伏笔尚未揭晓。".repeat(8) },
+        ] satisfies CompactMessage[],
+      }),
+    };
+    const getConfig = vi
+      .fn()
+      .mockReturnValueOnce({
+        triggerThresholdPercent: 0.85,
+        preserveRecentRounds: 1,
+        maxConsecutiveFailures: 3,
+        contextBudget: 100,
+        summaryMaxTokens: 200,
+        auxiliaryModel: "gpt-4o-mini",
+      })
+      .mockReturnValueOnce({
+        triggerThresholdPercent: 0.85,
+        preserveRecentRounds: 1,
+        maxConsecutiveFailures: 3,
+        contextBudget: 1_000_000,
+        summaryMaxTokens: 200,
+        auxiliaryModel: "gpt-4o-mini",
+      });
+    const autoCompact = createAutoCompact({
+      getConfig,
+      narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+    });
+
+    const first = await autoCompact.maybeCompact({
+      messages: makeMessages(),
+      kgSnapshot: makeKg(),
+      requestId: "req-lazy-1",
+    });
+    const second = await autoCompact.maybeCompact({
+      messages: makeMessages(),
+      kgSnapshot: makeKg(),
+      requestId: "req-lazy-2",
+    });
+
+    expect(first.reason).toBe("compacted");
+    expect(second.reason).toBe("below-threshold");
+    expect(getConfig).toHaveBeenCalledTimes(2);
+    expect(narrativeCompact.compact).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -119,7 +119,7 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(result.messages).toEqual(messages);
   });
 
-  it("rejects compaction output when token count expands and resets failure counter", async () => {
+  it("rejects compaction output when token count expands and counts it as failure", async () => {
     const messages: CompactMessage[] = [
       { id: "sys", role: "system", content: "系统提示", compactable: false },
       { id: "u1", role: "user", content: "白塔夜色。".repeat(12) },
@@ -170,7 +170,7 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(second.compacted).toBe(false);
     expect(second.messages).toEqual(messages);
     expect(second.totalTokensAfter).toBeGreaterThanOrEqual(second.totalTokensBefore);
-    expect(autoCompact.getConsecutiveFailures()).toBe(0);
+    expect(autoCompact.getConsecutiveFailures()).toBe(2);
   });
 
   it("returns compacted-insufficient when reduced tokens still exceed threshold and increments failures", async () => {
@@ -267,6 +267,10 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(prompt).toContain("Foreshadowing clues and suspense threads");
     expect(prompt).toContain("Timeline markers and sequence constraints");
     expect(prompt).toContain("Explicit user writing constraints");
+    expect(prompt).toContain(
+      "Do NOT use markdown headings, section labels, bullet lists, numbered lists, or tables.",
+    );
+    expect(prompt).not.toContain("## Narrative Summary");
   });
 
   it("preserves compactable:false messages", async () => {
@@ -562,6 +566,170 @@ describe("AutoCompact / NarrativeCompact", () => {
         kgSnapshot: makeKg(),
       });
       expect(afterProbeFailure.reason).toBe("circuit-open");
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          open: true,
+          reason: "threshold-reached",
+        }),
+      );
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          open: true,
+          reason: "half-open-probe-failed",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps breaker open when the half-open probe returns no-change", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    try {
+      const messages = makeMessages();
+      const narrativeCompact = {
+        compact: vi
+          .fn()
+          .mockRejectedValueOnce(new Error("llm unavailable-1"))
+          .mockRejectedValueOnce(new Error("llm unavailable-2"))
+          .mockRejectedValueOnce(new Error("llm unavailable-3"))
+          .mockResolvedValueOnce({
+            compactedMessages: messages,
+          }),
+      };
+      const onCircuitBreakerStateChange = vi.fn();
+      const autoCompact = createAutoCompact({
+        config: {
+          minTokenThreshold: 10,
+          triggerThresholdPercent: 0.2,
+          preserveRecentRounds: 1,
+          maxConsecutiveFailures: 3,
+          contextBudget: 200,
+          summaryMaxTokens: 120,
+        },
+        narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+        onCircuitBreakerStateChange,
+      });
+
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      vi.advanceTimersByTime(CIRCUIT_BREAKER_COOLDOWN_MS + 1);
+
+      const probeNoChange = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(probeNoChange.reason).toBe("no-change");
+
+      const blocked = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(blocked.reason).toBe("circuit-open");
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          open: true,
+          reason: "threshold-reached",
+        }),
+      );
+      expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          open: true,
+          reason: "half-open-probe-failed",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps breaker open when the half-open probe expands token count", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    try {
+      const messages = makeMessages();
+      const expandedMessages: CompactMessage[] = [
+        ...messages,
+        {
+          id: "summary-expanded",
+          role: "assistant",
+          content: "冗长扩展摘要".repeat(200),
+        },
+      ];
+      const narrativeCompact = {
+        compact: vi
+          .fn()
+          .mockRejectedValueOnce(new Error("llm unavailable-1"))
+          .mockRejectedValueOnce(new Error("llm unavailable-2"))
+          .mockRejectedValueOnce(new Error("llm unavailable-3"))
+          .mockResolvedValueOnce({
+            compactedMessages: expandedMessages,
+          }),
+      };
+      const onCircuitBreakerStateChange = vi.fn();
+      const autoCompact = createAutoCompact({
+        config: {
+          minTokenThreshold: 10,
+          triggerThresholdPercent: 0.2,
+          preserveRecentRounds: 1,
+          maxConsecutiveFailures: 3,
+          contextBudget: 200,
+          summaryMaxTokens: 120,
+        },
+        narrativeCompact: narrativeCompact as ReturnType<typeof createNarrativeCompact>,
+        onCircuitBreakerStateChange,
+      });
+
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      vi.advanceTimersByTime(CIRCUIT_BREAKER_COOLDOWN_MS + 1);
+
+      const probeExpanded = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(probeExpanded.reason).toBe("expansion-rejected");
+
+      const blocked = await autoCompact.maybeCompact({
+        messages,
+        auxiliaryModel: "gpt-4o-mini",
+        kgSnapshot: makeKg(),
+      });
+      expect(blocked.reason).toBe("circuit-open");
       expect(onCircuitBreakerStateChange).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({

--- a/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/autoCompact.test.ts
@@ -100,7 +100,7 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(result.messages.some((m) => m.id.startsWith("compact-summary-"))).toBe(true);
     expect(invokeSkillSummary).toHaveBeenCalledWith(
       expect.objectContaining({
-        skillId: "builtin:narrative-compact-summary",
+        skillId: "builtin:summarize",
         modelId: "gpt-4o-mini",
       }),
     );
@@ -222,9 +222,11 @@ describe("AutoCompact / NarrativeCompact", () => {
     const narrativeCompact = createNarrativeCompact({
       invokeSkillSummary: vi.fn().mockRejectedValue(new Error("llm unavailable")),
     });
+    const warn = vi.fn();
     const autoCompact = createAutoCompact({
       config,
       narrativeCompact,
+      logger: { warn },
     });
     const messages = makeMessages();
 
@@ -254,5 +256,65 @@ describe("AutoCompact / NarrativeCompact", () => {
     expect(third.reason).toBe("compact-failed");
     expect(fourth.reason).toBe("circuit-open");
     expect(fourth.messages).toEqual(messages);
+    expect(first.error).toBeInstanceOf(Error);
+    expect(warn).toHaveBeenCalledWith(
+      "auto_compact_failed",
+      expect.objectContaining({
+        reason: "narrative_compact_error",
+      }),
+    );
+  });
+
+  it("uses model context window from configured model id", () => {
+    const config = createCompactConfig({
+      modelConfig: {
+        primaryModel: "gpt-4.1-mini",
+        auxiliaryModel: "gpt-4o-mini",
+        sharedModel: false,
+      },
+    });
+    expect(config.contextBudget).toBe(1_000_000);
+  });
+
+  it("falls back when configured model is unknown", () => {
+    const config = createCompactConfig({
+      modelConfig: {
+        primaryModel: "unknown-model",
+        auxiliaryModel: "also-unknown-model",
+        sharedModel: false,
+      },
+    });
+    expect(config.contextBudget).toBe(128_000);
+  });
+
+  it("returns fallback summary when no history message is compactable", async () => {
+    const invokeSkillSummary = vi.fn().mockResolvedValue({
+      summary: "不应被调用",
+    });
+    const narrativeCompact = createNarrativeCompact({
+      invokeSkillSummary,
+    });
+    const messages: CompactMessage[] = [
+      { id: "sys", role: "system", content: "系统提示", compactable: false },
+      { id: "pinned-history", role: "assistant", content: "角色设定：苏岚", compactable: false },
+      { id: "u-recent", role: "user", content: "最近一轮用户消息", compactable: false },
+      { id: "a-recent", role: "assistant", content: "最近一轮助手消息", compactable: false },
+    ];
+
+    const result = await narrativeCompact.compact({
+      messages,
+      preserveRecentRounds: 1,
+      summaryMaxTokens: 200,
+      auxiliaryModel: "gpt-4o-mini",
+      kgSnapshot: makeKg(),
+      requestId: "req-no-compactable",
+    });
+
+    expect(result.summaryMessage.content).toBe("无需压缩：历史中没有可压缩内容。");
+    expect(invokeSkillSummary).not.toHaveBeenCalled();
+    const ids = result.compactedMessages.map((message) => message.id);
+    expect(ids).toContain("pinned-history");
+    expect(ids).toContain("u-recent");
+    expect(ids).toContain("a-recent");
   });
 });

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -11,7 +11,10 @@ import { randomUUID } from "node:crypto";
 import { estimateTokens } from "@shared/tokenBudget";
 
 import type { CompactConfig } from "./compactConfig";
-import { resolveKnownContextWindow } from "./compactConfig";
+import {
+  CIRCUIT_BREAKER_COOLDOWN_MS,
+  resolveKnownContextWindow,
+} from "./compactConfig";
 import type {
   CompactMessage,
   NarrativeKnowledgeSnapshot,
@@ -47,6 +50,7 @@ export interface AutoCompactService {
     requestId?: string;
   }) => Promise<AutoCompactResult>;
   getConsecutiveFailures: () => number;
+  resetCircuitBreaker: () => void;
 }
 
 export function estimateConversationTokens(
@@ -62,11 +66,21 @@ export function createAutoCompact(args: {
   config?: CompactConfig;
   getConfig?: () => CompactConfig;
   narrativeCompact: NarrativeCompactService;
+  now?: () => number;
+  onCircuitBreakerStateChange?: (payload: {
+    open: boolean;
+    consecutiveFailures: number;
+    openedAt: number | null;
+    cooldownMs: number;
+    reason: "threshold-reached" | "half-open-probe-failed" | "half-open-probe-succeeded" | "manual-reset";
+  }) => void;
   logger?: {
     warn: (event: string, data?: Record<string, unknown>) => void;
   };
 }): AutoCompactService {
   let consecutiveFailures = 0;
+  let lastOpenedAt: number | null = null;
+  const now = args.now ?? Date.now;
   const resolveConfig = (): CompactConfig => {
     if (args.getConfig) {
       return args.getConfig();
@@ -75,6 +89,45 @@ export function createAutoCompact(args: {
       return args.config;
     }
     throw new Error("AutoCompact requires config or getConfig");
+  };
+
+  const emitCircuitBreakerStateChange = (payload: {
+    open: boolean;
+    reason: "threshold-reached" | "half-open-probe-failed" | "half-open-probe-succeeded" | "manual-reset";
+  }): void => {
+    args.onCircuitBreakerStateChange?.({
+      open: payload.open,
+      consecutiveFailures,
+      openedAt: lastOpenedAt,
+      cooldownMs: CIRCUIT_BREAKER_COOLDOWN_MS,
+      reason: payload.reason,
+    });
+  };
+
+  const openCircuitBreaker = (reason: "threshold-reached" | "half-open-probe-failed"): void => {
+    const openedAt = now();
+    const alreadyOpen = lastOpenedAt !== null;
+    lastOpenedAt = openedAt;
+    if (!alreadyOpen || reason === "half-open-probe-failed") {
+      emitCircuitBreakerStateChange({
+        open: true,
+        reason,
+      });
+    }
+  };
+
+  const closeCircuitBreaker = (
+    reason: "half-open-probe-succeeded" | "manual-reset",
+  ): void => {
+    const wasOpen = lastOpenedAt !== null;
+    consecutiveFailures = 0;
+    lastOpenedAt = null;
+    if (wasOpen) {
+      emitCircuitBreakerStateChange({
+        open: false,
+        reason,
+      });
+    }
   };
 
   function isSameMessages(
@@ -141,7 +194,16 @@ export function createAutoCompact(args: {
       };
     }
 
-    if (consecutiveFailures >= config.maxConsecutiveFailures) {
+    const breakerOpen = consecutiveFailures >= config.maxConsecutiveFailures;
+    if (breakerOpen && lastOpenedAt === null) {
+      openCircuitBreaker("threshold-reached");
+    }
+    const cooldownElapsed =
+      breakerOpen &&
+      lastOpenedAt !== null &&
+      now() - lastOpenedAt >= CIRCUIT_BREAKER_COOLDOWN_MS;
+    const halfOpenProbe = breakerOpen && cooldownElapsed;
+    if (breakerOpen && !halfOpenProbe) {
       return {
         messages: input.messages,
         compacted: false,
@@ -166,7 +228,11 @@ export function createAutoCompact(args: {
       });
       const totalTokensAfter = estimateConversationTokens(compacted.compactedMessages);
       if (isSameMessages(compacted.compactedMessages, input.messages)) {
-        consecutiveFailures = 0;
+        if (halfOpenProbe) {
+          closeCircuitBreaker("half-open-probe-succeeded");
+        } else {
+          consecutiveFailures = 0;
+        }
         return {
           messages: input.messages,
           compacted: false,
@@ -177,7 +243,11 @@ export function createAutoCompact(args: {
         };
       }
       if (totalTokensAfter >= totalTokensBefore) {
-        consecutiveFailures = 0;
+        if (halfOpenProbe) {
+          closeCircuitBreaker("half-open-probe-succeeded");
+        } else {
+          consecutiveFailures = 0;
+        }
         return {
           messages: input.messages,
           compacted: false,
@@ -190,6 +260,11 @@ export function createAutoCompact(args: {
       if (totalTokensAfter > thresholdTokens) {
         // Spec circuit-breaker rule: compaction that still exceeds target budget counts as one failure.
         consecutiveFailures += 1;
+        if (halfOpenProbe) {
+          openCircuitBreaker("half-open-probe-failed");
+        } else if (consecutiveFailures >= config.maxConsecutiveFailures) {
+          openCircuitBreaker("threshold-reached");
+        }
         args.logger?.warn("auto_compact_insufficient", {
           totalTokensBefore,
           totalTokensAfter,
@@ -207,7 +282,11 @@ export function createAutoCompact(args: {
           reason: "compacted-insufficient",
         };
       }
-      consecutiveFailures = 0;
+      if (halfOpenProbe) {
+        closeCircuitBreaker("half-open-probe-succeeded");
+      } else {
+        consecutiveFailures = 0;
+      }
       return {
         messages: compacted.compactedMessages,
         compacted: true,
@@ -218,6 +297,11 @@ export function createAutoCompact(args: {
       };
     } catch (error) {
       consecutiveFailures += 1;
+      if (halfOpenProbe) {
+        openCircuitBreaker("half-open-probe-failed");
+      } else if (consecutiveFailures >= config.maxConsecutiveFailures) {
+        openCircuitBreaker("threshold-reached");
+      }
       args.logger?.warn("auto_compact_failed", {
         reason: "narrative_compact_error",
         consecutiveFailures,
@@ -236,8 +320,13 @@ export function createAutoCompact(args: {
     }
   }
 
+  function resetCircuitBreaker(): void {
+    closeCircuitBreaker("manual-reset");
+  }
+
   return {
     maybeCompact,
     getConsecutiveFailures: () => consecutiveFailures,
+    resetCircuitBreaker,
   };
 }

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import { estimateTokens } from "@shared/tokenBudget";
 
 import type { CompactConfig } from "./compactConfig";
+import { resolveKnownContextWindow } from "./compactConfig";
 import type {
   CompactMessage,
   NarrativeKnowledgeSnapshot,
@@ -29,6 +30,7 @@ export interface AutoCompactResult {
   reason:
     | "below-threshold"
     | "no-change"
+    | "expansion-rejected"
     | "compacted"
     | "compact-failed"
     | "circuit-open";
@@ -38,6 +40,7 @@ export interface AutoCompactService {
   maybeCompact: (args: {
     messages: CompactMessage[];
     auxiliaryModel?: string;
+    requestModelId?: string;
     kgSnapshot: NarrativeKnowledgeSnapshot;
     requestId?: string;
   }) => Promise<AutoCompactResult>;
@@ -97,13 +100,21 @@ export function createAutoCompact(args: {
   async function maybeCompact(input: {
     messages: CompactMessage[];
     auxiliaryModel?: string;
+    requestModelId?: string;
     kgSnapshot: NarrativeKnowledgeSnapshot;
     requestId?: string;
   }): Promise<AutoCompactResult> {
     const config = resolveConfig();
     const totalTokensBefore = estimateConversationTokens(input.messages);
+    const requestModelBudget = input.requestModelId
+      ? resolveKnownContextWindow(input.requestModelId)
+      : null;
+    const contextBudget =
+      requestModelBudget === null
+        ? config.contextBudget
+        : Math.min(config.contextBudget, requestModelBudget);
     const thresholdTokens = Math.floor(
-      config.contextBudget * config.triggerThresholdPercent,
+      contextBudget * config.triggerThresholdPercent,
     );
 
     if (totalTokensBefore < thresholdTokens) {
@@ -150,6 +161,17 @@ export function createAutoCompact(args: {
           totalTokensAfter,
           thresholdTokens,
           reason: "no-change",
+        };
+      }
+      if (totalTokensAfter >= totalTokensBefore) {
+        consecutiveFailures = 0;
+        return {
+          messages: input.messages,
+          compacted: false,
+          totalTokensBefore,
+          totalTokensAfter,
+          thresholdTokens,
+          reason: "expansion-rejected",
         };
       }
       consecutiveFailures = 0;

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -160,6 +160,14 @@ export function createAutoCompact(args: {
     requestId?: string;
   }): Promise<AutoCompactResult> {
     const config = resolveConfig();
+    const recordFailure = (): void => {
+      consecutiveFailures += 1;
+      if (halfOpenProbe) {
+        openCircuitBreaker("half-open-probe-failed");
+      } else if (consecutiveFailures >= config.maxConsecutiveFailures) {
+        openCircuitBreaker("threshold-reached");
+      }
+    };
     const totalTokensBefore = estimateConversationTokens(input.messages);
     const requestModelBudget = input.requestModelId
       ? resolveKnownContextWindow(input.requestModelId)
@@ -228,11 +236,7 @@ export function createAutoCompact(args: {
       });
       const totalTokensAfter = estimateConversationTokens(compacted.compactedMessages);
       if (isSameMessages(compacted.compactedMessages, input.messages)) {
-        if (halfOpenProbe) {
-          closeCircuitBreaker("half-open-probe-succeeded");
-        } else {
-          consecutiveFailures = 0;
-        }
+        recordFailure();
         return {
           messages: input.messages,
           compacted: false,
@@ -243,11 +247,7 @@ export function createAutoCompact(args: {
         };
       }
       if (totalTokensAfter >= totalTokensBefore) {
-        if (halfOpenProbe) {
-          closeCircuitBreaker("half-open-probe-succeeded");
-        } else {
-          consecutiveFailures = 0;
-        }
+        recordFailure();
         return {
           messages: input.messages,
           compacted: false,
@@ -259,12 +259,7 @@ export function createAutoCompact(args: {
       }
       if (totalTokensAfter > thresholdTokens) {
         // Spec circuit-breaker rule: compaction that still exceeds target budget counts as one failure.
-        consecutiveFailures += 1;
-        if (halfOpenProbe) {
-          openCircuitBreaker("half-open-probe-failed");
-        } else if (consecutiveFailures >= config.maxConsecutiveFailures) {
-          openCircuitBreaker("threshold-reached");
-        }
+        recordFailure();
         args.logger?.warn("auto_compact_insufficient", {
           totalTokensBefore,
           totalTokensAfter,
@@ -296,12 +291,7 @@ export function createAutoCompact(args: {
         reason: "compacted",
       };
     } catch (error) {
-      consecutiveFailures += 1;
-      if (halfOpenProbe) {
-        openCircuitBreaker("half-open-probe-failed");
-      } else if (consecutiveFailures >= config.maxConsecutiveFailures) {
-        openCircuitBreaker("threshold-reached");
-      }
+      recordFailure();
       args.logger?.warn("auto_compact_failed", {
         reason: "narrative_compact_error",
         consecutiveFailures,

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -25,6 +25,7 @@ export interface AutoCompactResult {
   totalTokensBefore: number;
   totalTokensAfter: number;
   thresholdTokens: number;
+  error?: unknown;
   reason:
     | "below-threshold"
     | "compacted"
@@ -54,6 +55,9 @@ export function estimateConversationTokens(
 export function createAutoCompact(args: {
   config: CompactConfig;
   narrativeCompact: NarrativeCompactService;
+  logger?: {
+    warn: (event: string, data?: Record<string, unknown>) => void;
+  };
 }): AutoCompactService {
   let consecutiveFailures = 0;
 
@@ -109,14 +113,21 @@ export function createAutoCompact(args: {
         thresholdTokens,
         reason: "compacted",
       };
-    } catch {
+    } catch (error) {
       consecutiveFailures += 1;
+      args.logger?.warn("auto_compact_failed", {
+        reason: "narrative_compact_error",
+        consecutiveFailures,
+        maxConsecutiveFailures: args.config.maxConsecutiveFailures,
+        error,
+      });
       return {
         messages: input.messages,
         compacted: false,
         totalTokensBefore,
         totalTokensAfter: totalTokensBefore,
         thresholdTokens,
+        error,
         reason: "compact-failed",
       };
     }

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -117,6 +117,17 @@ export function createAutoCompact(args: {
       contextBudget * config.triggerThresholdPercent,
     );
 
+    if (totalTokensBefore < config.minTokenThreshold) {
+      return {
+        messages: input.messages,
+        compacted: false,
+        totalTokensBefore,
+        totalTokensAfter: totalTokensBefore,
+        thresholdTokens,
+        reason: "below-threshold",
+      };
+    }
+
     if (totalTokensBefore < thresholdTokens) {
       return {
         messages: input.messages,

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -1,0 +1,129 @@
+/**
+ * @module autoCompact
+ * ## Responsibilities: trigger narrative compaction by context-budget threshold.
+ * ## Does not do: summary generation details (delegated to narrativeCompact).
+ * ## Dependency direction: ai/compact -> shared(tokenBudget) + ai/compact.
+ * ## Invariants: INV-3, INV-5, INV-10.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { estimateTokens } from "@shared/tokenBudget";
+
+import type { CompactConfig } from "./compactConfig";
+import type {
+  CompactMessage,
+  NarrativeKnowledgeSnapshot,
+} from "./narrativeCompact";
+import type { createNarrativeCompact } from "./narrativeCompact";
+
+type NarrativeCompactService = ReturnType<typeof createNarrativeCompact>;
+
+export interface AutoCompactResult {
+  messages: CompactMessage[];
+  compacted: boolean;
+  totalTokensBefore: number;
+  totalTokensAfter: number;
+  thresholdTokens: number;
+  reason:
+    | "below-threshold"
+    | "compacted"
+    | "compact-failed"
+    | "circuit-open";
+}
+
+export interface AutoCompactService {
+  maybeCompact: (args: {
+    messages: CompactMessage[];
+    auxiliaryModel: string;
+    kgSnapshot: NarrativeKnowledgeSnapshot;
+    requestId?: string;
+  }) => Promise<AutoCompactResult>;
+  getConsecutiveFailures: () => number;
+}
+
+export function estimateConversationTokens(
+  messages: ReadonlyArray<CompactMessage>,
+): number {
+  return messages.reduce(
+    (total, message) => total + estimateTokens(message.content),
+    0,
+  );
+}
+
+export function createAutoCompact(args: {
+  config: CompactConfig;
+  narrativeCompact: NarrativeCompactService;
+}): AutoCompactService {
+  let consecutiveFailures = 0;
+
+  async function maybeCompact(input: {
+    messages: CompactMessage[];
+    auxiliaryModel: string;
+    kgSnapshot: NarrativeKnowledgeSnapshot;
+    requestId?: string;
+  }): Promise<AutoCompactResult> {
+    const totalTokensBefore = estimateConversationTokens(input.messages);
+    const thresholdTokens = Math.floor(
+      args.config.contextBudget * args.config.triggerThresholdPercent,
+    );
+
+    if (totalTokensBefore < thresholdTokens) {
+      return {
+        messages: input.messages,
+        compacted: false,
+        totalTokensBefore,
+        totalTokensAfter: totalTokensBefore,
+        thresholdTokens,
+        reason: "below-threshold",
+      };
+    }
+
+    if (consecutiveFailures >= args.config.maxConsecutiveFailures) {
+      return {
+        messages: input.messages,
+        compacted: false,
+        totalTokensBefore,
+        totalTokensAfter: totalTokensBefore,
+        thresholdTokens,
+        reason: "circuit-open",
+      };
+    }
+
+    try {
+      const compacted = await args.narrativeCompact.compact({
+        messages: input.messages,
+        preserveRecentRounds: args.config.preserveRecentRounds,
+        summaryMaxTokens: args.config.summaryMaxTokens,
+        auxiliaryModel: input.auxiliaryModel,
+        kgSnapshot: input.kgSnapshot,
+        requestId: input.requestId ?? randomUUID(),
+      });
+      consecutiveFailures = 0;
+      const totalTokensAfter = estimateConversationTokens(compacted.compactedMessages);
+      return {
+        messages: compacted.compactedMessages,
+        compacted: true,
+        totalTokensBefore,
+        totalTokensAfter,
+        thresholdTokens,
+        reason: "compacted",
+      };
+    } catch {
+      consecutiveFailures += 1;
+      return {
+        messages: input.messages,
+        compacted: false,
+        totalTokensBefore,
+        totalTokensAfter: totalTokensBefore,
+        thresholdTokens,
+        reason: "compact-failed",
+      };
+    }
+  }
+
+  return {
+    maybeCompact,
+    getConsecutiveFailures: () => consecutiveFailures,
+  };
+}

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -28,6 +28,7 @@ export interface AutoCompactResult {
   error?: unknown;
   reason:
     | "below-threshold"
+    | "no-change"
     | "compacted"
     | "compact-failed"
     | "circuit-open";
@@ -139,18 +140,19 @@ export function createAutoCompact(args: {
         kgSnapshot: input.kgSnapshot,
         requestId: input.requestId ?? randomUUID(),
       });
-      consecutiveFailures = 0;
       const totalTokensAfter = estimateConversationTokens(compacted.compactedMessages);
       if (isSameMessages(compacted.compactedMessages, input.messages)) {
+        consecutiveFailures = 0;
         return {
           messages: input.messages,
           compacted: false,
           totalTokensBefore,
-          totalTokensAfter: totalTokensBefore,
+          totalTokensAfter,
           thresholdTokens,
-          reason: "below-threshold",
+          reason: "no-change",
         };
       }
+      consecutiveFailures = 0;
       return {
         messages: compacted.compactedMessages,
         compacted: true,

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -36,7 +36,7 @@ export interface AutoCompactResult {
 export interface AutoCompactService {
   maybeCompact: (args: {
     messages: CompactMessage[];
-    auxiliaryModel: string;
+    auxiliaryModel?: string;
     kgSnapshot: NarrativeKnowledgeSnapshot;
     requestId?: string;
   }) => Promise<AutoCompactResult>;
@@ -53,23 +53,56 @@ export function estimateConversationTokens(
 }
 
 export function createAutoCompact(args: {
-  config: CompactConfig;
+  config?: CompactConfig;
+  getConfig?: () => CompactConfig;
   narrativeCompact: NarrativeCompactService;
   logger?: {
     warn: (event: string, data?: Record<string, unknown>) => void;
   };
 }): AutoCompactService {
   let consecutiveFailures = 0;
+  const resolveConfig = (): CompactConfig => {
+    if (args.getConfig) {
+      return args.getConfig();
+    }
+    if (args.config) {
+      return args.config;
+    }
+    throw new Error("AutoCompact requires config or getConfig");
+  };
+
+  function isSameMessages(
+    lhs: ReadonlyArray<CompactMessage>,
+    rhs: ReadonlyArray<CompactMessage>,
+  ): boolean {
+    if (lhs.length !== rhs.length) {
+      return false;
+    }
+    for (let index = 0; index < lhs.length; index += 1) {
+      const left = lhs[index];
+      const right = rhs[index];
+      if (
+        left?.id !== right?.id ||
+        left?.role !== right?.role ||
+        left?.content !== right?.content ||
+        left?.compactable !== right?.compactable
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   async function maybeCompact(input: {
     messages: CompactMessage[];
-    auxiliaryModel: string;
+    auxiliaryModel?: string;
     kgSnapshot: NarrativeKnowledgeSnapshot;
     requestId?: string;
   }): Promise<AutoCompactResult> {
+    const config = resolveConfig();
     const totalTokensBefore = estimateConversationTokens(input.messages);
     const thresholdTokens = Math.floor(
-      args.config.contextBudget * args.config.triggerThresholdPercent,
+      config.contextBudget * config.triggerThresholdPercent,
     );
 
     if (totalTokensBefore < thresholdTokens) {
@@ -83,7 +116,7 @@ export function createAutoCompact(args: {
       };
     }
 
-    if (consecutiveFailures >= args.config.maxConsecutiveFailures) {
+    if (consecutiveFailures >= config.maxConsecutiveFailures) {
       return {
         messages: input.messages,
         compacted: false,
@@ -94,17 +127,30 @@ export function createAutoCompact(args: {
       };
     }
 
+    const auxiliaryModel =
+      config.auxiliaryModel ?? input.auxiliaryModel ?? "default";
+
     try {
       const compacted = await args.narrativeCompact.compact({
         messages: input.messages,
-        preserveRecentRounds: args.config.preserveRecentRounds,
-        summaryMaxTokens: args.config.summaryMaxTokens,
-        auxiliaryModel: input.auxiliaryModel,
+        preserveRecentRounds: config.preserveRecentRounds,
+        summaryMaxTokens: config.summaryMaxTokens,
+        auxiliaryModel,
         kgSnapshot: input.kgSnapshot,
         requestId: input.requestId ?? randomUUID(),
       });
       consecutiveFailures = 0;
       const totalTokensAfter = estimateConversationTokens(compacted.compactedMessages);
+      if (isSameMessages(compacted.compactedMessages, input.messages)) {
+        return {
+          messages: input.messages,
+          compacted: false,
+          totalTokensBefore,
+          totalTokensAfter: totalTokensBefore,
+          thresholdTokens,
+          reason: "below-threshold",
+        };
+      }
       return {
         messages: compacted.compactedMessages,
         compacted: true,
@@ -118,7 +164,7 @@ export function createAutoCompact(args: {
       args.logger?.warn("auto_compact_failed", {
         reason: "narrative_compact_error",
         consecutiveFailures,
-        maxConsecutiveFailures: args.config.maxConsecutiveFailures,
+        maxConsecutiveFailures: config.maxConsecutiveFailures,
         error,
       });
       return {

--- a/apps/desktop/main/src/services/ai/compact/autoCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/autoCompact.ts
@@ -26,11 +26,13 @@ export interface AutoCompactResult {
   totalTokensBefore: number;
   totalTokensAfter: number;
   thresholdTokens: number;
+  insufficientCompaction?: boolean;
   error?: unknown;
   reason:
     | "below-threshold"
     | "no-change"
     | "expansion-rejected"
+    | "compacted-insufficient"
     | "compacted"
     | "compact-failed"
     | "circuit-open";
@@ -183,6 +185,26 @@ export function createAutoCompact(args: {
           totalTokensAfter,
           thresholdTokens,
           reason: "expansion-rejected",
+        };
+      }
+      if (totalTokensAfter > thresholdTokens) {
+        // Spec circuit-breaker rule: compaction that still exceeds target budget counts as one failure.
+        consecutiveFailures += 1;
+        args.logger?.warn("auto_compact_insufficient", {
+          totalTokensBefore,
+          totalTokensAfter,
+          thresholdTokens,
+          consecutiveFailures,
+          maxConsecutiveFailures: config.maxConsecutiveFailures,
+        });
+        return {
+          messages: compacted.compactedMessages,
+          compacted: true,
+          totalTokensBefore,
+          totalTokensAfter,
+          thresholdTokens,
+          insufficientCompaction: true,
+          reason: "compacted-insufficient",
         };
       }
       consecutiveFailures = 0;

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -9,6 +9,38 @@
 import type { ResolvedModelConfig } from "../modelConfig";
 
 const FALLBACK_CONTEXT_BUDGET = 128_000;
+const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+  "gpt-4o": 128_000,
+  "gpt-4o-mini": 128_000,
+  "gpt-4.1": 1_000_000,
+  "gpt-4.1-mini": 1_000_000,
+  "gpt-4.1-nano": 1_000_000,
+  "claude-3-5-sonnet": 200_000,
+  "claude-3-7-sonnet": 200_000,
+  "claude-sonnet-4": 200_000,
+  "claude-sonnet-4.5": 200_000,
+  "claude-sonnet-4.6": 200_000,
+  "claude-opus-4.5": 200_000,
+  "claude-opus-4.6": 200_000,
+  "gemini-1.5-pro": 1_000_000,
+  "gemini-1.5-flash": 1_000_000,
+  "gemini-2.0-flash": 1_000_000,
+};
+
+function resolveKnownContextWindow(modelId: string): number | null {
+  const normalized = modelId.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  for (const [knownModelId, windowSize] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
+    if (normalized === knownModelId || normalized.startsWith(`${knownModelId}-`)) {
+      return windowSize;
+    }
+  }
+
+  return null;
+}
 
 export interface CompactConfig {
   triggerThresholdPercent: number;
@@ -27,11 +59,18 @@ export interface CompactConfigOverrides {
 }
 
 export function resolveContextBudgetFromModelConfig(
-  _modelConfig: ResolvedModelConfig,
+  modelConfig: ResolvedModelConfig,
 ): number {
-  // Why: current model config only resolves model ids. Until runtime provides
-  // per-model context windows, we keep a conservative default and allow caller
-  // overrides for explicit budgets.
+  const primaryBudget = resolveKnownContextWindow(modelConfig.primaryModel);
+  if (primaryBudget !== null) {
+    return primaryBudget;
+  }
+
+  const auxiliaryBudget = resolveKnownContextWindow(modelConfig.auxiliaryModel);
+  if (auxiliaryBudget !== null) {
+    return auxiliaryBudget;
+  }
+
   return FALLBACK_CONTEXT_BUDGET;
 }
 

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -85,12 +85,12 @@ export function createCompactConfig(args: {
   const resolvedBudget = resolveContextBudgetFromModelConfig(args.modelConfig);
 
   return {
-    minTokenThreshold: overrides.minTokenThreshold ?? 500,
-    triggerThresholdPercent: overrides.triggerThresholdPercent ?? 0.87,
-    preserveRecentRounds: overrides.preserveRecentRounds ?? 3,
-    maxConsecutiveFailures: overrides.maxConsecutiveFailures ?? 3,
+    minTokenThreshold: overrides.minTokenThreshold ?? 500, // Spec P2 shouldCompress floor: do not compact below 500 absolute tokens.
+    triggerThresholdPercent: overrides.triggerThresholdPercent ?? 0.87, // Spec P2 trigger ratio: start compaction at 87% of context budget.
+    preserveRecentRounds: overrides.preserveRecentRounds ?? 3, // Narrative safety default: keep ~3 recent rounds to preserve immediate writing intent.
+    maxConsecutiveFailures: overrides.maxConsecutiveFailures ?? 3, // Spec circuit breaker: open after 3 consecutive compaction failures.
     contextBudget: overrides.contextBudget ?? resolvedBudget,
-    summaryMaxTokens: overrides.summaryMaxTokens ?? 1_500,
+    summaryMaxTokens: overrides.summaryMaxTokens ?? 1_500, // Summary cap default: ~3-4 short narrative paragraphs without over-expanding context.
     auxiliaryModel: args.modelConfig.auxiliaryModel.trim() || undefined,
   };
 }

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -8,6 +8,8 @@
 
 import type { ResolvedModelConfig } from "../modelConfig";
 
+export const CIRCUIT_BREAKER_COOLDOWN_MS = 5 * 60 * 1000;
+
 // Safe fallback matching the most common modern context window (GPT-4o class, 128K);
 // used when neither primary nor auxiliary model appears in MODEL_CONTEXT_WINDOWS.
 const FALLBACK_CONTEXT_BUDGET = 128_000;

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -8,6 +8,8 @@
 
 import type { ResolvedModelConfig } from "../modelConfig";
 
+// Safe fallback matching the most common modern context window (GPT-4o class, 128K);
+// used when neither primary nor auxiliary model appears in MODEL_CONTEXT_WINDOWS.
 const FALLBACK_CONTEXT_BUDGET = 128_000;
 const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
   "gpt-4o": 128_000,

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -48,6 +48,7 @@ export interface CompactConfig {
   maxConsecutiveFailures: number;
   contextBudget: number;
   summaryMaxTokens: number;
+  auxiliaryModel?: string;
 }
 
 export interface CompactConfigOverrides {
@@ -87,5 +88,6 @@ export function createCompactConfig(args: {
     maxConsecutiveFailures: overrides.maxConsecutiveFailures ?? 3,
     contextBudget: overrides.contextBudget ?? resolvedBudget,
     summaryMaxTokens: overrides.summaryMaxTokens ?? 1_500,
+    auxiliaryModel: args.modelConfig.auxiliaryModel.trim() || undefined,
   };
 }

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -35,9 +35,19 @@ export function resolveKnownContextWindow(modelId: string): number | null {
     return null;
   }
 
-  for (const [knownModelId, windowSize] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
-    if (normalized === knownModelId || normalized.startsWith(`${knownModelId}-`)) {
-      return windowSize;
+  // Exact match first — avoids "gpt-4o" shadowing "gpt-4o-mini" via prefix.
+  const exact = MODEL_CONTEXT_WINDOWS[normalized];
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  // Prefix match sorted by descending key length so longer keys win.
+  const sortedKeys = Object.keys(MODEL_CONTEXT_WINDOWS).sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const knownModelId of sortedKeys) {
+    if (normalized.startsWith(`${knownModelId}-`)) {
+      return MODEL_CONTEXT_WINDOWS[knownModelId]!;
     }
   }
 

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -1,0 +1,52 @@
+/**
+ * @module compactConfig
+ * ## Responsibilities: provide AutoCompact defaults and safe overrides.
+ * ## Does not do: LLM invocation or message transformation.
+ * ## Dependency direction: ai/compact -> ai/modelConfig(shared type only).
+ * ## Invariants: INV-5, INV-10.
+ */
+
+import type { ResolvedModelConfig } from "../modelConfig";
+
+const FALLBACK_CONTEXT_BUDGET = 128_000;
+
+export interface CompactConfig {
+  triggerThresholdPercent: number;
+  preserveRecentRounds: number;
+  maxConsecutiveFailures: number;
+  contextBudget: number;
+  summaryMaxTokens: number;
+}
+
+export interface CompactConfigOverrides {
+  triggerThresholdPercent?: number;
+  preserveRecentRounds?: number;
+  maxConsecutiveFailures?: number;
+  contextBudget?: number;
+  summaryMaxTokens?: number;
+}
+
+export function resolveContextBudgetFromModelConfig(
+  _modelConfig: ResolvedModelConfig,
+): number {
+  // Why: current model config only resolves model ids. Until runtime provides
+  // per-model context windows, we keep a conservative default and allow caller
+  // overrides for explicit budgets.
+  return FALLBACK_CONTEXT_BUDGET;
+}
+
+export function createCompactConfig(args: {
+  modelConfig: ResolvedModelConfig;
+  overrides?: CompactConfigOverrides;
+}): CompactConfig {
+  const overrides = args.overrides ?? {};
+  const resolvedBudget = resolveContextBudgetFromModelConfig(args.modelConfig);
+
+  return {
+    triggerThresholdPercent: overrides.triggerThresholdPercent ?? 0.85,
+    preserveRecentRounds: overrides.preserveRecentRounds ?? 3,
+    maxConsecutiveFailures: overrides.maxConsecutiveFailures ?? 3,
+    contextBudget: overrides.contextBudget ?? resolvedBudget,
+    summaryMaxTokens: overrides.summaryMaxTokens ?? 1_500,
+  };
+}

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -43,6 +43,7 @@ export function resolveKnownContextWindow(modelId: string): number | null {
 }
 
 export interface CompactConfig {
+  minTokenThreshold: number;
   triggerThresholdPercent: number;
   preserveRecentRounds: number;
   maxConsecutiveFailures: number;
@@ -52,6 +53,7 @@ export interface CompactConfig {
 }
 
 export interface CompactConfigOverrides {
+  minTokenThreshold?: number;
   triggerThresholdPercent?: number;
   preserveRecentRounds?: number;
   maxConsecutiveFailures?: number;
@@ -83,7 +85,8 @@ export function createCompactConfig(args: {
   const resolvedBudget = resolveContextBudgetFromModelConfig(args.modelConfig);
 
   return {
-    triggerThresholdPercent: overrides.triggerThresholdPercent ?? 0.85,
+    minTokenThreshold: overrides.minTokenThreshold ?? 500,
+    triggerThresholdPercent: overrides.triggerThresholdPercent ?? 0.87,
     preserveRecentRounds: overrides.preserveRecentRounds ?? 3,
     maxConsecutiveFailures: overrides.maxConsecutiveFailures ?? 3,
     contextBudget: overrides.contextBudget ?? resolvedBudget,

--- a/apps/desktop/main/src/services/ai/compact/compactConfig.ts
+++ b/apps/desktop/main/src/services/ai/compact/compactConfig.ts
@@ -27,7 +27,7 @@ const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
   "gemini-2.0-flash": 1_000_000,
 };
 
-function resolveKnownContextWindow(modelId: string): number | null {
+export function resolveKnownContextWindow(modelId: string): number | null {
   const normalized = modelId.trim().toLowerCase();
   if (normalized.length === 0) {
     return null;

--- a/apps/desktop/main/src/services/ai/compact/index.ts
+++ b/apps/desktop/main/src/services/ai/compact/index.ts
@@ -9,6 +9,7 @@
 export {
   createCompactConfig,
   resolveContextBudgetFromModelConfig,
+  resolveKnownContextWindow,
   type CompactConfig,
   type CompactConfigOverrides,
 } from "./compactConfig";

--- a/apps/desktop/main/src/services/ai/compact/index.ts
+++ b/apps/desktop/main/src/services/ai/compact/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   createNarrativeCompact,
   type CompactMessage,
+  type CompactMessageRole,
   type NarrativeKnowledgeSnapshot,
   type NarrativeCompactDeps,
   type NarrativeCompactRequest,

--- a/apps/desktop/main/src/services/ai/compact/index.ts
+++ b/apps/desktop/main/src/services/ai/compact/index.ts
@@ -29,4 +29,5 @@ export {
   type NarrativeCompactResult,
   type SkillSummaryInvocation,
   type SkillSummaryResult,
+  NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER,
 } from "./narrativeCompact";

--- a/apps/desktop/main/src/services/ai/compact/index.ts
+++ b/apps/desktop/main/src/services/ai/compact/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @module ai/compact
+ * ## Responsibilities: export narrative-aware compaction services for writing pipeline integration.
+ * ## Does not do: orchestrator wiring or request lifecycle ownership.
+ * ## Dependency direction: ai/compact -> ai/modelConfig + shared token estimation.
+ * ## Invariants: INV-5, INV-10.
+ */
+
+export {
+  createCompactConfig,
+  resolveContextBudgetFromModelConfig,
+  type CompactConfig,
+  type CompactConfigOverrides,
+} from "./compactConfig";
+export {
+  createAutoCompact,
+  estimateConversationTokens,
+  type AutoCompactResult,
+  type AutoCompactService,
+} from "./autoCompact";
+export {
+  createNarrativeCompact,
+  type CompactMessage,
+  type NarrativeKnowledgeSnapshot,
+  type NarrativeCompactDeps,
+  type NarrativeCompactRequest,
+  type NarrativeCompactResult,
+  type SkillSummaryInvocation,
+  type SkillSummaryResult,
+} from "./narrativeCompact";

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -73,6 +73,7 @@ export interface NarrativeCompactResult {
 
 const NARRATIVE_COMPACT_SKILL_ID = "builtin:summarize";
 const NARRATIVE_COMPACT_SKILL_USAGE_ID = "builtin:narrative-compact";
+export const NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER = "[NARRATIVE_SUMMARY_TOKEN_LIMIT]";
 
 function toMessageText(messages: readonly CompactMessage[]): string {
   return messages
@@ -122,6 +123,8 @@ function buildNarrativeCompactPrompt(args: {
   return [
     "You are compressing fiction-writing conversation history.",
     "Return a compact narrative summary in Chinese.",
+    "Output must be flowing narrative prose paragraph(s).",
+    "Do NOT use markdown headings, section labels, bullet lists, numbered lists, or tables.",
     "MUST preserve:",
     "1) All KG entities and relations by exact name.",
     "2) Character settings and world settings.",
@@ -130,24 +133,7 @@ function buildNarrativeCompactPrompt(args: {
     "5) Foreshadowing clues and suspense threads.",
     "6) Timeline markers and sequence constraints.",
     "7) Explicit user writing constraints (style/voice/perspective instructions).",
-    "Output format:",
-    "## Narrative Summary",
-    "- key events",
-    "## KG Entities",
-    "- exact names",
-    "## KG Relations",
-    "- exact relations",
-    "## Character & World Settings",
-    "- preserved settings",
-    "## Unresolved Plot Points",
-    "- unresolved points",
-    "## Tone & POV",
-    "- tone markers and POV",
-    "## Foreshadowing & Timeline",
-    "- clues and timeline markers",
-    "## User Constraints",
-    "- explicit writing constraints",
-    `请将摘要控制在约 ${args.summaryMaxTokens} tokens 以内。`,
+    `${NARRATIVE_SUMMARY_TOKEN_LIMIT_MARKER}:${args.summaryMaxTokens} 请将摘要控制在约 ${args.summaryMaxTokens} tokens 以内。`,
     "",
     `[KG_ENTITIES] ${args.kgSnapshot.entities.join(" | ")}`,
     `[KG_RELATIONS] ${args.kgSnapshot.relations.join(" | ")}`,
@@ -211,39 +197,37 @@ function appendMissingNarrativeAnchors(args: {
     return args.summary;
   }
 
-  const suffixLines = [
-    "",
-    "## Preservation Addendum",
+  const preservationClauses = [
     missingEntities.length > 0
-      ? `- KG entities: ${missingEntities.join("、")}`
+      ? `需要明确提及的 KG 实体有：${missingEntities.join("、")}`
       : undefined,
     missingRelations.length > 0
-      ? `- KG relations: ${missingRelations.join("、")}`
+      ? `需要明确提及的 KG 关系有：${missingRelations.join("、")}`
       : undefined,
     missingSettings.length > 0
-      ? `- Character/World settings: ${missingSettings.join("、")}`
+      ? `需要明确提及的角色/世界设定有：${missingSettings.join("、")}`
       : undefined,
     missingPlotPoints.length > 0
-      ? `- Unresolved plot points: ${missingPlotPoints.join("、")}`
+      ? `需要明确提及的未解情节有：${missingPlotPoints.join("、")}`
       : undefined,
     missingToneMarkers.length > 0
-      ? `- Tone markers: ${missingToneMarkers.join("、")}`
+      ? `需要保留的语气标记有：${missingToneMarkers.join("、")}`
       : undefined,
     missingNarrativePOV.length > 0
-      ? `- Narrative POV: ${missingNarrativePOV.join("、")}`
+      ? `需要保留的叙事视角有：${missingNarrativePOV.join("、")}`
       : undefined,
     missingForeshadowing.length > 0
-      ? `- Foreshadowing clues: ${missingForeshadowing.join("、")}`
+      ? `需要保留的伏笔线索有：${missingForeshadowing.join("、")}`
       : undefined,
     missingTimelineMarkers.length > 0
-      ? `- Timeline markers: ${missingTimelineMarkers.join("、")}`
+      ? `需要保留的时间线标记有：${missingTimelineMarkers.join("、")}`
       : undefined,
     missingUserConstraints.length > 0
-      ? `- User constraints: ${missingUserConstraints.join("、")}`
+      ? `需要保留的用户写作约束有：${missingUserConstraints.join("、")}`
       : undefined,
   ].filter((line): line is string => line !== undefined);
 
-  return `${args.summary.trim()}\n${suffixLines.join("\n")}`.trim();
+  return `${args.summary.trim()}\n\n补充保真说明：${preservationClauses.join("；")}。`.trim();
 }
 
 function dedupeById(messages: ReadonlyArray<CompactMessage>): CompactMessage[] {

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -110,6 +110,7 @@ function splitConversationByRecentRounds(
 function buildNarrativeCompactPrompt(args: {
   historyMessages: ReadonlyArray<CompactMessage>;
   kgSnapshot: NarrativeKnowledgeSnapshot;
+  summaryMaxTokens: number;
 }): string {
   const historyText = toMessageText(args.historyMessages);
 
@@ -131,6 +132,7 @@ function buildNarrativeCompactPrompt(args: {
     "- preserved settings",
     "## Unresolved Plot Points",
     "- unresolved points",
+    `请将摘要控制在约 ${args.summaryMaxTokens} tokens 以内。`,
     "",
     `[KG_ENTITIES] ${args.kgSnapshot.entities.join(" | ")}`,
     `[KG_RELATIONS] ${args.kgSnapshot.relations.join(" | ")}`,
@@ -245,6 +247,7 @@ export function createNarrativeCompact(deps: NarrativeCompactDeps): {
     const prompt = buildNarrativeCompactPrompt({
       historyMessages: compactableHistoryMessages,
       kgSnapshot: request.kgSnapshot,
+      summaryMaxTokens: request.summaryMaxTokens,
     });
     const skillResult = await deps.invokeSkillSummary({
       skillId: NARRATIVE_COMPACT_SKILL_ID,

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -234,12 +234,9 @@ export function createNarrativeCompact(deps: NarrativeCompactDeps): {
         content: "无需压缩：历史中没有可压缩内容。",
         compactable: false,
       };
-      const preservedMessages = dedupeById([
-        ...pinnedHistoryMessages,
-        ...recentMessages,
-      ]);
+      const preservedMessages = dedupeById([...request.messages]);
       return {
-        compactedMessages: [...systemMessages, fallbackSummary, ...preservedMessages],
+        compactedMessages: [...request.messages],
         summaryMessage: fallbackSummary,
         preservedMessages,
       };

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -26,6 +26,11 @@ export interface NarrativeKnowledgeSnapshot {
   relations: string[];
   characterSettings: string[];
   unresolvedPlotPoints: string[];
+  toneMarkers?: string[];
+  narrativePOV?: string;
+  foreshadowingClues?: string[];
+  timelineMarkers?: string[];
+  userConstraints?: string[];
 }
 
 export interface SkillSummaryInvocation {
@@ -121,6 +126,10 @@ function buildNarrativeCompactPrompt(args: {
     "1) All KG entities and relations by exact name.",
     "2) Character settings and world settings.",
     "3) Unresolved plot points and pending clues.",
+    "4) Narrative tone markers and current POV (point of view).",
+    "5) Foreshadowing clues and suspense threads.",
+    "6) Timeline markers and sequence constraints.",
+    "7) Explicit user writing constraints (style/voice/perspective instructions).",
     "Output format:",
     "## Narrative Summary",
     "- key events",
@@ -132,12 +141,23 @@ function buildNarrativeCompactPrompt(args: {
     "- preserved settings",
     "## Unresolved Plot Points",
     "- unresolved points",
+    "## Tone & POV",
+    "- tone markers and POV",
+    "## Foreshadowing & Timeline",
+    "- clues and timeline markers",
+    "## User Constraints",
+    "- explicit writing constraints",
     `请将摘要控制在约 ${args.summaryMaxTokens} tokens 以内。`,
     "",
     `[KG_ENTITIES] ${args.kgSnapshot.entities.join(" | ")}`,
     `[KG_RELATIONS] ${args.kgSnapshot.relations.join(" | ")}`,
     `[CHARACTER_SETTINGS] ${args.kgSnapshot.characterSettings.join(" | ")}`,
     `[UNRESOLVED_PLOT_POINTS] ${args.kgSnapshot.unresolvedPlotPoints.join(" | ")}`,
+    `[TONE_MARKERS] ${(args.kgSnapshot.toneMarkers ?? []).join(" | ")}`,
+    `[NARRATIVE_POV] ${args.kgSnapshot.narrativePOV ?? ""}`,
+    `[FORESHADOWING_CLUES] ${(args.kgSnapshot.foreshadowingClues ?? []).join(" | ")}`,
+    `[TIMELINE_MARKERS] ${(args.kgSnapshot.timelineMarkers ?? []).join(" | ")}`,
+    `[USER_CONSTRAINTS] ${(args.kgSnapshot.userConstraints ?? []).join(" | ")}`,
     "",
     "[HISTORY]",
     historyText,
@@ -160,12 +180,33 @@ function appendMissingNarrativeAnchors(args: {
   const missingPlotPoints = args.kgSnapshot.unresolvedPlotPoints.filter(
     (plotPoint) => !args.summary.includes(plotPoint),
   );
+  const missingToneMarkers = (args.kgSnapshot.toneMarkers ?? []).filter(
+    (tone) => !args.summary.includes(tone),
+  );
+  const missingNarrativePOV =
+    args.kgSnapshot.narrativePOV && !args.summary.includes(args.kgSnapshot.narrativePOV)
+      ? [args.kgSnapshot.narrativePOV]
+      : [];
+  const missingForeshadowing = (args.kgSnapshot.foreshadowingClues ?? []).filter(
+    (clue) => !args.summary.includes(clue),
+  );
+  const missingTimelineMarkers = (args.kgSnapshot.timelineMarkers ?? []).filter(
+    (marker) => !args.summary.includes(marker),
+  );
+  const missingUserConstraints = (args.kgSnapshot.userConstraints ?? []).filter(
+    (constraint) => !args.summary.includes(constraint),
+  );
 
   if (
     missingEntities.length === 0 &&
     missingRelations.length === 0 &&
     missingSettings.length === 0 &&
-    missingPlotPoints.length === 0
+    missingPlotPoints.length === 0 &&
+    missingToneMarkers.length === 0 &&
+    missingNarrativePOV.length === 0 &&
+    missingForeshadowing.length === 0 &&
+    missingTimelineMarkers.length === 0 &&
+    missingUserConstraints.length === 0
   ) {
     return args.summary;
   }
@@ -184,6 +225,21 @@ function appendMissingNarrativeAnchors(args: {
       : undefined,
     missingPlotPoints.length > 0
       ? `- Unresolved plot points: ${missingPlotPoints.join("、")}`
+      : undefined,
+    missingToneMarkers.length > 0
+      ? `- Tone markers: ${missingToneMarkers.join("、")}`
+      : undefined,
+    missingNarrativePOV.length > 0
+      ? `- Narrative POV: ${missingNarrativePOV.join("、")}`
+      : undefined,
+    missingForeshadowing.length > 0
+      ? `- Foreshadowing clues: ${missingForeshadowing.join("、")}`
+      : undefined,
+    missingTimelineMarkers.length > 0
+      ? `- Timeline markers: ${missingTimelineMarkers.join("、")}`
+      : undefined,
+    missingUserConstraints.length > 0
+      ? `- User constraints: ${missingUserConstraints.join("、")}`
       : undefined,
   ].filter((line): line is string => line !== undefined);
 

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -66,7 +66,7 @@ export interface NarrativeCompactResult {
   preservedMessages: CompactMessage[];
 }
 
-const NARRATIVE_COMPACT_SKILL_ID = "builtin:narrative-compact-summary";
+const NARRATIVE_COMPACT_SKILL_ID = "builtin:summarize";
 const NARRATIVE_COMPACT_SKILL_USAGE_ID = "builtin:narrative-compact";
 
 function toMessageText(messages: readonly CompactMessage[]): string {

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -1,0 +1,299 @@
+/**
+ * @module narrativeCompact
+ * ## Responsibilities: narrative-aware conversation compaction with KG guards.
+ * ## Does not do: trigger decisions or circuit-breaker state ownership.
+ * ## Dependency direction: ai/compact -> shared(tokenBudget) + ai(costTracker).
+ * ## Invariants: INV-3, INV-5, INV-6, INV-9, INV-10.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { estimateTokens } from "@shared/tokenBudget";
+
+import type { CostTracker } from "../costTracker";
+
+export type CompactMessageRole = "system" | "user" | "assistant" | "tool";
+
+export interface CompactMessage {
+  id: string;
+  role: CompactMessageRole;
+  content: string;
+  compactable?: boolean;
+}
+
+export interface NarrativeKnowledgeSnapshot {
+  entities: string[];
+  relations: string[];
+  characterSettings: string[];
+  unresolvedPlotPoints: string[];
+}
+
+export interface SkillSummaryInvocation {
+  skillId: string;
+  modelId: string;
+  input: string;
+  summaryMaxTokens: number;
+  requestId: string;
+}
+
+export interface SkillSummaryResult {
+  summary: string;
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+  };
+}
+
+export interface NarrativeCompactDeps {
+  invokeSkillSummary: (
+    request: SkillSummaryInvocation,
+  ) => Promise<SkillSummaryResult>;
+  costTracker?: Pick<CostTracker, "recordUsage">;
+}
+
+export interface NarrativeCompactRequest {
+  messages: CompactMessage[];
+  preserveRecentRounds: number;
+  summaryMaxTokens: number;
+  auxiliaryModel: string;
+  kgSnapshot: NarrativeKnowledgeSnapshot;
+  requestId?: string;
+}
+
+export interface NarrativeCompactResult {
+  compactedMessages: CompactMessage[];
+  summaryMessage: CompactMessage;
+  preservedMessages: CompactMessage[];
+}
+
+const NARRATIVE_COMPACT_SKILL_ID = "builtin:narrative-compact-summary";
+const NARRATIVE_COMPACT_SKILL_USAGE_ID = "builtin:narrative-compact";
+
+function toMessageText(messages: readonly CompactMessage[]): string {
+  return messages
+    .map((message) => `[${message.role}] ${message.content}`)
+    .join("\n");
+}
+
+function splitConversationByRecentRounds(
+  messages: ReadonlyArray<CompactMessage>,
+  keepRecentRounds: number,
+): {
+  historyMessages: CompactMessage[];
+  recentMessages: CompactMessage[];
+} {
+  if (keepRecentRounds <= 0 || messages.length === 0) {
+    return {
+      historyMessages: [...messages],
+      recentMessages: [],
+    };
+  }
+
+  const rounds: CompactMessage[][] = [];
+  for (const message of messages) {
+    const lastRound = rounds.at(-1);
+    if (message.role === "user" || lastRound === undefined) {
+      rounds.push([message]);
+      continue;
+    }
+    lastRound.push(message);
+  }
+
+  const recentRounds = rounds.slice(-keepRecentRounds);
+  const historyRounds = rounds.slice(0, Math.max(0, rounds.length - keepRecentRounds));
+  return {
+    historyMessages: historyRounds.flat(),
+    recentMessages: recentRounds.flat(),
+  };
+}
+
+function buildNarrativeCompactPrompt(args: {
+  historyMessages: ReadonlyArray<CompactMessage>;
+  kgSnapshot: NarrativeKnowledgeSnapshot;
+}): string {
+  const historyText = toMessageText(args.historyMessages);
+
+  return [
+    "You are compressing fiction-writing conversation history.",
+    "Return a compact narrative summary in Chinese.",
+    "MUST preserve:",
+    "1) All KG entities and relations by exact name.",
+    "2) Character settings and world settings.",
+    "3) Unresolved plot points and pending clues.",
+    "Output format:",
+    "## Narrative Summary",
+    "- key events",
+    "## KG Entities",
+    "- exact names",
+    "## KG Relations",
+    "- exact relations",
+    "## Character & World Settings",
+    "- preserved settings",
+    "## Unresolved Plot Points",
+    "- unresolved points",
+    "",
+    `[KG_ENTITIES] ${args.kgSnapshot.entities.join(" | ")}`,
+    `[KG_RELATIONS] ${args.kgSnapshot.relations.join(" | ")}`,
+    `[CHARACTER_SETTINGS] ${args.kgSnapshot.characterSettings.join(" | ")}`,
+    `[UNRESOLVED_PLOT_POINTS] ${args.kgSnapshot.unresolvedPlotPoints.join(" | ")}`,
+    "",
+    "[HISTORY]",
+    historyText,
+  ].join("\n");
+}
+
+function appendMissingNarrativeAnchors(args: {
+  summary: string;
+  kgSnapshot: NarrativeKnowledgeSnapshot;
+}): string {
+  const missingEntities = args.kgSnapshot.entities.filter(
+    (entity) => !args.summary.includes(entity),
+  );
+  const missingRelations = args.kgSnapshot.relations.filter(
+    (relation) => !args.summary.includes(relation),
+  );
+  const missingSettings = args.kgSnapshot.characterSettings.filter(
+    (setting) => !args.summary.includes(setting),
+  );
+  const missingPlotPoints = args.kgSnapshot.unresolvedPlotPoints.filter(
+    (plotPoint) => !args.summary.includes(plotPoint),
+  );
+
+  if (
+    missingEntities.length === 0 &&
+    missingRelations.length === 0 &&
+    missingSettings.length === 0 &&
+    missingPlotPoints.length === 0
+  ) {
+    return args.summary;
+  }
+
+  const suffixLines = [
+    "",
+    "## Preservation Addendum",
+    missingEntities.length > 0
+      ? `- KG entities: ${missingEntities.join("、")}`
+      : undefined,
+    missingRelations.length > 0
+      ? `- KG relations: ${missingRelations.join("、")}`
+      : undefined,
+    missingSettings.length > 0
+      ? `- Character/World settings: ${missingSettings.join("、")}`
+      : undefined,
+    missingPlotPoints.length > 0
+      ? `- Unresolved plot points: ${missingPlotPoints.join("、")}`
+      : undefined,
+  ].filter((line): line is string => line !== undefined);
+
+  return `${args.summary.trim()}\n${suffixLines.join("\n")}`.trim();
+}
+
+function dedupeById(messages: ReadonlyArray<CompactMessage>): CompactMessage[] {
+  const seen = new Set<string>();
+  const deduped: CompactMessage[] = [];
+  for (const message of messages) {
+    if (seen.has(message.id)) {
+      continue;
+    }
+    seen.add(message.id);
+    deduped.push(message);
+  }
+  return deduped;
+}
+
+export function createNarrativeCompact(deps: NarrativeCompactDeps): {
+  compact: (request: NarrativeCompactRequest) => Promise<NarrativeCompactResult>;
+} {
+  async function compact(
+    request: NarrativeCompactRequest,
+  ): Promise<NarrativeCompactResult> {
+    const requestId = request.requestId ?? randomUUID();
+    const systemMessages = request.messages.filter(
+      (message) => message.role === "system",
+    );
+    const nonSystemMessages = request.messages.filter(
+      (message) => message.role !== "system",
+    );
+
+    const { historyMessages, recentMessages } = splitConversationByRecentRounds(
+      nonSystemMessages,
+      request.preserveRecentRounds,
+    );
+
+    const pinnedHistoryMessages = historyMessages.filter(
+      (message) => message.compactable === false,
+    );
+    const compactableHistoryMessages = historyMessages.filter(
+      (message) => message.compactable !== false,
+    );
+
+    if (compactableHistoryMessages.length === 0) {
+      const fallbackSummary: CompactMessage = {
+        id: `compact-summary-${requestId}`,
+        role: "assistant",
+        content: "无需压缩：历史中没有可压缩内容。",
+        compactable: false,
+      };
+      const preservedMessages = dedupeById([
+        ...pinnedHistoryMessages,
+        ...recentMessages,
+      ]);
+      return {
+        compactedMessages: [...systemMessages, fallbackSummary, ...preservedMessages],
+        summaryMessage: fallbackSummary,
+        preservedMessages,
+      };
+    }
+
+    const prompt = buildNarrativeCompactPrompt({
+      historyMessages: compactableHistoryMessages,
+      kgSnapshot: request.kgSnapshot,
+    });
+    const skillResult = await deps.invokeSkillSummary({
+      skillId: NARRATIVE_COMPACT_SKILL_ID,
+      modelId: request.auxiliaryModel,
+      input: prompt,
+      summaryMaxTokens: request.summaryMaxTokens,
+      requestId,
+    });
+    const completedSummary = appendMissingNarrativeAnchors({
+      summary: skillResult.summary,
+      kgSnapshot: request.kgSnapshot,
+    });
+
+    const summaryMessage: CompactMessage = {
+      id: `compact-summary-${requestId}`,
+      role: "assistant",
+      compactable: false,
+      content: completedSummary,
+    };
+
+    const preservedMessages = dedupeById([
+      ...pinnedHistoryMessages,
+      ...recentMessages,
+    ]);
+
+    const promptTokens =
+      skillResult.usage?.promptTokens ?? estimateTokens(prompt);
+    const completionTokens =
+      skillResult.usage?.completionTokens ?? estimateTokens(completedSummary);
+
+    deps.costTracker?.recordUsage(
+      {
+        promptTokens,
+        completionTokens,
+      },
+      request.auxiliaryModel,
+      requestId,
+      NARRATIVE_COMPACT_SKILL_USAGE_ID,
+    );
+
+    return {
+      compactedMessages: [...systemMessages, summaryMessage, ...preservedMessages],
+      summaryMessage,
+      preservedMessages,
+    };
+  }
+
+  return { compact };
+}

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -364,6 +364,48 @@ describe("WritingOrchestrator", () => {
       });
     });
 
+    it("在 AI 调用前执行 AutoCompact 并使用压缩后消息", async () => {
+      const aiService = createMockAIService();
+      const autoCompact = {
+        maybeCompact: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              id: "compact-0",
+              role: "user",
+              content: "这是压缩后的用户输入",
+            },
+          ],
+          totalTokensAfter: 42,
+        }),
+      };
+      orchestrator = createWritingOrchestrator(
+        buildConfig({
+          aiService,
+          autoCompact,
+          prepareRequest: async () => ({
+            messages: [{ role: "user", content: "原始输入" }],
+            tokenCount: 500,
+            modelId: "gpt-4o-mini",
+          }),
+        }),
+      );
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const assembled = events.find((event) => event.type === "context-assembled");
+      expect(assembled).toMatchObject({
+        type: "context-assembled",
+        tokenCount: 42,
+      });
+      expect(autoCompact.maybeCompact).toHaveBeenCalledTimes(1);
+      const streamMessages = aiService.streamChat.mock.calls[0]?.[0];
+      expect(streamMessages).toEqual([
+        {
+          role: "user",
+          content: "这是压缩后的用户输入",
+        },
+      ]);
+    });
+
     it("写回前先创建 pre-write 快照，再执行 documentWrite", async () => {
       await collectEvents(orchestrator.execute(makeRequest()));
 

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -413,6 +413,13 @@ describe("WritingOrchestrator", () => {
       expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
         expect.objectContaining({
           requestModelId: "gpt-4o-mini",
+          requestId: "req-001-compact",
+          messages: [
+            expect.objectContaining({
+              role: "user",
+              compactable: false,
+            }),
+          ],
           kgSnapshot: {
             entities: ["林远", "白塔"],
             relations: ["林远 -> 白塔: 守护"],
@@ -466,11 +473,17 @@ describe("WritingOrchestrator", () => {
       expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
         expect.objectContaining({
           requestModelId: "gpt-4o-mini",
+          requestId: "req-001-compact",
           kgSnapshot: {
             entities: [],
             relations: [],
             characterSettings: [],
             unresolvedPlotPoints: [],
+            toneMarkers: [],
+            narrativePOV: undefined,
+            foreshadowingClues: [],
+            timelineMarkers: [],
+            userConstraints: [],
           },
         }),
       );

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -412,6 +412,7 @@ describe("WritingOrchestrator", () => {
       });
       expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
         expect.objectContaining({
+          requestModelId: "gpt-4o-mini",
           kgSnapshot: {
             entities: ["林远", "白塔"],
             relations: ["林远 -> 白塔: 守护"],
@@ -464,6 +465,7 @@ describe("WritingOrchestrator", () => {
 
       expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
         expect.objectContaining({
+          requestModelId: "gpt-4o-mini",
           kgSnapshot: {
             entities: [],
             relations: [],
@@ -662,6 +664,11 @@ describe("WritingOrchestrator", () => {
 
       await collectEvents(orch.execute(makeRequest({ agenticLoop: true })));
 
+      expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestModelId: "gpt-4o-mini",
+        }),
+      );
       expect(generateText).toHaveBeenCalledTimes(1);
       expect(generateText.mock.calls[0]?.[0]).toMatchObject({
         messages: [

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -617,6 +617,60 @@ describe("WritingOrchestrator", () => {
       expect(eventTypes(events)).toContain("ai-done");
       orch.dispose();
     });
+
+    it("agenticLoop 首轮 generateText 使用压缩后消息", async () => {
+      const generateText = vi.fn(async ({ emitChunk }) => {
+        emitChunk("完成", 2);
+        return {
+          fullText: "完成",
+          usage: {
+            promptTokens: 10,
+            completionTokens: 2,
+            totalTokens: 12,
+          },
+          finishReason: "stop" as const,
+        };
+      });
+      const autoCompact = {
+        maybeCompact: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              id: "compact-system",
+              role: "system",
+              content: "你是小说写作助手。",
+              compactable: false,
+            },
+            {
+              id: "compact-user",
+              role: "user",
+              content: "这是压缩后的历史上下文。",
+            },
+          ],
+          totalTokensAfter: 12,
+        }),
+      };
+      const cfg = buildConfig({
+        generateText,
+        autoCompact,
+        prepareRequest: async () => ({
+          messages: [{ role: "user", content: "原始输入" }],
+          tokenCount: 256,
+          modelId: "gpt-4o-mini",
+        }),
+      });
+      const orch = createWritingOrchestrator(cfg);
+
+      await collectEvents(orch.execute(makeRequest({ agenticLoop: true })));
+
+      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(generateText.mock.calls[0]?.[0]).toMatchObject({
+        messages: [
+          { role: "system", content: "你是小说写作助手。" },
+          { role: "user", content: "这是压缩后的历史上下文。" },
+        ],
+      });
+      orch.dispose();
+    });
   });
 
   // ── 中止链路 ──────────────────────────────────────────────────

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -366,6 +366,12 @@ describe("WritingOrchestrator", () => {
 
     it("在 AI 调用前执行 AutoCompact 并使用压缩后消息", async () => {
       const aiService = createMockAIService();
+      const getAutoCompactSnapshot = vi.fn().mockResolvedValue({
+        entities: ["林远", "白塔"],
+        relations: ["林远 -> 白塔: 守护"],
+        characterSettings: ["林远: 谨慎寡言"],
+        unresolvedPlotPoints: ["白塔钟声来源未揭示"],
+      });
       const autoCompact = {
         maybeCompact: vi.fn().mockResolvedValue({
           messages: [
@@ -382,6 +388,7 @@ describe("WritingOrchestrator", () => {
         buildConfig({
           aiService,
           autoCompact,
+          getAutoCompactSnapshot,
           prepareRequest: async () => ({
             messages: [{ role: "user", content: "原始输入" }],
             tokenCount: 500,
@@ -397,6 +404,22 @@ describe("WritingOrchestrator", () => {
         tokenCount: 42,
       });
       expect(autoCompact.maybeCompact).toHaveBeenCalledTimes(1);
+      expect(getAutoCompactSnapshot).toHaveBeenCalledWith({
+        request: expect.objectContaining({
+          requestId: "req-001",
+          documentId: "doc-001",
+        }),
+      });
+      expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kgSnapshot: {
+            entities: ["林远", "白塔"],
+            relations: ["林远 -> 白塔: 守护"],
+            characterSettings: ["林远: 谨慎寡言"],
+            unresolvedPlotPoints: ["白塔钟声来源未揭示"],
+          },
+        }),
+      );
       const streamMessages = aiService.streamChat.mock.calls[0]?.[0];
       expect(streamMessages).toEqual([
         {
@@ -404,6 +427,57 @@ describe("WritingOrchestrator", () => {
           content: "这是压缩后的用户输入",
         },
       ]);
+    });
+
+    it("AutoCompact KG 快照获取失败时降级为空快照继续执行", async () => {
+      const aiService = createMockAIService();
+      const warn = vi.fn();
+      const autoCompact = {
+        maybeCompact: vi.fn().mockResolvedValue({
+          messages: [
+            {
+              id: "compact-0",
+              role: "user",
+              content: "这是压缩后的用户输入",
+            },
+          ],
+          totalTokensAfter: 42,
+        }),
+      };
+      orchestrator = createWritingOrchestrator(
+        buildConfig({
+          aiService,
+          autoCompact,
+          logger: { warn },
+          getAutoCompactSnapshot: vi
+            .fn()
+            .mockRejectedValue(new Error("kg unavailable")),
+          prepareRequest: async () => ({
+            messages: [{ role: "user", content: "原始输入" }],
+            tokenCount: 500,
+            modelId: "gpt-4o-mini",
+          }),
+        }),
+      );
+
+      await collectEvents(orchestrator.execute(makeRequest()));
+
+      expect(autoCompact.maybeCompact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kgSnapshot: {
+            entities: [],
+            relations: [],
+            characterSettings: [],
+            unresolvedPlotPoints: [],
+          },
+        }),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        "orchestrator_auto_compact_kg_degraded",
+        expect.objectContaining({
+          requestId: "req-001",
+        }),
+      );
     });
 
     it("写回前先创建 pre-write 快照，再执行 documentWrite", async () => {

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -30,6 +30,11 @@ import type { StreamChunk, ToolCallInfo } from "../ai/streaming";
 import type { CostTracker } from "../ai/costTracker";
 import type { ToolUseHandler } from "./toolUseHandler";
 import type {
+  CompactMessage,
+  CompactMessageRole,
+  NarrativeKnowledgeSnapshot,
+} from "../ai/compact";
+import type {
   DiffPreview,
   PermissionGate,
   PermissionLevel,
@@ -133,27 +138,6 @@ interface PreparedRequest {
 
 type OrchestratorTokenUsage = AiTokenUsage;
 
-type AutoCompactMessageRole = "system" | "user" | "assistant" | "tool";
-
-type AutoCompactMessage = {
-  id: string;
-  role: AutoCompactMessageRole;
-  content: string;
-  compactable?: boolean;
-};
-
-type AutoCompactSnapshot = {
-  entities: string[];
-  relations: string[];
-  characterSettings: string[];
-  unresolvedPlotPoints: string[];
-  toneMarkers?: string[];
-  narrativePOV?: string;
-  foreshadowingClues?: string[];
-  timelineMarkers?: string[];
-  userConstraints?: string[];
-};
-
 type GeneratedTextResult = {
   fullText: string;
   usage: OrchestratorTokenUsage;
@@ -216,16 +200,16 @@ export interface OrchestratorConfig {
   }>;
   autoCompact?: {
     maybeCompact: (args: {
-      messages: AutoCompactMessage[];
+      messages: CompactMessage[];
       auxiliaryModel?: string;
       requestModelId?: string;
-      kgSnapshot: AutoCompactSnapshot;
+      kgSnapshot: NarrativeKnowledgeSnapshot;
       requestId?: string;
-    }) => Promise<{ messages: AutoCompactMessage[]; totalTokensAfter: number }>;
+    }) => Promise<{ messages: CompactMessage[]; totalTokensAfter: number }>;
   };
   getAutoCompactSnapshot?: (args: {
     request: Pick<WritingRequest, "projectId" | "documentId" | "requestId">;
-  }) => Promise<AutoCompactSnapshot>;
+  }) => Promise<NarrativeKnowledgeSnapshot>;
   logger?: {
     warn: (event: string, data?: Record<string, unknown>) => void;
   };
@@ -305,7 +289,7 @@ export function createWritingOrchestrator(
     return { original, modified: fullText, changeType: "replace" };
   }
 
-  function normalizeAutoCompactRole(role: string): AutoCompactMessageRole {
+  function normalizeAutoCompactRole(role: string): CompactMessageRole {
     if (role === "system" || role === "assistant" || role === "tool") {
       return role;
     }
@@ -314,7 +298,7 @@ export function createWritingOrchestrator(
 
   function convertMessagesForAutoCompact(
     messages: Array<{ role: string; content: string }>,
-  ): AutoCompactMessage[] {
+  ): CompactMessage[] {
     const hasWritingDirective = (content: string): boolean =>
       /(第一人称|第三人称|语气|文风|风格|口吻|时态|不要|必须|请务必|写作约束|叙述视角|POV|pov)/i.test(
         content,
@@ -344,7 +328,7 @@ export function createWritingOrchestrator(
   }
 
   function convertMessagesFromAutoCompact(
-    messages: AutoCompactMessage[],
+    messages: CompactMessage[],
   ): Array<{ role: string; content: string }> {
     return messages.map((message) => ({
       role: message.role,
@@ -418,7 +402,7 @@ export function createWritingOrchestrator(
         const preparedWithCompaction = autoCompact
             ? await (async (): Promise<PreparedRequest> => {
               try {
-                let kgSnapshot: AutoCompactSnapshot = {
+                let kgSnapshot: NarrativeKnowledgeSnapshot = {
                   entities: [],
                   relations: [],
                   characterSettings: [],

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -416,12 +416,14 @@ export function createWritingOrchestrator(
                     });
                   }
                 }
+                // INV-9: Use a distinct requestId so costTracker does not
+                // conflate compact-call costs with the outer generation costs.
                 const compactResult = await autoCompact.maybeCompact({
                   messages: convertMessagesForAutoCompact(prepared.messages),
                   auxiliaryModel: prepared.modelId,
                   requestModelId: prepared.modelId,
                   kgSnapshot,
-                  requestId,
+                  requestId: `${requestId}-compact`,
                 });
                 return {
                   ...prepared,

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -559,6 +559,9 @@ export function createWritingOrchestrator(
                   onApiCallStarted: () => {
                     apiCallStarted = true;
                   },
+                  ...(request.agenticLoop === true
+                    ? { messages: preparedWithCompaction.messages }
+                    : {}),
                 })
                 .then(
                   (result) => {

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -147,6 +147,11 @@ type AutoCompactSnapshot = {
   relations: string[];
   characterSettings: string[];
   unresolvedPlotPoints: string[];
+  toneMarkers?: string[];
+  narrativePOV?: string;
+  foreshadowingClues?: string[];
+  timelineMarkers?: string[];
+  userConstraints?: string[];
 };
 
 type GeneratedTextResult = {
@@ -310,12 +315,32 @@ export function createWritingOrchestrator(
   function convertMessagesForAutoCompact(
     messages: Array<{ role: string; content: string }>,
   ): AutoCompactMessage[] {
-    return messages.map((message, index) => ({
-      id: `prepared-${index}`,
-      role: normalizeAutoCompactRole(message.role),
-      content: message.content,
-      compactable: message.role === "system" ? false : undefined,
-    }));
+    const hasWritingDirective = (content: string): boolean =>
+      /(第一人称|第三人称|语气|文风|风格|口吻|时态|不要|必须|请务必|写作约束|叙述视角|POV|pov)/i.test(
+        content,
+      );
+
+    let firstUserMessagePinned = false;
+    return messages.map((message, index) => {
+      const isSystem = message.role === "system";
+      const isUser = message.role === "user";
+      let compactable: boolean | undefined;
+      if (isSystem) {
+        compactable = false;
+      } else if (isUser) {
+        const shouldPinAsSetup = !firstUserMessagePinned;
+        firstUserMessagePinned = true;
+        compactable = shouldPinAsSetup || hasWritingDirective(message.content)
+          ? false
+          : undefined;
+      }
+      return {
+        id: `prepared-${index}`,
+        role: normalizeAutoCompactRole(message.role),
+        content: message.content,
+        compactable,
+      };
+    });
   }
 
   function convertMessagesFromAutoCompact(
@@ -398,6 +423,11 @@ export function createWritingOrchestrator(
                   relations: [],
                   characterSettings: [],
                   unresolvedPlotPoints: [],
+                  toneMarkers: [],
+                  narrativePOV: undefined,
+                  foreshadowingClues: [],
+                  timelineMarkers: [],
+                  userConstraints: [],
                 };
                 if (config.getAutoCompactSnapshot) {
                   try {

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -212,11 +212,14 @@ export interface OrchestratorConfig {
   autoCompact?: {
     maybeCompact: (args: {
       messages: AutoCompactMessage[];
-      auxiliaryModel: string;
+      auxiliaryModel?: string;
       kgSnapshot: AutoCompactSnapshot;
       requestId?: string;
     }) => Promise<{ messages: AutoCompactMessage[]; totalTokensAfter: number }>;
   };
+  getAutoCompactSnapshot?: (args: {
+    request: Pick<WritingRequest, "projectId" | "documentId" | "requestId">;
+  }) => Promise<AutoCompactSnapshot>;
   logger?: {
     warn: (event: string, data?: Record<string, unknown>) => void;
   };
@@ -387,17 +390,35 @@ export function createWritingOrchestrator(
             };
         const autoCompact = config.autoCompact;
         const preparedWithCompaction = autoCompact
-          ? await (async (): Promise<PreparedRequest> => {
+            ? await (async (): Promise<PreparedRequest> => {
               try {
+                let kgSnapshot: AutoCompactSnapshot = {
+                  entities: [],
+                  relations: [],
+                  characterSettings: [],
+                  unresolvedPlotPoints: [],
+                };
+                if (config.getAutoCompactSnapshot) {
+                  try {
+                    kgSnapshot = await config.getAutoCompactSnapshot({
+                      request: {
+                        projectId: request.projectId,
+                        documentId: request.documentId,
+                        requestId,
+                      },
+                    });
+                  } catch (error) {
+                    config.logger?.warn("orchestrator_auto_compact_kg_degraded", {
+                      requestId,
+                      error:
+                        error instanceof Error ? error.message : String(error),
+                    });
+                  }
+                }
                 const compactResult = await autoCompact.maybeCompact({
                   messages: convertMessagesForAutoCompact(prepared.messages),
                   auxiliaryModel: prepared.modelId,
-                  kgSnapshot: {
-                    entities: [],
-                    relations: [],
-                    characterSettings: [],
-                    unresolvedPlotPoints: [],
-                  },
+                  kgSnapshot,
                   requestId,
                 });
                 return {

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -213,6 +213,7 @@ export interface OrchestratorConfig {
     maybeCompact: (args: {
       messages: AutoCompactMessage[];
       auxiliaryModel?: string;
+      requestModelId?: string;
       kgSnapshot: AutoCompactSnapshot;
       requestId?: string;
     }) => Promise<{ messages: AutoCompactMessage[]; totalTokensAfter: number }>;
@@ -418,6 +419,7 @@ export function createWritingOrchestrator(
                 const compactResult = await autoCompact.maybeCompact({
                   messages: convertMessagesForAutoCompact(prepared.messages),
                   auxiliaryModel: prepared.modelId,
+                  requestModelId: prepared.modelId,
                   kgSnapshot,
                   requestId,
                 });

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -133,6 +133,22 @@ interface PreparedRequest {
 
 type OrchestratorTokenUsage = AiTokenUsage;
 
+type AutoCompactMessageRole = "system" | "user" | "assistant" | "tool";
+
+type AutoCompactMessage = {
+  id: string;
+  role: AutoCompactMessageRole;
+  content: string;
+  compactable?: boolean;
+};
+
+type AutoCompactSnapshot = {
+  entities: string[];
+  relations: string[];
+  characterSettings: string[];
+  unresolvedPlotPoints: string[];
+};
+
 type GeneratedTextResult = {
   fullText: string;
   usage: OrchestratorTokenUsage;
@@ -193,6 +209,17 @@ export interface OrchestratorConfig {
     /** P2: tool calls requested by the AI when finishReason === 'tool_use' */
     toolCalls?: ToolCallInfo[];
   }>;
+  autoCompact?: {
+    maybeCompact: (args: {
+      messages: AutoCompactMessage[];
+      auxiliaryModel: string;
+      kgSnapshot: AutoCompactSnapshot;
+      requestId?: string;
+    }) => Promise<{ messages: AutoCompactMessage[]; totalTokensAfter: number }>;
+  };
+  logger?: {
+    warn: (event: string, data?: Record<string, unknown>) => void;
+  };
 }
 
 export interface WritingOrchestrator {
@@ -269,6 +296,33 @@ export function createWritingOrchestrator(
     return { original, modified: fullText, changeType: "replace" };
   }
 
+  function normalizeAutoCompactRole(role: string): AutoCompactMessageRole {
+    if (role === "system" || role === "assistant" || role === "tool") {
+      return role;
+    }
+    return "user";
+  }
+
+  function convertMessagesForAutoCompact(
+    messages: Array<{ role: string; content: string }>,
+  ): AutoCompactMessage[] {
+    return messages.map((message, index) => ({
+      id: `prepared-${index}`,
+      role: normalizeAutoCompactRole(message.role),
+      content: message.content,
+      compactable: message.role === "system" ? false : undefined,
+    }));
+  }
+
+  function convertMessagesFromAutoCompact(
+    messages: AutoCompactMessage[],
+  ): Array<{ role: string; content: string }> {
+    return messages.map((message) => ({
+      role: message.role,
+      content: message.content,
+    }));
+  }
+
   return {
     execute(request: WritingRequest): AsyncGenerator<WritingEvent> {
       const { requestId } = request;
@@ -331,7 +385,37 @@ export function createWritingOrchestrator(
               tokenCount: config.aiService.estimateTokens(request.input.selectedText ?? ""),
               modelId: request.modelId ?? "default",
             };
-        const tokenCount = prepared.tokenCount;
+        const autoCompact = config.autoCompact;
+        const preparedWithCompaction = autoCompact
+          ? await (async (): Promise<PreparedRequest> => {
+              try {
+                const compactResult = await autoCompact.maybeCompact({
+                  messages: convertMessagesForAutoCompact(prepared.messages),
+                  auxiliaryModel: prepared.modelId,
+                  kgSnapshot: {
+                    entities: [],
+                    relations: [],
+                    characterSettings: [],
+                    unresolvedPlotPoints: [],
+                  },
+                  requestId,
+                });
+                return {
+                  ...prepared,
+                  messages: convertMessagesFromAutoCompact(compactResult.messages),
+                  tokenCount: compactResult.totalTokensAfter,
+                };
+              } catch (error) {
+                config.logger?.warn("orchestrator_auto_compact_degraded", {
+                  requestId,
+                  error:
+                    error instanceof Error ? error.message : String(error),
+                });
+                return prepared;
+              }
+            })()
+          : prepared;
+        const tokenCount = preparedWithCompaction.tokenCount;
         yield makeEvent("context-assembled", requestId, { tokenCount });
 
         if (abortController.signal.aborted) {
@@ -341,7 +425,9 @@ export function createWritingOrchestrator(
         }
 
         // Stage 3: model-selected
-        yield makeEvent("model-selected", requestId, { modelId: prepared.modelId });
+        yield makeEvent("model-selected", requestId, {
+          modelId: preparedWithCompaction.modelId,
+        });
 
         if (abortController.signal.aborted) {
           taskStates.set(requestId, "killed");
@@ -375,7 +461,7 @@ export function createWritingOrchestrator(
 
           const requestCost = config.costTracker.recordUsage(
             usage,
-            prepared.modelId,
+            preparedWithCompaction.modelId,
             requestId,
             normalizeSkillId(request.skillId),
             usage.cachedTokens,
@@ -520,7 +606,7 @@ export function createWritingOrchestrator(
             } else if (hasStreamChat) {
               let streamFinishReason: "stop" | "tool_use" | null = null;
               const gen = config.aiService.streamChat(
-                prepared.messages,
+                preparedWithCompaction.messages,
                 {
                   signal: abortController.signal,
                   onComplete: (result) => {
@@ -725,7 +811,7 @@ export function createWritingOrchestrator(
 
             // Inject tool results into message history
             const baseMsgs = (agenticMessages ??
-              prepared.messages) as AgenticMessage[];
+              preparedWithCompaction.messages) as AgenticMessage[];
             // Append assistant message (partial AI text before tool_use) then tool results
             const msgsWithAssistant: AgenticMessage[] = [
               ...(baseMsgs.map((m) => ({

--- a/apps/desktop/preload/src/aiStreamBridge.ts
+++ b/apps/desktop/preload/src/aiStreamBridge.ts
@@ -1,11 +1,13 @@
 import { ipcRenderer } from "electron";
 
 import {
+  CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
   SKILL_QUEUE_STATUS_CHANNEL,
   SKILL_STREAM_CHUNK_CHANNEL,
   SKILL_STREAM_DONE_CHANNEL,
   SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
+  type ContextCompactCircuitBreakerEvent,
   type SkillToolUseEvent,
 } from "@shared/types/ai";
 import {
@@ -153,6 +155,25 @@ function isCostAlertEvent(x: unknown): x is CostAlertEvent {
   );
 }
 
+function isContextCompactCircuitBreakerEvent(
+  x: unknown,
+): x is ContextCompactCircuitBreakerEvent {
+  if (!isRecord(x)) {
+    return false;
+  }
+
+  return (
+    typeof x.open === "boolean" &&
+    typeof x.consecutiveFailures === "number" &&
+    (x.openedAt === null || typeof x.openedAt === "number") &&
+    typeof x.cooldownMs === "number" &&
+    (x.reason === "threshold-reached"
+      || x.reason === "half-open-probe-failed"
+      || x.reason === "half-open-probe-succeeded"
+      || x.reason === "manual-reset")
+  );
+}
+
 
 export type AiStreamBridgeApi = {
   registerAiStreamConsumer: () => IpcResponse<{ subscriptionId: string }>;
@@ -246,6 +267,23 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
       }),
     );
   };
+  const onContextCompactCircuitBreaker = (_evt: unknown, payload: unknown) => {
+    if (subscriptions.count() === 0) {
+      return;
+    }
+    if (!isContextCompactCircuitBreakerEvent(payload)) {
+      return;
+    }
+
+    window.dispatchEvent(
+      new CustomEvent<ContextCompactCircuitBreakerEvent>(
+        CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
+        {
+          detail: payload,
+        },
+      ),
+    );
+  };
 
   ipcRenderer.on(SKILL_STREAM_CHUNK_CHANNEL, onSkillStreamChunk);
   ipcRenderer.on(SKILL_STREAM_DONE_CHANNEL, onSkillStreamDone);
@@ -253,6 +291,10 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
   ipcRenderer.on(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
   ipcRenderer.on(JUDGE_RESULT_CHANNEL, onJudgeResult);
   ipcRenderer.on(COST_ALERT_CHANNEL, onCostAlert);
+  ipcRenderer.on(
+    CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
+    onContextCompactCircuitBreaker,
+  );
 
   return {
     registerAiStreamConsumer: () => subscriptions.register(),
@@ -272,6 +314,10 @@ export function registerAiStreamBridge(): AiStreamBridgeApi {
       ipcRenderer.removeListener(SKILL_TOOL_USE_CHANNEL, onSkillToolUse);
       ipcRenderer.removeListener(JUDGE_RESULT_CHANNEL, onJudgeResult);
       ipcRenderer.removeListener(COST_ALERT_CHANNEL, onCostAlert);
+      ipcRenderer.removeListener(
+        CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL,
+        onContextCompactCircuitBreaker,
+      );
     },
   };
 }

--- a/openspec/specs/context-engine/spec.md
+++ b/openspec/specs/context-engine/spec.md
@@ -734,6 +734,8 @@ interface CompressionEngine {
    * 2. micro-compression: 对单条长消息做段内缩减（去冗余、精简表达）
    * 3. narrative-summarization: 使用 LLM 生成叙事感知摘要（最高质量但最慢）
    *
+   * > **实现阶段说明**：当前版本仅实现第三层（叙事压缩）。前两层（历史精简、微压缩）列入 P4-04 AutoCompact v2 路线图。
+   *
    * @param request 压缩请求
    * @returns 压缩结果
    * @throws CompressionError(COMPRESSION_CIRCUIT_OPEN) 熔断器打开时

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -5,6 +5,8 @@ export const SKILL_STREAM_DONE_CHANNEL = "skill:stream:done" as const;
 export const SKILL_QUEUE_STATUS_CHANNEL = "skill:queue:status" as const;
 /** P2: Agentic Loop tool-use event channel */
 export const SKILL_TOOL_USE_CHANNEL = "skill:tool-use" as const;
+/** P2: AutoCompact circuit-breaker status push channel */
+export const CONTEXT_COMPACT_CIRCUIT_BREAKER_CHANNEL = "context:compact:circuit-breaker" as const;
 
 export type AiStreamTerminal = "completed" | "cancelled" | "error";
 
@@ -127,3 +129,17 @@ export type SkillToolUseEvent =
   | SkillToolUseStartedEvent
   | SkillToolUseCompletedEvent
   | SkillToolUseFailedEvent;
+
+export type ContextCompactCircuitBreakerReason =
+  | "threshold-reached"
+  | "half-open-probe-failed"
+  | "half-open-probe-succeeded"
+  | "manual-reset";
+
+export type ContextCompactCircuitBreakerEvent = {
+  open: boolean;
+  consecutiveFailures: number;
+  openedAt: number | null;
+  cooldownMs: number;
+  reason: ContextCompactCircuitBreakerReason;
+};


### PR DESCRIPTION
Closes #91

## Summary
- AutoCompact 熔断器改为 closed/open/half-open 三态：新增 lastOpenedAt + 5 分钟冷却，冷却后仅允许一次探测压缩。
- 半开探测成功会关闭熔断并清零失败计数；探测失败会重新打开熔断并重置冷却。
- 新增 resetCircuitBreaker() 手动重置方法，并在手动重置后发出熔断关闭通知。
- 新增主进程 IPC 广播通道 context:compact:circuit-breaker，熔断打开/关闭都会通知渲染进程。
- orchestrator.ts 与 ipc/ai.ts 删除重复结构类型，改为复用 compact 模块导出类型。
- getAutoCompactSnapshot 中 foreshadowingClues 不再包含 unresolvedPlotPoints 全量，减少 token 冗余。
- 调用摘要 skill 时显式读取 summaryMaxTokens，并补充 runSkill maxOutputTokens 能力缺失的 TODO 注释。
- spec 更新：3 层压缩处增加“当前仅实现第 3 层，前两层进入 P4-04 AutoCompact v2 路线图”的阶段说明。
- 增加单测覆盖：熔断打开 -> 冷却半开探测成功关闭；半开探测失败重开；手动 reset 后恢复。

## Invariant Checklist
- [x] INV-1 原稿保护
- [x] INV-2 并发安全
- [x] INV-3 CJK Token
- [x] INV-4 Memory-First
- [x] INV-5 叙事压缩
- [x] INV-6 一切皆 Skill
- [x] INV-7 统一入口
- [x] INV-8 Hook 链
- [x] INV-9 成本追踪
- [x] INV-10 错误不丢上下文

## Validation Evidence
- [x] pnpm typecheck
- [x] pnpm test:unit
- [x] scripts/agent_pr_preflight.sh

## Risk & Rollback
- Risk: medium
- Rollback: git revert 2b899fe

## Visual Evidence
### Embedded Screenshots
- [x] N/A（backend-only change）

### Storybook Artifact / Link
- Link: N/A（backend-only change）
- Visual acceptance note: N/A（backend-only change）

## Audit Gate
- 工程：GPT-5.3 Codex (xhigh)
- 审计 1：GPT-5.4 (xhigh)
- 审计 2：GPT-5.3 Codex (xhigh)
- 审计 3：Claude Opus 4.6 (high)
- 审计 4：Claude Sonnet 4.6 (high)
- 评论汇总：Claude Opus 4.6 (high)
- [ ] 审计 1（GPT-5.4）：FINAL-VERDICT: PENDING
- [ ] 审计 2（GPT-5.3 Codex）：FINAL-VERDICT: PENDING
- [ ] 审计 3（Claude Opus 4.6）：FINAL-VERDICT: PENDING
- [ ] 审计 4（Claude Sonnet 4.6）：FINAL-VERDICT: PENDING