### PR TITLE
TASK-P1-04: 激活并验证 Skill Manifest Loader

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -19,6 +19,23 @@ const mocks = vi.hoisted(() => {
     ok: true,
     data: { executionId: "exec-1", runId: "run-1", traceId: "trace-1", outputText: "ok" },
   });
+  const skillListMock = vi.fn().mockReturnValue({ ok: true, data: { items: [] } });
+  const skillResolveForRunMock = vi.fn().mockReturnValue({
+    ok: true,
+    data: {
+      skill: {
+        id: "builtin:chat",
+        prompt: { system: "s", user: "u" },
+        output: undefined,
+        valid: true,
+        dependsOn: [],
+        timeoutMs: 30_000,
+        permissionLevel: "preview-confirm",
+      },
+      enabled: true,
+      inputType: "document",
+    },
+  });
   const bridgeStreamChatMock = vi.fn(async function* () {
     throw { kind: "unsupported-provider" };
   });
@@ -47,9 +64,12 @@ const mocks = vi.hoisted(() => {
       update: vi.fn().mockReturnValue({ ok: true, data: {} }),
       test: vi.fn().mockResolvedValue({ ok: true, data: { ok: true, latencyMs: 50 } }),
     })),
+    skillListMock,
+    skillResolveForRunMock,
     createSkillServiceMock: vi.fn(() => ({
-      listSkills: vi.fn().mockReturnValue({ ok: true, data: { items: [] } }),
-      getSkill: vi.fn(),
+      list: skillListMock,
+      resolveForRun: skillResolveForRunMock,
+      isDependencyAvailable: vi.fn().mockReturnValue({ ok: true, data: { available: true } }),
     })),
     createSkillExecutorMock: vi.fn(() => ({
       execute: vi.fn(),
@@ -243,6 +263,27 @@ function createHarness(dbNull = false, withCostTracker = false) {
 // ── Channel Registration ──
 
 describe("AI IPC channel registration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.skillListMock.mockReturnValue({ ok: true, data: { items: [] } });
+    mocks.skillResolveForRunMock.mockReturnValue({
+      ok: true,
+      data: {
+        skill: {
+          id: "builtin:chat",
+          prompt: { system: "s", user: "u" },
+          output: undefined,
+          valid: true,
+          dependsOn: [],
+          timeoutMs: 30_000,
+          permissionLevel: "preview-confirm",
+        },
+        enabled: true,
+        inputType: "document",
+      },
+    });
+  });
+
   it("注册所有预期通道", () => {
     const harness = createHarness();
     const expectedChannels = [
@@ -260,6 +301,21 @@ describe("AI IPC channel registration", () => {
     for (const ch of expectedChannels) {
       expect(harness.handlers.has(ch), `missing channel: ${ch}`).toBe(true);
     }
+  });
+
+  it("启动阶段预热 Skill registry 并检查必需内置技能", () => {
+    createHarness();
+    expect(mocks.createSkillServiceMock).toHaveBeenCalled();
+    expect(mocks.skillListMock).toHaveBeenCalledWith({ includeDisabled: true });
+    expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
+      id: "builtin:polish",
+    });
+    expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
+      id: "builtin:chat",
+    });
+    expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
+      id: "builtin:continue",
+    });
   });
 });
 

