### PR TITLE
fix(INV-9): 透传 cachedTokens 到 orchestrator cost tracking

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-build-skill-run-usage.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-build-skill-run-usage.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSkillRunUsage } from "../ai";
+
+describe("buildSkillRunUsage", () => {
+  it("在 cachedTokens > 0 且配置 cachedInputPricePer1kTokens 时按分段价格计算费用", () => {
+    const usage = buildSkillRunUsage({
+      modelPricingByModel: new Map([
+        [
+          "gpt-5.2",
+          {
+            promptPer1kTokens: 0.0015,
+            completionPer1kTokens: 0.003,
+            cachedInputPricePer1kTokens: 0.0003,
+          },
+        ],
+      ]),
+      model: "gpt-5.2",
+      promptTokens: 1200,
+      completionTokens: 300,
+      cachedTokens: 200,
+      sessionTotalTokens: 1500,
+    });
+
+    expect(usage).toMatchObject({
+      promptTokens: 1200,
+      completionTokens: 300,
+      cachedTokens: 200,
+      sessionTotalTokens: 1500,
+      estimatedCostUsd: 0.00246,
+    });
+  });
+
+  it("当 cachedTokens > promptTokens 时会先 clamp 再计算费用", () => {
+    const usage = buildSkillRunUsage({
+      modelPricingByModel: new Map([
+        [
+          "gpt-5.2",
+          {
+            promptPer1kTokens: 0.001,
+            completionPer1kTokens: 0.002,
+            cachedInputPricePer1kTokens: 0.004,
+          },
+        ],
+      ]),
+      model: "gpt-5.2",
+      promptTokens: 100,
+      completionTokens: 50,
+      cachedTokens: 300,
+      sessionTotalTokens: 150,
+    });
+
+    expect(usage).toMatchObject({
+      promptTokens: 100,
+      completionTokens: 50,
+      cachedTokens: 100,
+      sessionTotalTokens: 150,
+      estimatedCostUsd: 0.0005,
+    });
+  });
+});

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -11,6 +11,8 @@ import {
   SKILL_STREAM_DONE_CHANNEL,
   SKILL_TOOL_USE_CHANNEL,
   type AiStreamEvent,
+  type AiCompletionResult,
+  type AiTokenUsage,
 } from "@shared/types/ai";
 import type { Logger } from "../logging/logger";
 import { createIpcPushBackpressureGate } from "./pushBackpressure";
