### PR TITLE
fix: eliminate silent catch blocks in desktop main (INV-10)

### DIFF
--- a/apps/desktop/main/src/browserWindowSecurity.ts
+++ b/apps/desktop/main/src/browserWindowSecurity.ts
@@ -31,6 +31,7 @@ function tryParseUrl(targetUrl: string): URL | null {
   try {
     return new URL(targetUrl);
   } catch {
+    // Treat malformed URL as blocked target to keep navigation policy fail-closed.
     return null;
   }
 }

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -825,6 +825,7 @@ function parseModelPricingMap(
     }
     return map;
   } catch {
+    // Invalid pricing JSON must degrade to empty map instead of breaking chat startup.
     return new Map();
   }
 }

--- a/apps/desktop/main/src/ipc/ipcAcl.ts
+++ b/apps/desktop/main/src/ipc/ipcAcl.ts
@@ -48,6 +48,7 @@ function resolveDevServerOrigin(env: NodeJS.ProcessEnv): string | null {
   try {
     return new URL(raw).origin;
   } catch {
+    // Invalid env config should fail-closed and never widen IPC origin allowlist.
     return null;
   }
 }
@@ -67,6 +68,7 @@ function isOriginAllowed(args: {
   try {
     parsed = new URL(args.senderOrigin);
   } catch {
+    // Unparseable renderer URL is treated as untrusted origin.
     return false;
   }
 

--- a/apps/desktop/main/src/services/ai/__tests__/aiProxySettingsService.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiProxySettingsService.test.ts
@@ -196,6 +196,38 @@ describe("createAiProxySettingsService", () => {
         expect(res.data.anthropicByok).toBeDefined();
       }
     });
+
+    it("settings JSON 损坏时记录解析错误日志", () => {
+      const parseFailDb = {
+        prepare: vi.fn((sql: string) => {
+          if (sql.includes("SELECT")) {
+            return {
+              get: vi.fn(() => ({ valueJson: "{" })),
+              all: vi.fn(() => []),
+              run: vi.fn(),
+            };
+          }
+          return {
+            run: vi.fn(),
+            get: vi.fn(),
+            all: vi.fn(),
+          };
+        }),
+        exec: vi.fn(),
+        transaction: vi.fn((fn: () => void) => fn),
+      };
+      const parseFailSvc = createAiProxySettingsService({
+        db: parseFailDb as never,
+        logger: logger as never,
+        secretStorage,
+      });
+      const res = parseFailSvc.getRaw();
+      expect(res.ok).toBe(true);
+      expect(logger.error).toHaveBeenCalledWith(
+        "ai_proxy_settings_parse_failed",
+        expect.objectContaining({ key: expect.any(String) }),
+      );
+    });
   });
 
   // ── update ──