--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -25,6 +25,11 @@ const mocks = vi.hoisted(() => {
     data: {
       skill: {
         id: "builtin:chat",
+        name: "Chat",
+        scope: "builtin",
+        packageId: "pkg.creonow.builtin",
+        version: "1.0.0",
+        filePath: "/mock/skills/pkg.creonow.builtin/1.0.0/skills/chat/SKILL.md",
         prompt: { system: "s", user: "u" },
         output: undefined,
         valid: true,
@@ -263,25 +268,32 @@ function createHarness(dbNull = false, withCostTracker = false) {
 // ── Channel Registration ──
 
 describe("AI IPC channel registration", () => {
+  const makeResolvedSkill = (id: string, enabled = true, valid = true) => ({
+    ok: true as const,
+    data: {
+      skill: {
+        id,
+        name: "Chat",
+        scope: "builtin" as const,
+        packageId: "pkg.creonow.builtin",
+        version: "1.0.0",
+        filePath: `/mock/skills/pkg.creonow.builtin/1.0.0/skills/${id.replace("builtin:", "")}/SKILL.md`,
+        prompt: { system: "s", user: "u" },
+        output: undefined,
+        valid,
+        dependsOn: [],
+        timeoutMs: 30_000,
+        permissionLevel: "preview-confirm" as const,
+      },
+      enabled,
+      inputType: "document" as const,
+    },
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.skillListMock.mockReturnValue({ ok: true, data: { items: [] } });
-    mocks.skillResolveForRunMock.mockReturnValue({
-      ok: true,
-      data: {
-        skill: {
-          id: "builtin:chat",
-          prompt: { system: "s", user: "u" },
-          output: undefined,
-          valid: true,
-          dependsOn: [],
-          timeoutMs: 30_000,
-          permissionLevel: "preview-confirm",
-        },
-        enabled: true,
-        inputType: "document",
-      },
-    });
+    mocks.skillResolveForRunMock.mockReturnValue(makeResolvedSkill("builtin:chat"));
   });
 
   it("注册所有预期通道", () => {
@@ -315,6 +327,68 @@ describe("AI IPC channel registration", () => {
     });
     expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
       id: "builtin:continue",
+    });
+  });
+
+  it("预热 list 失败时记录 skill_registry_warmup_failed 错误日志", () => {
+    mocks.skillListMock.mockReturnValueOnce({
+      ok: false,
+      error: { code: "INTERNAL", message: "warmup failed" },
+    });
+    const harness = createHarness();
+    expect(harness.logger.error).toHaveBeenCalledWith("skill_registry_warmup_failed", {
+      code: "INTERNAL",
+      message: "warmup failed",
+    });
+  });
+
+  it("预热解析内置技能失败时记录 builtin_skill_missing_on_startup 错误日志", () => {
+    mocks.skillResolveForRunMock
+      .mockReturnValueOnce(makeResolvedSkill("builtin:polish"))
+      .mockReturnValueOnce({
+        ok: false,
+        error: { code: "NOT_FOUND", message: "chat missing" },
+      })
+      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"));
+    const harness = createHarness();
+    expect(harness.logger.error).toHaveBeenCalledWith("builtin_skill_missing_on_startup", {
+      skillId: "builtin:chat",
+      code: "NOT_FOUND",
+      message: "chat missing",
+    });
+  });
+
+  it("预热解析到 disabled skill 时记录 builtin_skill_disabled_on_startup 日志", () => {
+    mocks.skillResolveForRunMock
+      .mockReturnValueOnce(makeResolvedSkill("builtin:polish"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:chat", false, true))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"));
+    const harness = createHarness();
+    expect(harness.logger.info).toHaveBeenCalledWith("builtin_skill_disabled_on_startup", {
+      skillId: "builtin:chat",
+    });
+  });
+
+  it("预热解析到 invalid skill 时记录 builtin_skill_invalid_on_startup 错误日志", () => {
+    mocks.skillResolveForRunMock
+      .mockReturnValueOnce(makeResolvedSkill("builtin:polish"))
+      .mockReturnValueOnce({
+        ok: true,
+        data: {
+          ...makeResolvedSkill("builtin:chat", true, false).data,
+          skill: {
+            ...makeResolvedSkill("builtin:chat", true, false).data.skill,
+            error_code: "INVALID_ARGUMENT",
+            error_message: "manifest invalid",
+          },
+        },
+      })
+      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"));
+    const harness = createHarness();
+    expect(harness.logger.error).toHaveBeenCalledWith("builtin_skill_invalid_on_startup", {
+      skillId: "builtin:chat",
+      code: "INVALID_ARGUMENT",
+      message: "manifest invalid",
     });
   });
 });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1459,6 +1459,19 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
             code: resolved.error.code,
             message: resolved.error.message,
           });
+          continue;
+        }
+        if (!resolved.data.enabled) {
+          deps.logger.info("builtin_skill_disabled_on_startup", {
+            skillId,
+          });
+        }
+        if (!resolved.data.skill.valid) {
+          deps.logger.error("builtin_skill_invalid_on_startup", {
+            skillId,
+            code: resolved.data.skill.error_code ?? "INVALID_ARGUMENT",
+            message: resolved.data.skill.error_message ?? "Skill manifest is invalid",
+          });
         }
       }
     }

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1437,6 +1437,32 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       logger: deps.logger,
     });
   };