@@ -136,6 +138,7 @@ function isBridgeUnsupportedProviderError(error: unknown): boolean {
 type SkillRunUsage = {
   promptTokens: number;
   completionTokens: number;
+  cachedTokens?: number;
   sessionTotalTokens: number;
   estimatedCostUsd?: number;
 };
@@ -718,6 +721,7 @@ function emitOrchestratorDone(args: {
           model: args.model,
           promptTokens: args.usage?.promptTokens ?? 0,
           completionTokens: args.usage?.completionTokens ?? 0,
+          cachedTokens: args.usage?.cachedTokens ?? 0,
         },
         traceId: args.traceId,
         ...(args.error ? { error: args.error } : {}),
@@ -1134,10 +1138,12 @@ function buildSkillRunUsage(args: {
   model: string;
   promptTokens: number;
   completionTokens: number;
+  cachedTokens?: number;
   sessionTotalTokens: number;
 }): SkillRunUsage {
   const promptTokens = Math.max(0, args.promptTokens);
   const completionTokens = Math.max(0, args.completionTokens);
+  const cachedTokens = Math.max(0, args.cachedTokens ?? 0);
   const pricing = args.modelPricingByModel.get(args.model.trim());
   const estimatedCostUsd =
     pricing === undefined
@@ -1152,6 +1158,7 @@ function buildSkillRunUsage(args: {
   return {
     promptTokens,
     completionTokens,
+    ...(cachedTokens > 0 ? { cachedTokens } : {}),
     sessionTotalTokens: Math.max(0, args.sessionTotalTokens),
     ...(typeof estimatedCostUsd === "number" ? { estimatedCostUsd } : {}),
   };
@@ -1164,6 +1171,7 @@ function recordSkillRunUsage(
     context?: SkillRunPayload["context"];
     promptTokens: number;
     completionTokens: number;
+    cachedTokens?: number;
   },
 ): SkillRunUsage {
   const key = resolveUsageContextKey(args.context);
@@ -1177,6 +1185,7 @@ function recordSkillRunUsage(
     model: args.model,
     promptTokens: args.promptTokens,
     completionTokens: args.completionTokens,
+    cachedTokens: args.cachedTokens,
     sessionTotalTokens: nextTotal,
   });
 }
@@ -1485,16 +1494,8 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           options: {
             signal: AbortSignal;
             onComplete: (result: {
-              content?: string;
-              usage?: {
-                promptTokens?: number;
-                completionTokens?: number;
-                totalTokens?: number;
-                cachedTokens?: number;
-              };
-              wasRetried?: boolean;
-              persistenceError?: unknown;
-            }) => void;
+              usage?: Partial<AiTokenUsage>;
+            } & Partial<AiCompletionResult>) => void;
             onError: (e: unknown) => void;
             onApiCallStarted?: () => void;
             skillId?: string;
@@ -1620,16 +1621,8 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           options: {
             signal: AbortSignal;
             onComplete: (result: {
-              content?: string;
-              usage?: {
-                promptTokens?: number;
-                completionTokens?: number;
-                totalTokens?: number;
-                cachedTokens?: number;
-              };
-              wasRetried?: boolean;
-              persistenceError?: unknown;
-            }) => void;
+              usage?: Partial<AiTokenUsage>;
+            } & Partial<AiCompletionResult>) => void;
             onError: (e: unknown) => void;
             onApiCallStarted?: () => void;
             skillId?: string;
@@ -2015,6 +2008,7 @@ async function drainPreviewUntilPause(args: {
         promptTokens: number;
         completionTokens: number;
         totalTokens: number;
+        cachedTokens?: number;
       }
     | undefined;
   let versionId: string | undefined;
@@ -2028,6 +2022,7 @@ async function drainPreviewUntilPause(args: {
             context: args.payload.context,
             promptTokens: usage.promptTokens,
             completionTokens: usage.completionTokens,
+            cachedTokens: usage.cachedTokens,
           })
         : undefined;
       emitOrchestratorDone({
@@ -2079,6 +2074,7 @@ async function drainPreviewUntilPause(args: {
         promptTokens: number;
         completionTokens: number;
         totalTokens: number;
+        cachedTokens?: number;
       };
       continue;
     }
@@ -2090,6 +2086,7 @@ async function drainPreviewUntilPause(args: {
             context: args.payload.context,
             promptTokens: usage.promptTokens,
             completionTokens: usage.completionTokens,
+            cachedTokens: usage.cachedTokens,
           })
         : undefined;
       const session = {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1143,7 +1143,7 @@ function resolveUsageContextKey(context?: SkillRunPayload["context"]): string {
   return "global";
 }
 
-function buildSkillRunUsage(args: {
+export function buildSkillRunUsage(args: {
   modelPricingByModel: Map<string, ModelPricing>;
   model: string;
   promptTokens: number;
@@ -1153,7 +1153,10 @@ function buildSkillRunUsage(args: {
 }): SkillRunUsage {
   const promptTokens = Math.max(0, args.promptTokens);
   const completionTokens = Math.max(0, args.completionTokens);
-  const cachedTokens = Math.max(0, args.cachedTokens ?? 0);
+  const cachedTokens = Math.min(
+    promptTokens,
+    Math.max(0, args.cachedTokens ?? 0),
+  );
   const nonCachedPromptTokens = Math.max(0, promptTokens - cachedTokens);
   const pricing = args.modelPricingByModel.get(args.model.trim());
   const estimatedCostUsd =

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1485,12 +1485,15 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           options: {
             signal: AbortSignal;
             onComplete: (result: {
+              content?: string;
               usage?: {
                 promptTokens?: number;
                 completionTokens?: number;
                 totalTokens?: number;
                 cachedTokens?: number;
               };
+              wasRetried?: boolean;
+              persistenceError?: unknown;
             }) => void;
             onError: (e: unknown) => void;
             onApiCallStarted?: () => void;
@@ -1617,12 +1620,15 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           options: {
             signal: AbortSignal;
             onComplete: (result: {
+              content?: string;
               usage?: {
                 promptTokens?: number;
                 completionTokens?: number;
                 totalTokens?: number;
                 cachedTokens?: number;
               };
+              wasRetried?: boolean;
+              persistenceError?: unknown;
             }) => void;
             onError: (e: unknown) => void;
             onApiCallStarted?: () => void;
@@ -1746,7 +1752,12 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       messages,
     }) => {
       let outputText = "";
-      let usage = {
+      let usage: {
+        promptTokens: number;
+        completionTokens: number;
+        totalTokens: number;
+        cachedTokens?: number;
+      } = {
         promptTokens: 0,
         completionTokens: 0,
         totalTokens: 0,

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -280,6 +280,7 @@ const AI_CANDIDATE_COUNT_MAX = 5;
 type ModelPricing = {
   promptPer1kTokens: number;
   completionPer1kTokens: number;
+  cachedInputPricePer1kTokens?: number;
 };
 
 /**
@@ -812,19 +813,27 @@ function parseModelPricingMap(
       const record = value as Record<string, unknown>;
       const prompt = record.promptPer1kTokens;
       const completion = record.completionPer1kTokens;
+      const cachedInput = record.cachedInputPricePer1kTokens;
       if (
         typeof prompt !== "number" ||
         !Number.isFinite(prompt) ||
         prompt < 0 ||
         typeof completion !== "number" ||
         !Number.isFinite(completion) ||
-        completion < 0
+        completion < 0 ||
+        (cachedInput !== undefined &&
+          (typeof cachedInput !== "number" ||
+            !Number.isFinite(cachedInput) ||
+            cachedInput < 0))
       ) {
         continue;
       }
       map.set(model, {
         promptPer1kTokens: prompt,
         completionPer1kTokens: completion,
+        ...(typeof cachedInput === "number"
+          ? { cachedInputPricePer1kTokens: cachedInput }
+          : {}),
       });
     }
     return map;
@@ -1001,6 +1010,7 @@ type PendingPreviewSession = {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
+    cachedTokens?: number;
   };
   usageSummary?: SkillRunUsage;
   completion: Promise<IpcResponse<SkillRunConfirmResponse>>;
@@ -1144,13 +1154,16 @@ function buildSkillRunUsage(args: {
   const promptTokens = Math.max(0, args.promptTokens);
   const completionTokens = Math.max(0, args.completionTokens);
   const cachedTokens = Math.max(0, args.cachedTokens ?? 0);
+  const nonCachedPromptTokens = Math.max(0, promptTokens - cachedTokens);
   const pricing = args.modelPricingByModel.get(args.model.trim());
   const estimatedCostUsd =
     pricing === undefined
       ? undefined
       : Number(
           (
-            (promptTokens / 1000) * pricing.promptPer1kTokens +
+            (nonCachedPromptTokens / 1000) * pricing.promptPer1kTokens +
+            (cachedTokens / 1000) *
+              (pricing.cachedInputPricePer1kTokens ?? pricing.promptPer1kTokens) +
             (completionTokens / 1000) * pricing.completionPer1kTokens
           ).toFixed(6),
         );
@@ -2089,7 +2102,7 @@ async function drainPreviewUntilPause(args: {
             cachedTokens: usage.cachedTokens,
           })
         : undefined;
-      const session = {
+      const session: PendingPreviewSession = {
         executionId: args.executionId,
         runId: args.runId,
         traceId: args.traceId,
@@ -2099,7 +2112,14 @@ async function drainPreviewUntilPause(args: {
         outputText,
         usage,
         usageSummary,
-      } as PendingPreviewSession;
+        completion: Promise.resolve({
+          ok: false,
+          error: {
+            code: "INTERNAL",
+            message: "AI skill confirmation pending initialization",
+          },
+        }),
+      };
       session.completion = Promise.resolve()
         .then(() =>
           continuePreviewSession({
@@ -2225,6 +2245,7 @@ async function continuePreviewSession(args: {
               context: args.session.payload.context,
               promptTokens: args.session.usage.promptTokens,
               completionTokens: args.session.usage.completionTokens,
+              cachedTokens: args.session.usage.cachedTokens,
             })
           : undefined);
       emitOrchestratorDone({

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1484,7 +1484,14 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           messages: Array<{ role: string; content: string }>,
           options: {
             signal: AbortSignal;
-            onComplete: (r: unknown) => void;
+            onComplete: (result: {
+              usage?: {
+                promptTokens?: number;
+                completionTokens?: number;
+                totalTokens?: number;
+                cachedTokens?: number;
+              };
+            }) => void;
             onError: (e: unknown) => void;
             onApiCallStarted?: () => void;
             skillId?: string;
@@ -1565,6 +1572,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
                 promptTokens: 0,
                 completionTokens,
                 totalTokens: completionTokens,
+                cachedTokens: 0,
               },
               wasRetried: false,
             });
@@ -1608,7 +1616,14 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           messages: Array<{ role: string; content: string }>,
           options: {
             signal: AbortSignal;
-            onComplete: (r: unknown) => void;
+            onComplete: (result: {
+              usage?: {
+                promptTokens?: number;
+                completionTokens?: number;
+                totalTokens?: number;
+                cachedTokens?: number;
+              };
+            }) => void;
             onError: (e: unknown) => void;
             onApiCallStarted?: () => void;
             skillId?: string;
@@ -1759,7 +1774,11 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         terminal: string;
         error?: { message?: string; code?: string };
         result?: {
-          metadata: { promptTokens: number; completionTokens: number };
+          metadata: {
+            promptTokens: number;
+            completionTokens: number;
+            cachedTokens?: number;
+          };
         };
         finishReason?: "stop" | "tool_use";
         toolCalls?: Array<{
@@ -1787,6 +1806,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
               estimateTokens(resolveWritingRequestInput(request))) +
             (event.result?.metadata.completionTokens ??
               estimateTokens(event.outputText)),
+          cachedTokens: event.result?.metadata.cachedTokens ?? 0,
         };
         // F1: capture finishReason and toolCalls from the done event
         if (event.finishReason !== undefined) {

--- a/apps/desktop/main/src/services/ai/__tests__/aiServiceBridge.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiServiceBridge.test.ts
@@ -187,6 +187,96 @@ describe("aiServiceBridge", () => {
     );
   });
 
+  it("propagates cachedTokens > 0 through bridge completion and persistence", async () => {
+    const db = createDb();
+    putSetting(db, "creonow.ai.model.primary", "gpt-4.1");
+    putSetting(db, "creonow.ai.model.auxiliary", "gpt-4.1-mini");
+
+    const bridge = createAiServiceBridge({
+      db,
+      logger: createLogger(),
+      costTracker: createCostTracker({
+        pricingTable: createPricingTable(),
+        budgetPolicy: {
+          warningThreshold: 10,
+          hardStopLimit: 100,
+          enabled: false,
+        },
+        estimateTokens: () => 0,
+      }),
+      env: {
+        CREONOW_AI_PROVIDER: "openai",
+        CREONOW_AI_BASE_URL: "https://api.openai.com",
+        CREONOW_AI_API_KEY: "sk-test",
+      },
+      runtimeAiTimeoutMs: 30_000,
+      fetchImpl: (async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode(
+                  [
+                    'data: {"choices":[{"delta":{"content":"cached "}}]}',
+                    "",
+                    'data: {"choices":[{"delta":{"content":"ok"}}]}',
+                    "",
+                    'data: {"usage":{"prompt_tokens":1000,"completion_tokens":200,"cached_tokens":400}}',
+                    "",
+                    "data: [DONE]",
+                    "",
+                  ].join("\n"),
+                ),
+              );
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        )) as unknown as typeof fetch,
+      now: () => 1_000,
+    });
+
+    const onComplete = vi.fn();
+    for await (const _chunk of bridge.streamChat(
+      [{ role: "user", content: "summarize this" }],
+      {
+        signal: new AbortController().signal,
+        onComplete,
+        onError: vi.fn(),
+        skillId: "builtin:summarize",
+        requestId: "bridge-req-cached",
+      },
+    )) {
+      // drain
+    }
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usage: expect.objectContaining({
+          cachedTokens: 400,
+        }),
+      }),
+    );
+
+    const row = db
+      .prepare<
+        [string],
+        {
+          inputTokens: number;
+          outputTokens: number;
+          cacheHitTokens: number;
+        }
+      >(
+        "SELECT input_tokens AS inputTokens, output_tokens AS outputTokens, cache_hit_tokens AS cacheHitTokens FROM cost_records WHERE id = ?",
+      )
+      .get("bridge-req-cached");
+    expect(row).toEqual({
+      inputTokens: 1000,
+      outputTokens: 200,
+      cacheHitTokens: 400,
+    });
+  });
+
   it("logs persistenceError and propagates it in onComplete payload", async () => {
     const db = createDb();
     putSetting(db, "creonow.ai.model.primary", "gpt-4.1");

--- a/apps/desktop/main/src/services/ai/__tests__/aiServiceBridge.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/aiServiceBridge.test.ts
@@ -162,6 +162,7 @@ describe("aiServiceBridge", () => {
           promptTokens: 11,
           completionTokens: 4,
           totalTokens: 15,
+          cachedTokens: 0,
         },
       }),
     );

--- a/apps/desktop/main/src/services/ai/__tests__/apiClient.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/apiClient.test.ts
@@ -5,6 +5,11 @@ import { createApiClient } from "../apiClient";
 import { createCostTracker, type ModelPricingTable } from "../costTracker";
 import type { Logger } from "../../../logging/logger";
 
+const ALIAS_PROMPT_TOKENS = 120;
+const ALIAS_COMPLETION_TOKENS = 30;
+const ALIAS_CACHE_READ_TOKENS = 18;
+const OPENAI_CACHE_TOKENS = 7;
+
 function createLogger(): Logger {
   return {
     logPath: "<test>",
@@ -173,9 +178,9 @@ describe("apiClient", () => {
         JSON.stringify({
           choices: [{ message: { content: "alias ok" } }],
           usage: {
-            input_tokens: 120,
-            output_tokens: 30,
-            cache_read_input_tokens: 18,
+            input_tokens: ALIAS_PROMPT_TOKENS,
+            output_tokens: ALIAS_COMPLETION_TOKENS,
+            cache_read_input_tokens: ALIAS_CACHE_READ_TOKENS,
             cache_creation_input_tokens: 2,
           },
         }),
@@ -209,9 +214,176 @@ describe("apiClient", () => {
       throw new Error("expected request success");
     }
     expect(result.data.usage).toMatchObject({
-      promptTokens: 120,
-      completionTokens: 30,
-      cachedTokens: 20,
+      promptTokens: ALIAS_PROMPT_TOKENS,
+      completionTokens: ALIAS_COMPLETION_TOKENS,
+      cachedTokens: ALIAS_CACHE_READ_TOKENS,
+    });
+  });
+
+  it("prefers explicit prompt_tokens=0 over input_tokens fallback", async () => {
+    const db = createDb();
+    const tracker = createCostTracker({
+      pricingTable: createPricingTable(),
+      budgetPolicy: {
+        warningThreshold: 10,
+        hardStopLimit: 100,
+        enabled: false,
+      },
+      estimateTokens: () => 0,
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "zero prompt" } }],
+          usage: {
+            prompt_tokens: 0,
+            input_tokens: 10,
+            completion_tokens: 2,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createApiClient({
+      db,
+      costTracker: tracker,
+      logger: createLogger(),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now: () => 1_000,
+    });
+
+    const result = await client.createChatCompletion({
+      provider: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o",
+        maxTokens: 512,
+        temperature: 0.2,
+      },
+      messages: [{ role: "user", content: "Say hello" }],
+      requestId: "req-usage-zero",
+      skillId: "builtin:continue",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected request success");
+    }
+    expect(result.data.usage.promptTokens).toBe(0);
+  });
+
+  it("uses max cache-hit value for mixed provider payload", async () => {
+    const db = createDb();
+    const tracker = createCostTracker({
+      pricingTable: createPricingTable(),
+      budgetPolicy: {
+        warningThreshold: 10,
+        hardStopLimit: 100,
+        enabled: false,
+      },
+      estimateTokens: () => 0,
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "mixed cache fields" } }],
+          usage: {
+            prompt_tokens: 8,
+            completion_tokens: 3,
+            cached_tokens: OPENAI_CACHE_TOKENS,
+            cache_read_input_tokens: ALIAS_CACHE_READ_TOKENS,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createApiClient({
+      db,
+      costTracker: tracker,
+      logger: createLogger(),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now: () => 1_000,
+    });
+
+    const result = await client.createChatCompletion({
+      provider: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o",
+        maxTokens: 512,
+        temperature: 0.2,
+      },
+      messages: [{ role: "user", content: "Say hello" }],
+      requestId: "req-mixed-cache",
+      skillId: "builtin:continue",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected request success");
+    }
+    expect(result.data.usage.cachedTokens).toBe(ALIAS_CACHE_READ_TOKENS);
+  });
+
+  it("normalizes non-finite usage values to zero", async () => {
+    const db = createDb();
+    const tracker = createCostTracker({
+      pricingTable: createPricingTable(),
+      budgetPolicy: {
+        warningThreshold: 10,
+        hardStopLimit: 100,
+        enabled: false,
+      },
+      estimateTokens: () => 0,
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "non-finite usage" } }],
+          usage: {
+            prompt_tokens: Number.POSITIVE_INFINITY,
+            completion_tokens: Number.NaN,
+            cache_read_input_tokens: Number.NEGATIVE_INFINITY,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createApiClient({
+      db,
+      costTracker: tracker,
+      logger: createLogger(),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now: () => 1_000,
+    });
+
+    const result = await client.createChatCompletion({
+      provider: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o",
+        maxTokens: 512,
+        temperature: 0.2,
+      },
+      messages: [{ role: "user", content: "Say hello" }],
+      requestId: "req-non-finite-usage",
+      skillId: "builtin:continue",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected request success");
+    }
+    expect(result.data.usage).toMatchObject({
+      promptTokens: 0,
+      completionTokens: 0,
+      cachedTokens: 0,
     });
   });
 

--- a/apps/desktop/main/src/services/ai/__tests__/apiClient.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/apiClient.test.ts
@@ -146,6 +146,7 @@ describe("apiClient", () => {
     expect(result.data.content).toBe("hello world");
     expect(result.data.usage.promptTokens).toBe(100);
     expect(result.data.usage.completionTokens).toBe(40);
+    expect(result.data.usage.cachedTokens).toBe(20);
     const calledUrl = String(fetchMock.mock.calls[0]?.[0]);
     expect(calledUrl).toBe("https://api.openai.com/v1/chat/completions");
 
@@ -153,6 +154,65 @@ describe("apiClient", () => {
     expect(row).not.toBeNull();
     expect(row?.model).toBe("gpt-4o");
     expect(row?.estimatedCostUsd).toBeGreaterThan(0);
+  });
+
+  it("maps anthropic/local usage aliases to cachedTokens", async () => {
+    const db = createDb();
+    const tracker = createCostTracker({
+      pricingTable: createPricingTable(),
+      budgetPolicy: {
+        warningThreshold: 10,
+        hardStopLimit: 100,
+        enabled: false,
+      },
+      estimateTokens: () => 0,
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "alias ok" } }],
+          usage: {
+            input_tokens: 120,
+            output_tokens: 30,
+            cache_read_input_tokens: 18,
+            cache_creation_input_tokens: 2,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createApiClient({
+      db,
+      costTracker: tracker,
+      logger: createLogger(),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now: () => 1_000,
+    });
+
+    const result = await client.createChatCompletion({
+      provider: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-test",
+        model: "gpt-4o",
+        maxTokens: 512,
+        temperature: 0.2,
+      },
+      messages: [{ role: "user", content: "Say hello" }],
+      requestId: "req-alias-usage-1",
+      skillId: "builtin:continue",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected request success");
+    }
+    expect(result.data.usage).toMatchObject({
+      promptTokens: 120,
+      completionTokens: 30,
+      cachedTokens: 20,
+    });
   });
 
   it("parses SSE stream chunks and records cost", async () => {

--- a/apps/desktop/main/src/services/ai/__tests__/cost-tracker.test.ts
+++ b/apps/desktop/main/src/services/ai/__tests__/cost-tracker.test.ts
@@ -915,6 +915,26 @@ describe("CostTracker — 费用追踪", () => {
       expect(cost.inputTokens).toBeGreaterThanOrEqual(0);
       expect(cost.outputTokens).toBeGreaterThanOrEqual(0);
     });
+
+    it("cachedTokens 超出 promptTokens 或为负数时会被 clamp", () => {
+      const overflow = tracker.recordUsage(
+        { promptTokens: 10, completionTokens: 2 },
+        "claude-sonnet-4-20250514",
+        "req-cached-overflow",
+        "polish",
+        999,
+      );
+      const negative = tracker.recordUsage(
+        { promptTokens: 10, completionTokens: 2 },
+        "claude-sonnet-4-20250514",
+        "req-cached-negative",
+        "polish",
+        -5,
+      );
+
+      expect(overflow.cachedTokens).toBe(10);
+      expect(negative.cachedTokens).toBe(0);
+    });
   });
 
   // ── CostRecordedEvent / BudgetExceededEvent ───────────────────

--- a/apps/desktop/main/src/services/ai/aiServiceAdapter.ts
+++ b/apps/desktop/main/src/services/ai/aiServiceAdapter.ts
@@ -11,7 +11,16 @@ export type { StreamChunk };
 
 interface StreamOptions {
   signal?: AbortSignal;
-  onComplete: (result: { content: string; usage: { promptTokens: number; completionTokens: number; totalTokens: number }; wasRetried: boolean }) => void;
+  onComplete: (result: {
+    content: string;
+    usage: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+      cachedTokens?: number;
+    };
+    wasRetried: boolean;
+  }) => void;
   onError: (error: { kind: string; message: string; retryCount: number; partialContent?: string }) => void;
   onApiCallStarted?: () => void;
 }

--- a/apps/desktop/main/src/services/ai/aiServiceAdapter.ts
+++ b/apps/desktop/main/src/services/ai/aiServiceAdapter.ts
@@ -4,6 +4,7 @@
  * 包装底层 AI 服务，提供 streamChat / estimateTokens / abort 接口
  */
 
+import type { AiCompletionResult } from "@shared/types/ai";
 import { estimateTokens } from "../context/tokenEstimation";
 import type { StreamChunk } from "./streaming";
 
@@ -11,16 +12,7 @@ export type { StreamChunk };
 
 interface StreamOptions {
   signal?: AbortSignal;
-  onComplete: (result: {
-    content: string;
-    usage: {
-      promptTokens: number;
-      completionTokens: number;
-      totalTokens: number;
-      cachedTokens?: number;
-    };
-    wasRetried: boolean;
-  }) => void;
+  onComplete: (result: AiCompletionResult) => void;
   onError: (error: { kind: string; message: string; retryCount: number; partialContent?: string }) => void;
   onApiCallStarted?: () => void;
 }

--- a/apps/desktop/main/src/services/ai/aiServiceBridge.ts
+++ b/apps/desktop/main/src/services/ai/aiServiceBridge.ts
@@ -7,6 +7,7 @@
  */
 
 import type Database from "better-sqlite3";
+import type { AiCompletionResult } from "@shared/types/ai";
 
 import type { Logger } from "../../logging/logger";
 import { estimateTokens as estimateTokenCount } from "../context/tokenEstimation";
@@ -26,17 +27,7 @@ import type { StreamChunk } from "./streaming";
 
 type StreamChatOptions = {
   signal: AbortSignal;
-  onComplete: (result: {
-    content: string;
-    usage: {
-      promptTokens: number;
-      completionTokens: number;
-      totalTokens: number;
-      cachedTokens?: number;
-    };
-    wasRetried: boolean;
-    persistenceError?: unknown;
-  }) => void;
+  onComplete: (result: AiCompletionResult) => void;
   onError: (e: unknown) => void;
   onApiCallStarted?: () => void;
   skillId?: string;

--- a/apps/desktop/main/src/services/ai/aiServiceBridge.ts
+++ b/apps/desktop/main/src/services/ai/aiServiceBridge.ts
@@ -26,7 +26,17 @@ import type { StreamChunk } from "./streaming";
 
 type StreamChatOptions = {
   signal: AbortSignal;
-  onComplete: (r: unknown) => void;
+  onComplete: (result: {
+    content: string;
+    usage: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+      cachedTokens?: number;
+    };
+    wasRetried: boolean;
+    persistenceError?: unknown;
+  }) => void;
   onError: (e: unknown) => void;
   onApiCallStarted?: () => void;
   skillId?: string;
@@ -347,6 +357,7 @@ export function createAiServiceBridge(args: {
           totalTokens:
             streamResult.data.usage.promptTokens +
             streamResult.data.usage.completionTokens,
+          cachedTokens: streamResult.data.usage.cachedTokens,
         },
         ...(streamResult.data.persistenceError
           ? { persistenceError: streamResult.data.persistenceError }

--- a/apps/desktop/main/src/services/ai/apiClient.ts
+++ b/apps/desktop/main/src/services/ai/apiClient.ts
@@ -78,6 +78,11 @@ type OpenAiUsagePayload = {
   prompt_tokens?: unknown;
   completion_tokens?: unknown;
   cached_tokens?: unknown;
+  input_tokens?: unknown;
+  output_tokens?: unknown;
+  cachedTokens?: unknown;
+  cache_read_input_tokens?: unknown;
+  cache_creation_input_tokens?: unknown;
 };
 
 const MAX_FETCH_RETRIES = 3;
@@ -101,10 +106,17 @@ function parseUsage(raw: unknown): CompletionUsage {
   if (!row) {
     return { promptTokens: 0, completionTokens: 0, cachedTokens: 0 };
   }
+  const promptTokens = toNonNegativeInt(row.prompt_tokens) || toNonNegativeInt(row.input_tokens);
+  const completionTokens =
+    toNonNegativeInt(row.completion_tokens) || toNonNegativeInt(row.output_tokens);
+  const openAiCached = toNonNegativeInt(row.cached_tokens) || toNonNegativeInt(row.cachedTokens);
+  const anthropicCached =
+    toNonNegativeInt(row.cache_read_input_tokens) +
+    toNonNegativeInt(row.cache_creation_input_tokens);
   return {
-    promptTokens: toNonNegativeInt(row.prompt_tokens),
-    completionTokens: toNonNegativeInt(row.completion_tokens),
-    cachedTokens: toNonNegativeInt(row.cached_tokens),
+    promptTokens,
+    completionTokens,
+    cachedTokens: Math.max(openAiCached, anthropicCached),
   };
 }
 

--- a/apps/desktop/main/src/services/ai/apiClient.ts
+++ b/apps/desktop/main/src/services/ai/apiClient.ts
@@ -101,7 +101,7 @@ function toNonNegativeInt(value: unknown): number {
     : 0;
 }
 
-function hasValue(value: unknown): value is number {
+function hasValue<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
 }
 

--- a/apps/desktop/main/src/services/ai/apiClient.ts
+++ b/apps/desktop/main/src/services/ai/apiClient.ts
@@ -96,9 +96,13 @@ function asObject(value: unknown): JsonObject | null {
 }
 
 function toNonNegativeInt(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
     ? Math.floor(value)
     : 0;
+}
+
+function hasValue(value: unknown): value is number {
+  return value !== null && value !== undefined;
 }
 
 function parseUsage(raw: unknown): CompletionUsage {
@@ -106,16 +110,21 @@ function parseUsage(raw: unknown): CompletionUsage {
   if (!row) {
     return { promptTokens: 0, completionTokens: 0, cachedTokens: 0 };
   }
-  const promptTokens = toNonNegativeInt(row.prompt_tokens) || toNonNegativeInt(row.input_tokens);
-  const completionTokens =
-    toNonNegativeInt(row.completion_tokens) || toNonNegativeInt(row.output_tokens);
-  const openAiCached = toNonNegativeInt(row.cached_tokens) || toNonNegativeInt(row.cachedTokens);
-  const anthropicCached =
-    toNonNegativeInt(row.cache_read_input_tokens) +
-    toNonNegativeInt(row.cache_creation_input_tokens);
+  const promptTokens = hasValue(row.prompt_tokens)
+    ? toNonNegativeInt(row.prompt_tokens)
+    : toNonNegativeInt(row.input_tokens);
+  const completionTokens = hasValue(row.completion_tokens)
+    ? toNonNegativeInt(row.completion_tokens)
+    : toNonNegativeInt(row.output_tokens);
+  const openAiCached = hasValue(row.cached_tokens)
+    ? toNonNegativeInt(row.cached_tokens)
+    : toNonNegativeInt(row.cachedTokens);
+  const anthropicCached = toNonNegativeInt(row.cache_read_input_tokens);
   return {
     promptTokens,
     completionTokens,
+    // Keep `max` for mixed payload compatibility: some gateways expose both
+    // OpenAI-style and Anthropic-style cache-hit fields in the same response.
     cachedTokens: Math.max(openAiCached, anthropicCached),
   };
 }

--- a/apps/desktop/main/src/services/ai/costTracker.ts
+++ b/apps/desktop/main/src/services/ai/costTracker.ts
@@ -60,14 +60,14 @@ export interface BudgetAlert {
   timestamp: number;
 }
 
-interface TokenUsage {
+interface CostTokenUsage {
   promptTokens: number;
   completionTokens: number;
 }
 
 export interface CostTracker {
   recordUsage(
-    usage: TokenUsage,
+    usage: CostTokenUsage,
     modelId: string,
     requestId: string,
     skillId: string,
@@ -159,7 +159,7 @@ export function createCostTracker(config: CostTrackerConfig): CostTracker {
 
     const safeInput = Math.max(0, inputTokens);
     const safeOutput = Math.max(0, outputTokens);
-    const safeCached = Math.max(0, cachedTokens ?? 0);
+    const safeCached = Math.min(safeInput, Math.max(0, cachedTokens ?? 0));
 
     let inputCost: number;
     if (safeCached > 0 && pricing.cachedInputPricePer1K !== undefined) {
@@ -186,7 +186,7 @@ export function createCostTracker(config: CostTrackerConfig): CostTracker {
 
   const tracker: CostTracker = {
     recordUsage(
-      usage: TokenUsage,
+      usage: CostTokenUsage,
       modelId: string,
       requestId: string,
       skillId: string,
@@ -199,7 +199,10 @@ export function createCostTracker(config: CostTrackerConfig): CostTracker {
           modelId,
           inputTokens: Math.max(0, usage.promptTokens),
           outputTokens: Math.max(0, usage.completionTokens),
-          cachedTokens: cachedTokens ?? 0,
+          cachedTokens: Math.min(
+            Math.max(0, usage.promptTokens),
+            Math.max(0, cachedTokens ?? 0),
+          ),
           cost: 0,
           skillId,
           timestamp: Date.now(),
@@ -209,7 +212,7 @@ export function createCostTracker(config: CostTrackerConfig): CostTracker {
 
       const safeInput = Math.max(0, usage.promptTokens);
       const safeOutput = Math.max(0, usage.completionTokens);
-      const safeCachedParam = cachedTokens ?? 0;
+      const safeCachedParam = Math.min(safeInput, Math.max(0, cachedTokens ?? 0));
 
       const { cost, warning } = computeCost(safeInput, safeOutput, modelId, safeCachedParam);
 

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -25,6 +25,12 @@ import type {
   SessionCostSummary,
 } from "../../ai/costTracker";
 
+const DEFAULT_PROMPT_TOKENS = 10;
+const DEFAULT_COMPLETION_TOKENS = 6;
+const DEFAULT_TOTAL_TOKENS = DEFAULT_PROMPT_TOKENS + DEFAULT_COMPLETION_TOKENS;
+const STREAM_CACHED_TOKENS = 7;
+const GENERATE_CACHED_TOKENS = 9;
+
 // ─── helpers ────────────────────────────────────────────────────────
 
 /** Collect all events from an async generator */
@@ -304,7 +310,12 @@ describe("WritingOrchestrator", () => {
       const costEvent = events.find((event) => event.type === "cost-recorded");
 
       expect(tracker.recordUsage).toHaveBeenCalledWith(
-        { promptTokens: 10, completionTokens: 6, totalTokens: 16, cachedTokens: 0 },
+        {
+          promptTokens: DEFAULT_PROMPT_TOKENS,
+          completionTokens: DEFAULT_COMPLETION_TOKENS,
+          totalTokens: DEFAULT_TOTAL_TOKENS,
+          cachedTokens: 0,
+        },
         "default",
         "req-001",
         "polish",
@@ -1213,7 +1224,7 @@ describe("WritingOrchestrator", () => {
               promptTokens: 12,
               completionTokens: 4,
               totalTokens: 16,
-              cachedTokens: 9,
+              cachedTokens: GENERATE_CACHED_TOKENS,
             },
             finishReason: "stop",
           };
@@ -1231,12 +1242,50 @@ describe("WritingOrchestrator", () => {
           promptTokens: 12,
           completionTokens: 4,
           totalTokens: 16,
-          cachedTokens: 9,
+          cachedTokens: GENERATE_CACHED_TOKENS,
         },
         "default",
         "req-cached-001",
         "polish",
-        9,
+        GENERATE_CACHED_TOKENS,
+      );
+      orch.dispose();
+    });
+
+    it("streamChat onComplete 返回 cachedTokens 时传给 costTracker", async () => {
+      const aiService = createMockAIService();
+      const tracker = createMockCostTracker();
+      aiService.streamChat.mockImplementation(
+        (_messages, options: { onApiCallStarted?: () => void; onComplete: (result: unknown) => void }) =>
+          (async function* () {
+            options.onApiCallStarted?.();
+            yield { delta: "缓存", finishReason: null, accumulatedTokens: 2 };
+            yield { delta: "命中", finishReason: "stop", accumulatedTokens: 4 };
+            options.onComplete({
+              usage: {
+                promptTokens: DEFAULT_PROMPT_TOKENS,
+                completionTokens: 4,
+                totalTokens: 14,
+                cachedTokens: STREAM_CACHED_TOKENS,
+              },
+            });
+          })(),
+      );
+      const orch = createWritingOrchestrator(buildConfig({ aiService, costTracker: tracker }));
+
+      await collectEvents(orch.execute(makeRequest({ requestId: "req-stream-cached-001" })));
+
+      expect(tracker.recordUsage).toHaveBeenCalledWith(
+        {
+          promptTokens: DEFAULT_PROMPT_TOKENS,
+          completionTokens: 4,
+          totalTokens: 14,
+          cachedTokens: STREAM_CACHED_TOKENS,
+        },
+        "default",
+        "req-stream-cached-001",
+        "polish",
+        STREAM_CACHED_TOKENS,
       );
       orch.dispose();
     });

--- a/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writing-orchestrator.test.ts
@@ -304,10 +304,11 @@ describe("WritingOrchestrator", () => {
       const costEvent = events.find((event) => event.type === "cost-recorded");
 
       expect(tracker.recordUsage).toHaveBeenCalledWith(
-        { promptTokens: 10, completionTokens: 6, totalTokens: 16 },
+        { promptTokens: 10, completionTokens: 6, totalTokens: 16, cachedTokens: 0 },
         "default",
         "req-001",
         "polish",
+        0,
       );
       expect(costEvent).toMatchObject({
         type: "cost-recorded",
@@ -554,10 +555,11 @@ describe("WritingOrchestrator", () => {
 
       expect(eventTypes(events)).toContain("aborted");
       expect(tracker.recordUsage).toHaveBeenCalledWith(
-        { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+        { promptTokens: 10, completionTokens: 2, totalTokens: 12, cachedTokens: 0 },
         "default",
         "req-001",
         "polish",
+        0,
       );
       expect(aiService.abort).not.toHaveBeenCalled();
       orch.dispose();
@@ -1190,10 +1192,51 @@ describe("WritingOrchestrator", () => {
           .details?.partialContent,
       ).toBe("半截");
       expect(tracker.recordUsage).toHaveBeenCalledWith(
-        { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+        { promptTokens: 10, completionTokens: 2, totalTokens: 12, cachedTokens: 0 },
         "default",
         "req-001",
         "polish",
+        0,
+      );
+      orch.dispose();
+    });
+
+    it("generateText 返回 cachedTokens 时传给 costTracker", async () => {
+      const tracker = createMockCostTracker();
+      const cfg = buildConfig({
+        generateText: async ({ emitChunk, onApiCallStarted }) => {
+          onApiCallStarted?.();
+          emitChunk("缓存命中", 4);
+          return {
+            fullText: "缓存命中",
+            usage: {
+              promptTokens: 12,
+              completionTokens: 4,
+              totalTokens: 16,
+              cachedTokens: 9,
+            },
+            finishReason: "stop",
+          };
+        },
+        costTracker: tracker,
+      });
+      const orch = createWritingOrchestrator(cfg);
+
+      await collectEvents(
+        orch.execute(makeRequest({ requestId: "req-cached-001", agenticLoop: true })),
+      );
+
+      expect(tracker.recordUsage).toHaveBeenCalledWith(
+        {
+          promptTokens: 12,
+          completionTokens: 4,
+          totalTokens: 16,
+          cachedTokens: 9,
+        },
+        "default",
+        "req-cached-001",
+        "polish",
+        9,
       );
       orch.dispose();
     });

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -96,7 +96,7 @@ interface AIService {
     messages: Array<{ role: string; content: string }>,
     options: {
       signal: AbortSignal;
-      onComplete: (r: unknown) => void;
+      onComplete: (result: { usage?: Partial<TokenUsage> }) => void;
       onError: (e: unknown) => void;
       onApiCallStarted?: () => void;
       skillId?: string;
@@ -114,9 +114,16 @@ interface PreparedRequest {
   modelId: string;
 }
 
+type TokenUsage = {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cachedTokens?: number;
+};
+
 type GeneratedTextResult = {
   fullText: string;
-  usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  usage: TokenUsage;
   /** P2: finish reason from the AI */
   finishReason?: "stop" | "tool_use" | null;
   /** P2: tool calls requested by the AI */
@@ -168,7 +175,7 @@ export interface OrchestratorConfig {
     messages?: Array<{ role: string; content: string; toolCallId?: string }>;
   }) => Promise<{
     fullText: string;
-    usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+    usage: TokenUsage;
     /** P2: finish reason from the AI (null = streaming, stop = done, tool_use = wants tools) */
     finishReason?: "stop" | "tool_use" | null;
     /** P2: tool calls requested by the AI when finishReason === 'tool_use' */
@@ -343,14 +350,12 @@ export function createWritingOrchestrator(
 
         let totalPromptTokens = 0;
         let totalCompletionTokens = 0;
+        let totalCachedTokens = 0;
         const pendingCostEvents: WritingEvent[] = [];
-        const recordUsage = (usage: {
-          promptTokens: number;
-          completionTokens: number;
-          totalTokens: number;
-        }): void => {
+        const recordUsage = (usage: TokenUsage): void => {
           totalPromptTokens += usage.promptTokens;
           totalCompletionTokens += usage.completionTokens;
+          totalCachedTokens += Math.max(0, usage.cachedTokens ?? 0);
 
           if (!config.costTracker) {
             return;
@@ -361,6 +366,7 @@ export function createWritingOrchestrator(
             prepared.modelId,
             requestId,
             normalizeSkillId(request.skillId),
+            usage.cachedTokens,
           );
           const summary = config.costTracker.getSessionCost();
           const budgetAlert = config.costTracker.checkBudget() ?? undefined;
@@ -393,6 +399,7 @@ export function createWritingOrchestrator(
         let lastFinishReason: "stop" | "tool_use" | null = null;
         let lastToolCalls: ToolCallInfo[] = [];
         let lastPromptTokens = tokenCount;
+        let lastCachedTokens = 0;
         let apiCallStarted = false;
 
         while (aiAttempt <= MAX_AI_RETRIES && !aiSuccess) {
@@ -454,6 +461,7 @@ export function createWritingOrchestrator(
                       promptTokens: lastPromptTokens,
                       completionTokens: lastTokens,
                       totalTokens: lastPromptTokens + lastTokens,
+                      cachedTokens: lastCachedTokens,
                     });
                   }
                   taskStates.set(requestId, "killed");
@@ -494,15 +502,19 @@ export function createWritingOrchestrator(
               fullText = generatedResult.fullText;
               lastPromptTokens = generatedResult.usage.promptTokens;
               lastTokens = generatedResult.usage.completionTokens;
+              lastCachedTokens = generatedResult.usage.cachedTokens ?? 0;
               lastFinishReason = generatedResult.finishReason ?? null;
               lastToolCalls = generatedResult.toolCalls ?? [];
             } else if (hasStreamChat) {
               let streamFinishReason: "stop" | "tool_use" | null = null;
+              let streamUsage: Partial<TokenUsage> | null = null;
               const gen = config.aiService.streamChat(
                 prepared.messages,
                 {
                   signal: abortController.signal,
-                  onComplete: () => {},
+                  onComplete: (result) => {
+                    streamUsage = result.usage ?? null;
+                  },
                   onError: () => {},
                   onApiCallStarted: () => {
                     apiCallStarted = true;
@@ -520,6 +532,7 @@ export function createWritingOrchestrator(
                       promptTokens: lastPromptTokens,
                       completionTokens: lastTokens,
                       totalTokens: lastPromptTokens + lastTokens,
+                      cachedTokens: lastCachedTokens,
                     });
                   }
                   taskStates.set(requestId, "killed");
@@ -538,7 +551,9 @@ export function createWritingOrchestrator(
                 });
               }
               lastFinishReason = streamFinishReason;
-              lastPromptTokens = tokenCount;
+              lastPromptTokens = streamUsage?.promptTokens ?? tokenCount;
+              lastTokens = streamUsage?.completionTokens ?? lastTokens;
+              lastCachedTokens = streamUsage?.cachedTokens ?? 0;
             } else {
               throw new Error("No AI execution path available");
             }
@@ -557,6 +572,7 @@ export function createWritingOrchestrator(
                   promptTokens: lastPromptTokens,
                   completionTokens: lastTokens,
                   totalTokens: lastPromptTokens + lastTokens,
+                  cachedTokens: lastCachedTokens,
                 });
               }
               taskStates.set(requestId, "killed");
@@ -570,6 +586,7 @@ export function createWritingOrchestrator(
                   promptTokens: lastPromptTokens,
                   completionTokens: lastTokens,
                   totalTokens: lastPromptTokens + lastTokens,
+                  cachedTokens: lastCachedTokens,
                 });
               }
               const partialContent =
@@ -628,6 +645,7 @@ export function createWritingOrchestrator(
             promptTokens: lastPromptTokens,
             completionTokens: lastTokens,
             totalTokens: lastPromptTokens + lastTokens,
+            cachedTokens: lastCachedTokens,
           });
         }
 
@@ -784,6 +802,7 @@ export function createWritingOrchestrator(
             fullText = nextResult.fullText || roundFullText;
             lastPromptTokens = nextResult.usage.promptTokens;
             lastTokens = nextResult.usage.completionTokens;
+            lastCachedTokens = nextResult.usage.cachedTokens ?? 0;
             lastFinishReason = nextResult.finishReason ?? null;
             lastToolCalls = nextResult.toolCalls ?? [];
 
@@ -792,6 +811,7 @@ export function createWritingOrchestrator(
                 promptTokens: lastPromptTokens,
                 completionTokens: lastTokens,
                 totalTokens: lastPromptTokens + lastTokens,
+                cachedTokens: lastCachedTokens,
               });
             }
 
@@ -832,6 +852,7 @@ export function createWritingOrchestrator(
             promptTokens: totalPromptTokens,
             completionTokens: totalCompletionTokens,
             totalTokens: totalPromptTokens + totalCompletionTokens,
+            ...(totalCachedTokens > 0 ? { cachedTokens: totalCachedTokens } : {}),
           },
         });
         for (const costEvent of pendingCostEvents) {

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -96,7 +96,12 @@ interface AIService {
     messages: Array<{ role: string; content: string }>,
     options: {
       signal: AbortSignal;
-      onComplete: (result: { usage?: Partial<TokenUsage> }) => void;
+      onComplete: (result: {
+        usage?: Partial<TokenUsage>;
+        content?: string;
+        wasRetried?: boolean;
+        persistenceError?: unknown;
+      }) => void;
       onError: (e: unknown) => void;
       onApiCallStarted?: () => void;
       skillId?: string;
@@ -507,13 +512,17 @@ export function createWritingOrchestrator(
               lastToolCalls = generatedResult.toolCalls ?? [];
             } else if (hasStreamChat) {
               let streamFinishReason: "stop" | "tool_use" | null = null;
-              let streamUsage: Partial<TokenUsage> | null = null;
               const gen = config.aiService.streamChat(
                 prepared.messages,
                 {
                   signal: abortController.signal,
                   onComplete: (result) => {
-                    streamUsage = result.usage ?? null;
+                    const completedUsage = result.usage;
+                    if (completedUsage) {
+                      lastPromptTokens = completedUsage.promptTokens ?? lastPromptTokens;
+                      lastTokens = completedUsage.completionTokens ?? lastTokens;
+                      lastCachedTokens = completedUsage.cachedTokens ?? lastCachedTokens;
+                    }
                   },
                   onError: () => {},
                   onApiCallStarted: () => {
@@ -551,9 +560,9 @@ export function createWritingOrchestrator(
                 });
               }
               lastFinishReason = streamFinishReason;
-              lastPromptTokens = streamUsage?.promptTokens ?? tokenCount;
-              lastTokens = streamUsage?.completionTokens ?? lastTokens;
-              lastCachedTokens = streamUsage?.cachedTokens ?? 0;
+              if (lastPromptTokens === tokenCount && lastTokens === 0) {
+                lastPromptTokens = tokenCount;
+              }
             } else {
               throw new Error("No AI execution path available");
             }

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -8,6 +8,7 @@
  * 权限门禁、120s 权限超时、Post-Writing Hooks、任务状态机
  */
 
+import type { AiCompletionResult, AiTokenUsage } from "@shared/types/ai";
 import type { ToolRegistry } from "./toolRegistry";
 import type { StreamChunk, ToolCallInfo } from "../ai/streaming";
 import type { CostTracker } from "../ai/costTracker";
@@ -96,12 +97,7 @@ interface AIService {
     messages: Array<{ role: string; content: string }>,
     options: {
       signal: AbortSignal;
-      onComplete: (result: {
-        usage?: Partial<TokenUsage>;
-        content?: string;
-        wasRetried?: boolean;
-        persistenceError?: unknown;
-      }) => void;
+      onComplete: (result: Partial<AiCompletionResult> & { usage?: Partial<AiTokenUsage> }) => void;
       onError: (e: unknown) => void;
       onApiCallStarted?: () => void;
       skillId?: string;
@@ -119,16 +115,11 @@ interface PreparedRequest {
   modelId: string;
 }
 
-type TokenUsage = {
-  promptTokens: number;
-  completionTokens: number;
-  totalTokens: number;
-  cachedTokens?: number;
-};
+type OrchestratorTokenUsage = AiTokenUsage;
 
 type GeneratedTextResult = {
   fullText: string;
-  usage: TokenUsage;
+  usage: OrchestratorTokenUsage;
   /** P2: finish reason from the AI */
   finishReason?: "stop" | "tool_use" | null;
   /** P2: tool calls requested by the AI */
@@ -180,7 +171,7 @@ export interface OrchestratorConfig {
     messages?: Array<{ role: string; content: string; toolCallId?: string }>;
   }) => Promise<{
     fullText: string;
-    usage: TokenUsage;
+    usage: OrchestratorTokenUsage;
     /** P2: finish reason from the AI (null = streaming, stop = done, tool_use = wants tools) */
     finishReason?: "stop" | "tool_use" | null;
     /** P2: tool calls requested by the AI when finishReason === 'tool_use' */
@@ -357,7 +348,7 @@ export function createWritingOrchestrator(
         let totalCompletionTokens = 0;
         let totalCachedTokens = 0;
         const pendingCostEvents: WritingEvent[] = [];
-        const recordUsage = (usage: TokenUsage): void => {
+        const recordUsage = (usage: OrchestratorTokenUsage): void => {
           totalPromptTokens += usage.promptTokens;
           totalCompletionTokens += usage.completionTokens;
           totalCachedTokens += Math.max(0, usage.cachedTokens ?? 0);
@@ -519,9 +510,15 @@ export function createWritingOrchestrator(
                   onComplete: (result) => {
                     const completedUsage = result.usage;
                     if (completedUsage) {
-                      lastPromptTokens = completedUsage.promptTokens ?? lastPromptTokens;
-                      lastTokens = completedUsage.completionTokens ?? lastTokens;
-                      lastCachedTokens = completedUsage.cachedTokens ?? lastCachedTokens;
+                      if (typeof completedUsage.promptTokens === "number" && Number.isFinite(completedUsage.promptTokens)) {
+                        lastPromptTokens = Math.max(lastPromptTokens, Math.max(0, completedUsage.promptTokens));
+                      }
+                      if (typeof completedUsage.completionTokens === "number" && Number.isFinite(completedUsage.completionTokens)) {
+                        lastTokens = Math.max(lastTokens, Math.max(0, completedUsage.completionTokens));
+                      }
+                      if (typeof completedUsage.cachedTokens === "number" && Number.isFinite(completedUsage.cachedTokens)) {
+                        lastCachedTokens = Math.max(0, completedUsage.cachedTokens);
+                      }
                     }
                   },
                   onError: () => {},
@@ -560,9 +557,6 @@ export function createWritingOrchestrator(
                 });
               }
               lastFinishReason = streamFinishReason;
-              if (lastPromptTokens === tokenCount && lastTokens === 0) {
-                lastPromptTokens = tokenCount;
-              }
             } else {
               throw new Error("No AI execution path available");
             }

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -15,6 +15,20 @@ export type SkillResultMetadata = {
   cachedTokens?: number;
 };
 
+export type AiTokenUsage = {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cachedTokens?: number;
+};
+
+export type AiCompletionResult = {
+  content: string;
+  usage: AiTokenUsage;
+  wasRetried: boolean;
+  persistenceError?: unknown;
+};
+
 export type SkillResult = {
   success: boolean;
   output: string;

--- a/packages/shared/types/ai.ts
+++ b/packages/shared/types/ai.ts
@@ -12,6 +12,7 @@ export type SkillResultMetadata = {
   model: string;
   promptTokens: number;
   completionTokens: number;
+  cachedTokens?: number;
 };
 
 export type SkillResult = {


### PR DESCRIPTION
Closes #102

## Summary
- 修复 apiClient.parseUsage：Anthropic cachedTokens 仅统计 cache_read_input_tokens，移除 cache_creation_input_tokens 误归类
- 修复 usage 解析 0 值语义：用显式字段存在性判断替代 ||，避免 prompt_tokens: 0 被错误 fallback
- 补齐并统一 cachedTokens 链路：aiServiceBridge → orchestrator → costTracker → IPC done metadata 全链路透传
- 统一流式完成回调与 usage 类型定义，消除重复命名漂移
- 增补边界测试（mixed payload、0 vs undefined、streamChat cachedTokens>0、costTracker cached clamp）

## Invariant Checklist
- [x] INV-1 原稿保护：未改动 Permission Gate / 快照门禁
- [x] INV-2 并发安全：未改动并发调度策略
- [x] INV-3 CJK Token：未改动 token 估算公式
- [x] INV-4 Memory-First：未改动记忆检索路径
- [x] INV-5 叙事压缩：未改动压缩策略
- [x] INV-6 一切皆 Skill：改动保持在 Skill/AI 统一管线
- [x] INV-7 统一入口：未新增 IPC 直调 Service 绕行
- [x] INV-8 Hook 链：未破坏 post-writing hooks 顺序
- [x] INV-9 成本追踪：修复 cachedTokens 全链路透传与语义准确性
- [x] INV-10 错误上下文：保留中断/错误事件上下文

## Validation Evidence
- ✅ pnpm typecheck
- ✅ pnpm test:unit
- ✅ scripts/agent_pr_preflight.sh

## Risk & Rollback
- 风险：usage 类型收敛与 IPC metadata 扩展可能影响依赖方的字段假设
- 回滚点：git revert 288913a

## Visual Evidence

### Embedded Screenshots
N/A

### Storybook Artifact / Link
- Link: N/A
- Visual acceptance note: N/A

## Audit Gate
- 工程：GPT-5.3 Codex (xhigh)
- 审计 1：GPT-5.4 (xhigh)
- 审计 2：GPT-5.3 Codex (xhigh)
- 审计 3：Claude Opus 4.6 (high)
- 审计 4：Claude Sonnet 4.6 (high)
- [ ] 审计 1（GPT-5.4）：FINAL-VERDICT: REJECT (Round 3) — 2 findings
- [ ] 审计 2（GPT-5.3 Codex）：FINAL-VERDICT: REJECT (Round 3) — 1 finding
- [ ] 审计 3（Claude Opus 4.6）：FINAL-VERDICT: REJECT (Round 3) — 1 finding
- [ ] 审计 4（Claude Sonnet 4.6）：FINAL-VERDICT: REJECT (Round 3) — 3 findings
- 评论汇总：[Round 3 Comment](https://github.com/Leeky1017/CreoNow/pull/106#issuecomment-4229858936)