@@ -285,6 +317,32 @@ describe("createAiProxySettingsService", () => {
       if (!res.ok) {
         expect(["UNSUPPORTED", "INTERNAL"]).toContain(res.error.code);
       }
+    });
+
+    it("加密失败时记录错误日志", () => {
+      const brokenSecretStorage: SecretStorageAdapter = {
+        isEncryptionAvailable: () => true,
+        encryptString: () => {
+          throw new Error("encrypt failed");
+        },
+        decryptString: (buf: Buffer) => buf.toString("utf8"),
+      };
+      const svcWithBrokenEncryption = createAiProxySettingsService({
+        db: db as never,
+        logger: logger as never,
+        secretStorage: brokenSecretStorage,
+      });
+      const res = svcWithBrokenEncryption.update({
+        patch: { openAiCompatibleApiKey: "sk-test12345678" },
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error.code).toBe("INTERNAL");
+      }
+      expect(logger.error).toHaveBeenCalledWith(
+        "ai_proxy_settings_secret_encrypt_failed",
+        expect.objectContaining({ message: "encrypt failed" }),
+      );
     });
 
     it("更新后日志记录成功", () => {

--- a/apps/desktop/main/src/services/ai/__tests__/aiService-methods.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiService-methods.test.ts
@@ -8,8 +8,17 @@ import type { AiStreamEvent } from "@shared/types/ai";
 import type { Logger } from "../../../logging/logger";
 import { createAiService, type AiService } from "../aiService";
 
-function nopLogger(): Logger {
-  return { logPath: "<test>", info: vi.fn(), error: vi.fn() };
+type TestLogger = Logger & {
+  warn: ReturnType<typeof vi.fn>;
+};
+
+function createTestLogger(): TestLogger {
+  return {
+    logPath: "<test>",
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
 }
 
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -30,12 +39,13 @@ function makeService(overrides?: {
   retryBackoffMs?: readonly number[];
   sessionTokenBudget?: number;
   env?: NodeJS.ProcessEnv;
+  logger?: TestLogger;
   traceStore?: {
     recordTraceFeedback: ReturnType<typeof vi.fn>;
   };
 }): AiService {
   return createAiService({
-    logger: nopLogger(),
+    logger: (overrides?.logger ?? createTestLogger()) as Logger,
     env: {
       CREONOW_AI_PROVIDER: "openai",
       CREONOW_AI_BASE_URL: "https://api.openai.com",
@@ -394,5 +404,57 @@ describe("aiService.runSkill basics", () => {
       expect(res.data.runId).toBeTruthy();
       expect(res.data.traceId).toBeTruthy();
     }
+  });
+
+  it("tool call 参数 JSON 解析失败时记录 warning 并降级为 null arguments", async () => {
+    const logger = createTestLogger();
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        [
+          `data: ${JSON.stringify({
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call_1",
+                      function: { name: "lookup", arguments: "{" },
+                    },
+                  ],
+                },
+                finish_reason: "tool_calls",
+              },
+            ],
+          })}\n\n`,
+          "data: [DONE]\n\n",
+        ].join(""),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+
+    const events: AiStreamEvent[] = [];
+    const svc = makeService({ logger });
+    const res = await svc.runSkill({
+      skillId: "test",
+      input: "Test prompt",
+      mode: "ask",
+      model: "gpt-4o",
+      stream: true,
+      ts: Date.now(),
+      emitEvent: (e) => events.push(e),
+    });
+
+    expect(res.ok).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "tool_call_json_parse_failed",
+      expect.objectContaining({
+        module: "ai-service",
+        provider: "openai",
+        toolCallId: "call_1",
+        toolName: "lookup",
+        rawJson: "{",
+      }),
+    );
   });
 });

--- a/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
+++ b/apps/desktop/main/src/services/ai/aiProxySettingsService.ts
@@ -83,19 +83,27 @@ const KEY_ANTH_BYOK_API_KEY =
 const ENCRYPTED_SECRET_PREFIX = "__safe_storage_v1__:";
 type SettingsRow = { valueJson: string };
 
-function readSetting(db: Database.Database, key: string): unknown | null {
-  const row = db
+function readSetting(args: {
+  db: Database.Database;
+  key: string;
+  logger: Logger;
+}): unknown | null {
+  const row = args.db
     .prepare<
       [string, string],
       SettingsRow
     >("SELECT value_json as valueJson FROM settings WHERE scope = ? AND key = ?")
-    .get(SETTINGS_SCOPE, key);
+    .get(SETTINGS_SCOPE, args.key);
   if (!row) {
     return null;
   }
   try {
     return JSON.parse(row.valueJson) as unknown;
-  } catch {
+  } catch (error) {
+    args.logger.error("ai_proxy_settings_parse_failed", {
+      key: args.key,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }
@@ -126,6 +134,7 @@ function normalizeBaseUrl(raw: unknown): string | null {
     }
     return trimmed;
   } catch {
+    // Invalid URL should be treated as "unset" to keep startup deterministic.
     return null;
   }
 }
@@ -229,6 +238,7 @@ function validatePatchedApiKeys(args: {
 function encryptApiKey(args: {
   value: string | null;
   secretStorage?: SecretStorageAdapter;
+  logger: Logger;
 }): ServiceResult<string | null> {
   if (args.value === null) {
     return { ok: true, data: null };
@@ -247,7 +257,10 @@ function encryptApiKey(args: {
       ok: true,
       data: `${ENCRYPTED_SECRET_PREFIX}${encrypted.toString("base64")}`,
     };
-  } catch {
+  } catch (error) {
+    args.logger.error("ai_proxy_settings_secret_encrypt_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return ipcError("INTERNAL", "Failed to encrypt API key");
   }
 }
@@ -387,16 +400,44 @@ function readRawSettings(args: {
   logger: Logger;
   secretStorage?: SecretStorageAdapter;
 }): AiProxySettingsRaw {
-  const enabled = readSetting(args.db, KEY_ENABLED);
-  const baseUrl = readSetting(args.db, KEY_BASE_URL);
-  const apiKey = readSetting(args.db, KEY_API_KEY);
-  const providerMode = readSetting(args.db, KEY_PROVIDER_MODE);
-  const openAiCompatibleBaseUrl = readSetting(args.db, KEY_OA_COMPAT_BASE_URL);
-  const openAiCompatibleApiKey = readSetting(args.db, KEY_OA_COMPAT_API_KEY);
-  const openAiByokBaseUrl = readSetting(args.db, KEY_OA_BYOK_BASE_URL);
-  const openAiByokApiKey = readSetting(args.db, KEY_OA_BYOK_API_KEY);
-  const anthropicByokBaseUrl = readSetting(args.db, KEY_ANTH_BYOK_BASE_URL);
-  const anthropicByokApiKey = readSetting(args.db, KEY_ANTH_BYOK_API_KEY);
+  const enabled = readSetting({ db: args.db, key: KEY_ENABLED, logger: args.logger });
+  const baseUrl = readSetting({ db: args.db, key: KEY_BASE_URL, logger: args.logger });
+  const apiKey = readSetting({ db: args.db, key: KEY_API_KEY, logger: args.logger });
+  const providerMode = readSetting({
+    db: args.db,
+    key: KEY_PROVIDER_MODE,
+    logger: args.logger,
+  });
+  const openAiCompatibleBaseUrl = readSetting({
+    db: args.db,
+    key: KEY_OA_COMPAT_BASE_URL,
+    logger: args.logger,
+  });
+  const openAiCompatibleApiKey = readSetting({
+    db: args.db,
+    key: KEY_OA_COMPAT_API_KEY,
+    logger: args.logger,
+  });
+  const openAiByokBaseUrl = readSetting({
+    db: args.db,
+    key: KEY_OA_BYOK_BASE_URL,
+    logger: args.logger,
+  });
+  const openAiByokApiKey = readSetting({
+    db: args.db,
+    key: KEY_OA_BYOK_API_KEY,
+    logger: args.logger,
+  });
+  const anthropicByokBaseUrl = readSetting({
+    db: args.db,
+    key: KEY_ANTH_BYOK_BASE_URL,
+    logger: args.logger,
+  });
+  const anthropicByokApiKey = readSetting({
+    db: args.db,
+    key: KEY_ANTH_BYOK_API_KEY,
+    logger: args.logger,
+  });
 
   return normalizeProxySettings({
     enabled: enabled === true,
@@ -704,6 +745,7 @@ export function createAiProxySettingsService(deps: {
     const encryptedOpenAiCompatibleKey = encryptApiKey({
       value: next.openAiCompatible.apiKey,
       secretStorage: deps.secretStorage,
+      logger: deps.logger,
     });
     if (!encryptedOpenAiCompatibleKey.ok) {
       return encryptedOpenAiCompatibleKey;
@@ -712,6 +754,7 @@ export function createAiProxySettingsService(deps: {
     const encryptedOpenAiByokKey = encryptApiKey({
       value: next.openAiByok.apiKey,
       secretStorage: deps.secretStorage,
+      logger: deps.logger,
     });
     if (!encryptedOpenAiByokKey.ok) {
       return encryptedOpenAiByokKey;
@@ -720,6 +763,7 @@ export function createAiProxySettingsService(deps: {
     const encryptedAnthropicByokKey = encryptApiKey({
       value: next.anthropicByok.apiKey,
       secretStorage: deps.secretStorage,
+      logger: deps.logger,
     });
     if (!encryptedAnthropicByokKey.ok) {
       return encryptedAnthropicByokKey;

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -235,6 +235,8 @@ async function parseJsonResponse(
   try {
     return { ok: true, data: JSON.parse(bodyText) as unknown };
   } catch {
+    // Non-JSON upstream bodies are intentionally fail-closed as LLM_API_ERROR;
+    // caller-side request logging already captures provider, endpoint, and HTTP status context.
     return ipcError("LLM_API_ERROR", "Non-JSON upstream response");
   }
 }

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -1490,7 +1490,21 @@ function createAiStreamHelpers(
                       arguments: parsedArgs,
                     },
                   ];
-                } catch {
+                } catch (error) {
+                  logWarn(
+                    deps.logger as Logger & {
+                      warn?: (event: string, data?: Record<string, unknown>) => void;
+                    },
+                    "tool_call_json_parse_failed",
+                    {
+                      module: "ai-service",
+                      provider: "openai",
+                      toolCallId: value.id,
+                      toolName: value.name,
+                      error: error instanceof Error ? error.message : String(error),
+                      rawJson: value.argumentsRaw.slice(0, SSE_PARSE_RAW_MAX_LEN),
+                    },
+                  );
                   // Partial tool-call chunks may contain incomplete JSON; keep call trace with null arguments.
                   return [
                     {

--- a/apps/desktop/main/src/services/ai/aiService.ts
+++ b/apps/desktop/main/src/services/ai/aiService.ts
@@ -1491,6 +1491,7 @@ function createAiStreamHelpers(
                     },
                   ];
                 } catch {
+                  // Partial tool-call chunks may contain incomplete JSON; keep call trace with null arguments.
                   return [
                     {
                       id: value.id,

--- a/apps/desktop/main/src/services/context/contextFs.ts
+++ b/apps/desktop/main/src/services/context/contextFs.ts
@@ -92,6 +92,7 @@ async function fileExistsAsync(absPath: string): Promise<boolean> {
     await fsPromises.access(absPath);
     return true;
   } catch {
+    // Missing/unreadable file should behave as "not exists" for idempotent bootstrap.
     return false;
   }
 }

--- a/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
@@ -1005,6 +1005,44 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
       }
     });
   });
+
+  describe("parse fallback logging (INV-10)", () => {
+    it("entityRead attributesJson 解析失败时记录日志并返回空 attributes", () => {
+      db.prepare
+        .mockReturnValueOnce(projectExistsStmt())
+        .mockReturnValueOnce(
+          selectEntityStmt(makeEntityRow({ attributesJson: "{invalid" })),
+        );
+
+      const result = svc.entityRead({ projectId: PROJECT_ID, id: ENTITY_ID });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.attributes).toEqual({});
+      }
+      expect(logger.error).toHaveBeenCalledWith(
+        "kg_entity_attributes_parse_failed",
+        expect.objectContaining({ message: expect.any(String) }),
+      );
+    });
+
+    it("entityRead aliasesJson 解析失败时记录日志并返回空 aliases", () => {
+      db.prepare
+        .mockReturnValueOnce(projectExistsStmt())
+        .mockReturnValueOnce(
+          selectEntityStmt(makeEntityRow({ aliasesJson: "{invalid" })),
+        );
+
+      const result = svc.entityRead({ projectId: PROJECT_ID, id: ENTITY_ID });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data.aliases).toEqual([]);
+      }
+      expect(logger.error).toHaveBeenCalledWith(
+        "kg_entity_aliases_parse_failed",
+        expect.objectContaining({ message: expect.any(String) }),
+      );
+    });
+  });
 });
 
 // ===========================================================================

--- a/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
@@ -1008,7 +1008,6 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
 
   describe("parse fallback logging (INV-10)", () => {
     it("entityRead attributesJson 解析失败时记录日志并返回空 attributes", () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       db.prepare
         .mockReturnValueOnce(projectExistsStmt())
         .mockReturnValueOnce(
@@ -1020,15 +1019,13 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
       if (result.ok) {
         expect(result.data.attributes).toEqual({});
       }
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         "kg_entity_attributes_parse_failed",
         expect.objectContaining({ message: expect.any(String) }),
       );
-      consoleSpy.mockRestore();
     });
 
     it("entityRead aliasesJson 解析失败时记录日志并返回空 aliases", () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       db.prepare
         .mockReturnValueOnce(projectExistsStmt())
         .mockReturnValueOnce(
@@ -1040,11 +1037,10 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
       if (result.ok) {
         expect(result.data.aliases).toEqual([]);
       }
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         "kg_entity_aliases_parse_failed",
         expect.objectContaining({ message: expect.any(String) }),
       );
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
@@ -1008,6 +1008,7 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
 
   describe("parse fallback logging (INV-10)", () => {
     it("entityRead attributesJson 解析失败时记录日志并返回空 attributes", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       db.prepare
         .mockReturnValueOnce(projectExistsStmt())
         .mockReturnValueOnce(
@@ -1019,13 +1020,15 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
       if (result.ok) {
         expect(result.data.attributes).toEqual({});
       }
-      expect(logger.error).toHaveBeenCalledWith(
+      expect(consoleSpy).toHaveBeenCalledWith(
         "kg_entity_attributes_parse_failed",
         expect.objectContaining({ message: expect.any(String) }),
       );
+      consoleSpy.mockRestore();
     });
 
     it("entityRead aliasesJson 解析失败时记录日志并返回空 aliases", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       db.prepare
         .mockReturnValueOnce(projectExistsStmt())
         .mockReturnValueOnce(
@@ -1037,10 +1040,11 @@ describe("kgCoreService — Relation CRUD（关系增删改查）", () => {
       if (result.ok) {
         expect(result.data.aliases).toEqual([]);
       }
-      expect(logger.error).toHaveBeenCalledWith(
+      expect(consoleSpy).toHaveBeenCalledWith(
         "kg_entity_aliases_parse_failed",
         expect.objectContaining({ message: expect.any(String) }),
       );
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -297,9 +297,12 @@ function validateAndNormalizeAttributes(args: {
   return { ok: true, data: normalized };
 }
 
-function parseAttributes(attributesJson: string): Record<string, string> {
+function parseAttributes(args: {
+  attributesJson: string;
+  logger: Logger;
+}): Record<string, string> {
   try {
-    const parsed = JSON.parse(attributesJson) as unknown;
+    const parsed = JSON.parse(args.attributesJson) as unknown;
     if (!isRecord(parsed)) {
       return {};
     }
@@ -311,20 +314,26 @@ function parseAttributes(attributesJson: string): Record<string, string> {
       }
     }
     return normalized;
-  } catch {
+  } catch (error) {
+    args.logger.error("kg_entity_attributes_parse_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return {};
   }
 }
 
-function parseAliases(aliasesJson: string): string[] {
+function parseAliases(args: { aliasesJson: string; logger: Logger }): string[] {
   try {
-    const parsed = JSON.parse(aliasesJson) as unknown;
+    const parsed = JSON.parse(args.aliasesJson) as unknown;
     const normalized = ALIASES_SCHEMA.safeParse(parsed);
     if (!normalized.success) {
       return [];
     }
     return normalized.data;
-  } catch {
+  } catch (error) {
+    args.logger.error("kg_entity_aliases_parse_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return [];
   }
 }
@@ -400,10 +409,13 @@ function rowToEntity(row: EntityRow): KnowledgeEntity {
     type: row.type,
     name: row.name,
     description: row.description,
-    attributes: parseAttributes(row.attributesJson),
+    attributes: parseAttributes({
+      attributesJson: row.attributesJson,
+      logger: args.logger,
+    }),
     lastSeenState: row.lastSeenState ?? undefined,
     aiContextLevel: normalizedAiContextLevel,
-    aliases: parseAliases(row.aliasesJson),
+    aliases: parseAliases({ aliasesJson: row.aliasesJson, logger: args.logger }),
     version: row.version,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -299,7 +299,7 @@ function validateAndNormalizeAttributes(args: {
 
 function parseAttributes(args: {
   attributesJson: string;
-  logger: Logger;
+  logger?: Logger;
 }): Record<string, string> {
   try {
     const parsed = JSON.parse(args.attributesJson) as unknown;
@@ -315,14 +315,20 @@ function parseAttributes(args: {
     }
     return normalized;
   } catch (error) {
-    args.logger.error("kg_entity_attributes_parse_failed", {
-      message: error instanceof Error ? error.message : String(error),
-    });
+    if (args.logger) {
+      args.logger.error("kg_entity_attributes_parse_failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      console.error("kg_entity_attributes_parse_failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
     return {};
   }
 }
 
-function parseAliases(args: { aliasesJson: string; logger: Logger }): string[] {
+function parseAliases(args: { aliasesJson: string; logger?: Logger }): string[] {
   try {
     const parsed = JSON.parse(args.aliasesJson) as unknown;
     const normalized = ALIASES_SCHEMA.safeParse(parsed);
@@ -331,9 +337,15 @@ function parseAliases(args: { aliasesJson: string; logger: Logger }): string[] {
     }
     return normalized.data;
   } catch (error) {
-    args.logger.error("kg_entity_aliases_parse_failed", {
-      message: error instanceof Error ? error.message : String(error),
-    });
+    if (args.logger) {
+      args.logger.error("kg_entity_aliases_parse_failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      console.error("kg_entity_aliases_parse_failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
     return [];
   }
 }
@@ -411,11 +423,10 @@ function rowToEntity(row: EntityRow): KnowledgeEntity {
     description: row.description,
     attributes: parseAttributes({
       attributesJson: row.attributesJson,
-      logger: args.logger,
     }),
     lastSeenState: row.lastSeenState ?? undefined,
     aiContextLevel: normalizedAiContextLevel,
-    aliases: parseAliases({ aliasesJson: row.aliasesJson, logger: args.logger }),
+    aliases: parseAliases({ aliasesJson: row.aliasesJson }),
     version: row.version,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -412,7 +412,7 @@ function selectRelationById(
     .get(id);
 }
 
-function rowToEntity(row: EntityRow): KnowledgeEntity {
+function rowToEntity(row: EntityRow, logger?: Logger): KnowledgeEntity {
   const normalizedAiContextLevel =
     normalizeAiContextLevel(row.aiContextLevel) ?? DEFAULT_AI_CONTEXT_LEVEL;
   return {
@@ -423,10 +423,11 @@ function rowToEntity(row: EntityRow): KnowledgeEntity {
     description: row.description,
     attributes: parseAttributes({
       attributesJson: row.attributesJson,
+      logger,
     }),
     lastSeenState: row.lastSeenState ?? undefined,
     aiContextLevel: normalizedAiContextLevel,
-    aliases: parseAliases({ aliasesJson: row.aliasesJson }),
+    aliases: parseAliases({ aliasesJson: row.aliasesJson, logger }),
     version: row.version,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -561,6 +562,7 @@ function ensureRelationTypeRegistered(
 function listProjectEntities(
   db: Database.Database,
   projectId: string,
+  logger?: Logger,
   filter?: {
     aiContextLevel?: AiContextLevel;
   },
@@ -587,7 +589,7 @@ function listProjectEntities(
       `SELECT id, project_id as projectId, type, name, description, attributes_json as attributesJson, last_seen_state as lastSeenState, ai_context_level as aiContextLevel, aliases as aliasesJson, version, created_at as createdAt, updated_at as updatedAt FROM kg_entities ${whereSql} ORDER BY updated_at DESC, id ASC${paginationSql}`,
     )
     .all(...params) as EntityRow[];
-  return rows.map(rowToEntity);
+  return rows.map((row) => rowToEntity(row, logger));
 }
 
 function listProjectRelations(
@@ -1142,7 +1144,7 @@ function createEntityOps(
           return ipcError("DB_ERROR", "Failed to load created entity");
         }
 
-        return { ok: true, data: rowToEntity(row) };
+        return { ok: true, data: rowToEntity(row, args.logger) };
       } catch (error) {
         args.logger.error("kg_entity_create_failed", {
           code: "DB_ERROR",
@@ -1175,7 +1177,7 @@ function createEntityOps(
           return ipcError("NOT_FOUND", "Entity not found");
         }
 
-        return { ok: true, data: rowToEntity(row) };
+        return { ok: true, data: rowToEntity(row, args.logger) };
       } catch (error) {
         args.logger.error("kg_entity_read_failed", {
           code: "DB_ERROR",
@@ -1232,6 +1234,7 @@ function createEntityOps(
             items: listProjectEntities(
               args.db,
               normalizedProjectId,
+              args.logger,
               {
                 aiContextLevel: normalizedFilterAiContextLevel,
               },
@@ -1359,7 +1362,7 @@ function createEntityUpdateOps(
           return ipcError("KG_ENTITY_CONFLICT", "entity version conflict", {
             expectedVersion,
             latestVersion: existing.version,
-            latestSnapshot: rowToEntity(existing),
+            latestSnapshot: rowToEntity(existing, args.logger),
           });
         }
 
@@ -1427,7 +1430,7 @@ function createEntityUpdateOps(
           return ipcError("DB_ERROR", "Failed to load updated entity");
         }
 
-        return { ok: true, data: rowToEntity(row) };
+        return { ok: true, data: rowToEntity(row, args.logger) };
       } catch (error) {
         args.logger.error("kg_entity_update_failed", {
           code: "DB_ERROR",
@@ -1849,7 +1852,7 @@ function createQueryGraphOps(
           reachableEntityIds,
         ).filter((entry) => entry.projectId === normalizedProjectId);
         const entityById = new Map(
-          selectedEntityRows.map((entry) => [entry.id, rowToEntity(entry.row)]),
+          selectedEntityRows.map((entry) => [entry.id, rowToEntity(entry.row, args.logger)]),
         );
         const selectedEntities = reachableEntityIds
           .map((entityId) => entityById.get(entityId))
@@ -2009,7 +2012,7 @@ function createQueryGraphOps(
         const orderedItems = normalizedEntityIds
           .map((id) => {
             const row = rowById.get(id);
-            return row ? rowToEntity(row) : null;
+            return row ? rowToEntity(row, args.logger) : null;
           })
           .filter((entity): entity is KnowledgeEntity => entity !== null);
 
@@ -2243,11 +2246,15 @@ function createQueryTextOps(
           candidateEntities = normalizedEntityIds
             .map((id) => {
               const row = rowById.get(id);
-              return row ? rowToEntity(row) : null;
+              return row ? rowToEntity(row, args.logger) : null;
             })
             .filter((entity): entity is KnowledgeEntity => entity !== null);
         } else {
-          candidateEntities = listProjectEntities(args.db, normalizedProjectId);
+          candidateEntities = listProjectEntities(
+            args.db,
+            normalizedProjectId,
+            args.logger,
+          );
         }
 
         if (normalizedExcerpt.length === 0) {
@@ -2383,6 +2390,7 @@ function createQueryTextOps(
         for (const entity of listProjectEntities(
           args.db,
           normalizedProjectId,
+          args.logger,
         )) {
           entityNameById.set(entity.id, entity.name);
         }

--- a/apps/desktop/main/src/services/memory/__tests__/userMemoryVec.test.ts
+++ b/apps/desktop/main/src/services/memory/__tests__/userMemoryVec.test.ts
@@ -22,6 +22,25 @@ function createLogger(): Logger {
   };
 }
 
+function createSpyLogger(): Logger & {
+  infoEvents: string[];
+  errorEvents: string[];
+} {
+  const infoEvents: string[] = [];
+  const errorEvents: string[] = [];
+  return {
+    logPath: "<test>",
+    info: (event: string) => {
+      infoEvents.push(event);
+    },
+    error: (event: string) => {
+      errorEvents.push(event);
+    },
+    infoEvents,
+    errorEvents,
+  };
+}
+
 function createModelUnavailableDbStub(): Database.Database {
   const db = {
     prepare: () => ({
@@ -34,6 +53,30 @@ function createModelUnavailableDbStub(): Database.Database {
     },
   } as unknown as Database.Database;
 
+  return db;
+}
+
+function createInvalidSettingDbStub(): Database.Database {
+  const db = {
+    prepare: (sql: string) => {
+      if (sql.includes("SELECT value_json as valueJson FROM settings")) {
+        return {
+          get: () => ({ valueJson: "{" }),
+        };
+      }
+      if (sql.includes("SELECT vec_version() as version")) {
+        return {
+          get: () => ({ version: "0.1.0" }),
+        };
+      }
+      return {
+        get: () => undefined,
+        run: () => undefined,
+      };
+    },
+    exec: () => undefined,
+    loadExtension: () => undefined,
+  } as unknown as Database.Database;
   return db;
 }
 
@@ -158,6 +201,43 @@ function cosine(a: readonly number[], b: readonly number[]): number {
       true,
     );
   }
+}
+
+// Scenario: sqlite-vec probe failures should be logged (INV-10 no silent catch)
+{
+  const logger = createSpyLogger();
+  const svc = createUserMemoryVecService({
+    db: createModelUnavailableDbStub(),
+    logger,
+  });
+  const result = svc.topK({
+    sources: [{ memoryId: "m-1", content: "高兴的打斗节奏" }],
+    queryText: "开心动作",
+    k: 1,
+    ts: 1_700_000_000_000,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(logger.infoEvents.includes("sqlite_vec_probe_failed"), true);
+}
+
+// Scenario: damaged settings JSON should be logged and fallback to default dimension
+{
+  const logger = createSpyLogger();
+  const svc = createUserMemoryVecService({
+    db: createInvalidSettingDbStub(),
+    logger,
+  });
+  const result = svc.topK({
+    sources: [{ memoryId: "m-1", content: "高兴的打斗节奏" }],
+    queryText: "开心动作",
+    k: 1,
+    ts: 1_700_000_000_000,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(
+    logger.errorEvents.includes("user_memory_vec_setting_parse_failed"),
+    true,
+  );
 }
 
 console.log("userMemoryVec.test.ts: all assertions passed");

--- a/apps/desktop/main/src/services/memory/userMemoryVec.ts
+++ b/apps/desktop/main/src/services/memory/userMemoryVec.ts
@@ -62,19 +62,27 @@ const SEMANTIC_ALIAS_MAP: Record<string, string> = {
 
 const LOADED_DBS = new WeakSet<Database.Database>();
 
-function readSetting(db: Database.Database, key: string): unknown | null {
+function readSetting(args: {
+  db: Database.Database;
+  key: string;
+  logger: Logger;
+}): unknown | null {
   try {
-    const row = db
+    const row = args.db
       .prepare<
         [string, string],
         { valueJson: string }
       >("SELECT value_json as valueJson FROM settings WHERE scope = ? AND key = ?")
-      .get(SETTINGS_SCOPE, key);
+      .get(SETTINGS_SCOPE, args.key);
     if (!row) {
       return null;
     }
     return JSON.parse(row.valueJson) as unknown;
-  } catch {
+  } catch (error) {
+    args.logger.error("user_memory_vec_setting_parse_failed", {
+      key: args.key,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }
@@ -114,13 +122,19 @@ function resolveLoadablePath(): ServiceResult<string> {
  * Why: the DB bootstrap may have already loaded the extension; double-loading can
  * fail on some platforms/builds and would incorrectly force deterministic fallback.
  */
-function isSqliteVecLoaded(db: Database.Database): boolean {
+function isSqliteVecLoaded(args: {
+  db: Database.Database;
+  logger: Logger;
+}): boolean {
   try {
-    const row = db
+    const row = args.db
       .prepare<[], { version: string }>("SELECT vec_version() as version")
       .get();
     return typeof row?.version === "string" && row.version.length > 0;
-  } catch {
+  } catch (error) {
+    args.logger.info("sqlite_vec_probe_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return false;
   }
 }
@@ -133,7 +147,7 @@ function ensureSqliteVecLoaded(args: {
     return { ok: true, data: true };
   }
 
-  if (isSqliteVecLoaded(args.db)) {
+  if (isSqliteVecLoaded({ db: args.db, logger: args.logger })) {
     LOADED_DBS.add(args.db);
     return { ok: true, data: true };
   }
@@ -166,7 +180,11 @@ function ensureSchema(args: {
     return loaded;
   }
 
-  const stored = readSetting(args.db, DIMENSION_KEY);
+  const stored = readSetting({
+    db: args.db,
+    key: DIMENSION_KEY,
+    logger: args.logger,
+  });
   if (typeof stored === "number" && Number.isFinite(stored) && stored > 0) {
     if (stored !== args.dimension) {
       return ipcError("CONFLICT", "user_memory_vec dimension mismatch", {

--- a/apps/desktop/main/src/services/projects/templateService.ts
+++ b/apps/desktop/main/src/services/projects/templateService.ts
@@ -57,6 +57,7 @@ function isDirectory(candidate: string): boolean {
   try {
     return fs.statSync(candidate).isDirectory();
   } catch {
+    // Resolve flow probes multiple candidates; inaccessible path means "not a directory".
     return false;
   }
 }

--- a/apps/desktop/main/src/services/settings/settingsService.ts
+++ b/apps/desktop/main/src/services/settings/settingsService.ts
@@ -194,6 +194,7 @@ export function createSettingsService(deps: Deps): SettingsService {
       ).get(args.projectId, args.type, args.name, args.excludeId ?? "");
       return typeof row?.id === "string";
     } catch {
+      // Name conflict check is best-effort; DB probe failure should not block in-memory guard path.
       return false;
     }
   }

--- a/apps/desktop/main/src/services/skills/__tests__/skillService-lifecycle.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/skillService-lifecycle.test.ts
@@ -174,6 +174,7 @@ describe("createSkillService", () => {
   let projectRoot: string;
   let db: Database.Database;
   let svc: SkillService;
+  let logger: Logger;
 
   beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "creonow-skill-svc-"));
@@ -197,11 +198,12 @@ describe("createSkillService", () => {
     seedProject({ db, projectId: "proj-1", projectRoot });
     setCurrentProject({ db, projectId: "proj-1" });
 
+    logger = createNoopLogger();
     svc = createSkillService({
       db,
       userDataDir,
       builtinSkillsDir,
-      logger: createNoopLogger(),
+      logger,
     });
   });
 
@@ -593,6 +595,39 @@ describe("createSkillService", () => {
       if (result.ok) {
         expect(result.data.items).toHaveLength(2);
       }
+    });
+
+    it("should log when persisted context_rules JSON is invalid", () => {
+      const ts = Date.now();
+      db.prepare(
+        "INSERT INTO custom_skills (id, name, description, prompt_template, input_type, context_rules, scope, project_id, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        "custom-invalid-json",
+        "坏数据技能",
+        "bad payload",
+        "template",
+        "selection",
+        "{invalid-json",
+        "global",
+        null,
+        1,
+        ts,
+        ts,
+      );
+
+      const result = svc.listCustom();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const target = result.data.items.find(
+          (item) => item.id === "custom-invalid-json",
+        );
+        expect(target?.contextRules).toEqual({});
+      }
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "custom_skill_context_rules_parse_failed",
+        expect.objectContaining({ skillId: "custom-invalid-json" }),
+      );
     });
   });
 

--- a/apps/desktop/main/src/services/skills/skillService.ts
+++ b/apps/desktop/main/src/services/skills/skillService.ts
@@ -337,6 +337,7 @@ function readEnabledMap(
 function readCustomSkills(args: {
   db: Database.Database;
   currentProjectId: string | null;
+  logger: Logger;
 }): ServiceResult<CustomSkillRecord[]> {
   try {
     let rows: CustomSkillDbRow[];
@@ -405,10 +406,12 @@ function readCustomSkillById(args: {
   db: Database.Database;
   currentProjectId: string | null;
   id: string;
+  logger: Logger;
 }): ServiceResult<CustomSkillRecord | null> {
   const listed = readCustomSkills({
     db: args.db,
     currentProjectId: args.currentProjectId,
+    logger: args.logger,
   });
   if (!listed.ok) {
     return listed;
@@ -956,6 +959,7 @@ function executeSkillToggle(
     db: ctx.db,
     currentProjectId: loaded.data.currentProjectId,
     id: normalizedCustomId,
+    logger: ctx.logger,
   });
   if (!custom.ok) {
     return custom;
@@ -1153,6 +1157,7 @@ async function executeUpdateCustom(
     db: ctx.db,
     currentProjectId: loaded.data.currentProjectId,
     id: customId,
+    logger: ctx.logger,
   });
   if (!custom.ok) {
     return custom;
@@ -1384,6 +1389,7 @@ function executeResolveForRun(
     db: ctx.db,
     currentProjectId: loaded.data.currentProjectId,
     id: customId,
+    logger: ctx.logger,
   });
   if (!custom.ok) {
     return custom;
@@ -1627,6 +1633,7 @@ export function createSkillService(deps: {
       const customSkills = readCustomSkills({
         db: deps.db,
         currentProjectId: loaded.data.currentProjectId,
+        logger: deps.logger,
       });
       if (!customSkills.ok) {
         return customSkills;
@@ -1697,6 +1704,7 @@ export function createSkillService(deps: {
         db: deps.db,
         currentProjectId: loaded.data.currentProjectId,
         id: normalizedId,
+        logger: deps.logger,
       });
       if (!custom.ok) {
         return custom;
@@ -1729,6 +1737,7 @@ export function createSkillService(deps: {
       const listed = readCustomSkills({
         db: deps.db,
         currentProjectId: loaded.data.currentProjectId,
+        logger: deps.logger,
       });
       if (!listed.ok) {
         return listed;
@@ -1756,6 +1765,7 @@ export function createSkillService(deps: {
           db: deps.db,
           currentProjectId: loaded.data.currentProjectId,
           id: normalizeCustomSkillId(trimmed),
+          logger: deps.logger,
         });
         if (!custom.ok) {
           return custom;

--- a/apps/desktop/main/src/services/skills/skillService.ts
+++ b/apps/desktop/main/src/services/skills/skillService.ts
@@ -212,9 +212,13 @@ function requireCustomScope(scope: string): ServiceResult<CustomSkillScope> {
   return validationError("scope", "scope 必须为 global 或 project");
 }
 
-function parseContextRulesJson(raw: string): Record<string, unknown> {
+function parseContextRulesJson(args: {
+  raw: string;
+  logger: Logger;
+  skillId: string;
+}): Record<string, unknown> {
   try {
-    const parsed: unknown = JSON.parse(raw);
+    const parsed: unknown = JSON.parse(args.raw);
     if (
       typeof parsed === "object" &&
       parsed !== null &&
@@ -223,7 +227,11 @@ function parseContextRulesJson(raw: string): Record<string, unknown> {
       return parsed as Record<string, unknown>;
     }
     return {};
-  } catch {
+  } catch (error) {
+    args.logger.error("custom_skill_context_rules_parse_failed", {
+      skillId: args.skillId,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return {};
   }
 }
@@ -244,14 +252,22 @@ function customPromptSystem(args: {
   return lines.join("\n");
 }
 
-function toCustomSkillRecord(row: CustomSkillDbRow): CustomSkillRecord {
+function toCustomSkillRecord(args: {
+  row: CustomSkillDbRow;
+  logger: Logger;
+}): CustomSkillRecord {
+  const row = args.row;
   return {
     id: row.id,
     name: row.name,
     description: row.description,
     promptTemplate: row.promptTemplate,
     inputType: row.inputType,
-    contextRules: parseContextRulesJson(row.contextRules),
+    contextRules: parseContextRulesJson({
+      raw: row.contextRules,
+      logger: args.logger,
+      skillId: row.id,
+    }),
     scope: row.scope,
     enabled: row.enabled === 1,
     createdAt: row.createdAt,
@@ -372,7 +388,9 @@ function readCustomSkills(args: {
 
     return {
       ok: true,
-      data: rows.map((row) => toCustomSkillRecord(row)),
+      data: rows.map((row) =>
+        toCustomSkillRecord({ row, logger: args.logger }),
+      ),
     };
   } catch (error) {
     return ipcError(


### PR DESCRIPTION
## Summary
Closes #101

- Removed silent catch behavior in apps/desktop/main/src hot paths by adding explicit error logging or explicit fail-closed comments.
- Prioritized AI/Skills/KG/Memory paths and covered new error branches in tests.
- Added deterministic fallback rationale where silent-ignore is intentional (startup/env parse/URL parse probes).
- Rebased to latest main and fixed rebase regressions in KG/Skill service wiring.

## Invariant Checklist
- [x] INV-1 原稿保护
- [x] INV-2 并发安全
- [x] INV-3 CJK Token
- [x] INV-4 Memory-First
- [x] INV-5 叙事压缩
- [x] INV-6 一切皆 Skill
- [x] INV-7 统一入口
- [x] INV-8 Hook 链
- [x] INV-9 成本追踪
- [x] INV-10 错误不丢上下文

## Validation Evidence
- pnpm typecheck: pass
- pnpm test:unit: pass (2497/2497)
- scripts/agent_pr_preflight.sh: pass

## Risk & Rollback
- Risk: low-to-medium (error-handling path changes + new logging branches)
- Rollback: git revert f44f9dd

## Audit Gate
- 工程：GPT-5.3 Codex (xhigh)
- 审计 1：GPT-5.4 (xhigh)
- 审计 2：GPT-5.3 Codex (xhigh)
- 审计 3：Claude Opus 4.6 (high)
- 审计 4：Claude Sonnet 4.6 (high)
- 评论汇总：Claude Opus 4.6 (high)

### Round 1 (HEAD: 04a9cce) — REJECT
- [x] 审计发现 2 个 findings（kgCoreService rowToEntity logger / aiService tool-call parse logger）
- [x] 修复提交: f92db33

### Round 2 (HEAD: f92db33) — REJECT
- [x] 审计 1（GPT-5.4）：REJECT — 5 findings (1 consensus + 4 out-of-scope pre-existing)
- [x] 审计 2（GPT-5.3 Codex）：REJECT — 2 findings (1 consensus + 1 out-of-scope)
- [x] 审计 3（Claude Opus 4.6）：ACCEPT — 0 findings
- [x] 审计 4（Claude Sonnet 4.6）：REJECT — 1 finding (consensus)
- **Consensus Finding:** aiService.ts:237 parseJsonResponse bare catch — no INV-10(a) logging, no INV-10(b) comment
- **Status:** Pending engineering fix

### Round 3 (pending)
- [ ] 审计 1（GPT-5.4）：pending
- [ ] 审计 2（GPT-5.3 Codex）：pending
- [ ] 审计 3（Claude Opus 4.6）：pending
- [ ] 审计 4（Claude Sonnet 4.6）：pending

## Visual Evidence
### Embedded Screenshots
![Backend-only change placeholder](https://dummyimage.com/1200x800/111/fff.png&text=Backend+Only+No+UI+Diff)

### Storybook Artifact / Link
- Link: https://storybook.js.org
- Visual acceptance note: Backend-only change; no renderer/Storybook surface changed.

## Changed Files (silent-catch focus)
- AI: aiProxySettingsService.ts, aiService.ts, ipc/ai.ts
- Skills: skillService.ts
- KG: kgCoreService.ts
- Memory: userMemoryVec.ts
- Other fail-closed catches with explicit rationale: ipc/ipcAcl.ts, context/contextFs.ts, projects/templateService.ts, settings/settingsService.ts, browserWindowSecurity.ts

## Tests Added/Updated
- aiProxySettingsService.test.ts
- userMemoryVec.test.ts
- kgCoreService-crud.test.ts
- skillService-lifecycle.test.ts
- aiService-methods.test.ts