+  if (deps.db) {
+    const startupSkillService = skillServiceFactory();
+    const listed = startupSkillService.list({ includeDisabled: true });
+    if (!listed.ok) {
+      deps.logger.error("skill_registry_warmup_failed", {
+        code: listed.error.code,
+        message: listed.error.message,
+      });
+    } else {
+      const requiredBuiltinSkillIds = [
+        "builtin:polish",
+        "builtin:chat",
+        "builtin:continue",
+      ] as const;
+      for (const skillId of requiredBuiltinSkillIds) {
+        const resolved = startupSkillService.resolveForRun({ id: skillId });
+        if (!resolved.ok) {
+          deps.logger.error("builtin_skill_missing_on_startup", {
+            skillId,
+            code: resolved.error.code,
+            message: resolved.error.message,
+          });
+        }
+      }
+    }
+  }
   const writingOrchestrator = createWritingOrchestrator({
     aiService: (() => {
       const legacyActiveAbortControllers = new Set<AbortController>();

--- a/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
@@ -109,7 +109,9 @@ describe("P3 runtime skill chain", () => {
       const requiredIds = ["builtin:polish", "builtin:chat", "builtin:continue"] as const;
       const builtinItems = listed.data.items.filter((item) => item.scope === "builtin");
       expect(builtinItems.length).toBeGreaterThanOrEqual(3);
-      expect(builtinItems.map((item) => item.id)).toEqual(expect.arrayContaining(requiredIds));
+      expect(builtinItems.map((item) => item.id)).toEqual(
+        expect.arrayContaining([...requiredIds]),
+      );
 
       for (const skillId of requiredIds) {
         const resolved = svc.resolveForRun({ id: skillId });

--- a/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
@@ -90,6 +90,46 @@ function builtinSkillsDir(): string {
 }
 
 describe("P3 runtime skill chain", () => {
+  it("lists at least three required builtin skills with complete runtime schema", () => {
+    const db = createSkillTestDb();
+    try {
+      const svc = createSkillService({
+        db,
+        userDataDir: builtinSkillsDir(),
+        builtinSkillsDir: builtinSkillsDir(),
+        logger: createNoopLogger(),
+      });
+
+      const listed = svc.list({ includeDisabled: true });
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) {
+        throw new Error("expected list() to succeed");
+      }
+
+      const requiredIds = ["builtin:polish", "builtin:chat", "builtin:continue"] as const;
+      const builtinItems = listed.data.items.filter((item) => item.scope === "builtin");
+      expect(builtinItems.length).toBeGreaterThanOrEqual(3);
+      expect(builtinItems.map((item) => item.id)).toEqual(expect.arrayContaining(requiredIds));
+
+      for (const skillId of requiredIds) {
+        const resolved = svc.resolveForRun({ id: skillId });
+        expect(resolved.ok).toBe(true);
+        if (!resolved.ok) {
+          throw new Error(`expected ${skillId} to resolve`);
+        }
+
+        expect(resolved.data.enabled).toBe(true);
+        expect(resolved.data.skill.valid).toBe(true);
+        expect(resolved.data.skill.scope).toBe("builtin");
+        expect(resolved.data.skill.permissionLevel).toBeTruthy();
+        expect(resolved.data.skill.prompt?.system?.trim().length).toBeGreaterThan(0);
+        expect(resolved.data.skill.prompt?.user?.trim().length).toBeGreaterThan(0);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
   it("loads the three builtin P3 skills through the real loader", () => {
     const db = createSkillTestDb();
     try {

--- a/openspec/guards/spec-test-mapping-baseline.json
+++ b/openspec/guards/spec-test-mapping-baseline.json
@@ -1,7 +1,7 @@
 {
   "count": 10,
   "explicitUnmappedCount": 10,
-  "derivedUnmappedCount": 405,
+  "derivedUnmappedCount": 402,
   "derivedCoverageFloor": 0.6,
-  "updatedAt": "2026-04-10T23:01:19.095Z"
+  "updatedAt": "2026-04-11T14:50:44.834Z"
 }

--- a/openspec/guards/spec-test-mapping-fallback-baseline.json
+++ b/openspec/guards/spec-test-mapping-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
   "count": 10,
   "explicitUnmappedCount": 10,
-  "derivedUnmappedCount": 405,
+  "derivedUnmappedCount": 402,
   "derivedCoverageFloor": 0.066,
-  "updatedAt": "2026-04-10T23:01:19.095Z"
+  "updatedAt": "2026-04-11T14:51:35.000Z"
 }


### PR DESCRIPTION
## Summary
- 在 registerAiIpcHandlers 启动阶段新增 Skill registry 预热，触发 SKILL.md runtime loader 扫描。
- 启动时显式校验 3 个关键内置 Skill：builtin:polish、builtin:chat、builtin:continue。
- 新增测试覆盖：启动预热调用链 + builtin skills 列表与 schema 完整性验证。
- 修复 apps/desktop/tests/integration/db-migration-system.test.ts 中已提交的冲突标记，恢复 typecheck 门禁可用性。
- 同步下调 spec-test-mapping baseline 与 fallback baseline，满足 ratchet 门禁。

Closes #103

## Impact Scope
- 应用启动时即可发现内置 Skill 配置缺失问题，避免首次执行技能时才暴露故障。
- CI typecheck 与 spec-test mapping gate 不再被基线问题阻塞。

## Invariant Checklist
- [x] INV-1 原稿保护：不涉及写回路径与权限门控逻辑。
- [x] INV-2 并发安全：未改变并发调度策略，仅增加启动预热读取。
- [x] INV-3 CJK Token：未修改 token 估算逻辑。
- [x] INV-4 Memory-First：未修改记忆分层/检索链路。
- [x] INV-5 叙事压缩：未修改压缩策略。
- [x] INV-6 一切皆 Skill：通过启动预热与必备内置 Skill 校验强化 Skill 统一入口可用性。
- [x] INV-7 统一入口：未新增 IPC 直连服务绕行路径。
- [x] INV-8 Hook 链：未修改 post-writing hooks。
- [x] INV-9 成本追踪：未改动 cost tracker。
- [x] INV-10 错误不丢上下文：预热失败会记录结构化错误日志，不静默吞掉。

## Validation Evidence
- [x] pnpm typecheck
- [x] pnpm test:unit
- [x] pnpm test:unit -- apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
- [x] scripts/agent_pr_preflight.sh

## Risk & Rollback
- Worst case if not fixed: 启动预热失败时仅记录日志，运行时仍可按原路径加载技能。
- Rollback ref: 0b5b3ff

## Visual Evidence

### Embedded Screenshots
- [x] N/A（非前端改动）

### Storybook Artifact / Link
- Link: N/A（非前端改动）
- Visual acceptance note: N/A（非前端改动）

## 审计门禁
- 工程：GPT-5.3 Codex (xhigh)
- 审计 1：GPT-5.4 (xhigh)
- 审计 2：GPT-5.3 Codex (xhigh)
- 审计 3：Claude Opus 4.6 (high)
- 审计 4：Claude Sonnet 4.6 (high)
- 评论汇总：Claude Opus 4.6 (high)

- [ ] 审计 1（GPT-5.4）：FINAL-VERDICT ___
- [ ] 审计 2（GPT-5.3 Codex）：FINAL-VERDICT ___
- [ ] 审计 3（Claude Opus 4.6）：FINAL-VERDICT ___
- [ ] 审计 4（Claude Sonnet 4.6）：FINAL-VERDICT ___