### PR TITLE
fix(skill-system): disambiguate write-back path — single authority in orchestrator Stage 7

### DIFF
--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -2159,6 +2159,11 @@ async function drainPreviewUntilPause(args: {
       };
     }
 
+    // ── Write-back event consumption (READ-ONLY) ────────────────────
+    // IPC captures the versionId from the orchestrator's write-back-done
+    // event purely for the skill-run response payload.  The actual
+    // document write happened in orchestrator.ts Stage 7; IPC performs
+    // NO document writes itself.  See Issue #109.
     if (event.type === "write-back-done") {
       versionId =
         typeof event.versionId === "string" ? event.versionId : undefined;
@@ -2277,6 +2282,7 @@ async function continuePreviewSession(args: {
     }
 
     const event = next.value;
+    // Read-only: capture versionId for the response — see comment above.
     if (event.type === "write-back-done") {
       versionId =
         typeof event.versionId === "string" ? event.versionId : versionId;
@@ -2471,6 +2477,9 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
         ctx,
         sender: e.sender,
       });
+      // IPC layer resolves the declared permission level from the skill manifest
+      // but does NOT enforce policy — the orchestrator's Stage 6 is the single
+      // authority that evaluates + enforces permission (INV-1).
       const permissionLevel = resolveSkillPermissionLevel({
         ctx,
         skillId: normalizedPayload.skillId,
@@ -2478,10 +2487,7 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
       const generator = ctx.writingOrchestrator.execute({
         requestId: executionId,
         skillId: normalizedPayload.skillId,
-        level:
-          permissionLevel === "auto-allow"
-            ? "preview-confirm"
-            : permissionLevel,
+        level: permissionLevel,
         input: {
           selectedText:
             normalizedPayload.selection?.text ?? normalizedPayload.input,

--- a/apps/desktop/main/src/services/skills/__tests__/writeback-path-disambiguation.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writeback-path-disambiguation.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Write-back path disambiguation tests (Issue #109)
+ *
+ * Verifies that the WritingOrchestrator is the SINGLE canonical path for
+ * AI-output write-back to documents.  These tests enforce:
+ *
+ *   INV-1 — Permission Gate + pre-write snapshot before every write
+ *   INV-6 — All write-back uses the registered `documentWrite` tool
+ *   INV-7 — Unified entry through IPC → orchestrator pipeline
+ *
+ * The tests prove that:
+ *   1. Only `documentWrite` tool performs the actual write
+ *   2. The orchestrator enforces `auto-allow → preview-confirm` independently
+ *   3. Pre-write snapshot always precedes documentWrite
+ *   4. Removing the IPC-level override does not change observable behaviour
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import type {
+  WritingOrchestrator,
+  WritingRequest,
+  WritingEvent,
+  OrchestratorConfig,
+} from "../orchestrator";
+import { createWritingOrchestrator } from "../orchestrator";
+import { createToolRegistry } from "../toolRegistry";
+import type {
+  BudgetAlert,
+  BudgetPolicy,
+  CostTracker,
+  ModelPricingTable,
+  RequestCost,
+  SessionCostSummary,
+} from "../../ai/costTracker";
+
+// ─── helpers (mirrors writing-orchestrator.test.ts) ─────────────────
+
+async function collectEvents(
+  gen: AsyncGenerator<WritingEvent>,
+): Promise<WritingEvent[]> {
+  const events: WritingEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+function eventTypes(events: WritingEvent[]): string[] {
+  return events.map((e) => e.type);
+}
+
+function makeRequest(overrides: Partial<WritingRequest> = {}): WritingRequest {
+  return {
+    requestId: "req-wb-001",
+    skillId: "polish",
+    input: { selectedText: "需要润色的文字。" },
+    documentId: "doc-wb-001",
+    selection: {
+      from: 0,
+      to: 8,
+      text: "需要润色的文字。",
+      selectionTextHash: "wb-hash-001",
+    },
+    ...overrides,
+  };
+}
+
+function createMockAIService() {
+  const chunks = [
+    { delta: "润色", finishReason: null, accumulatedTokens: 2 } as const,
+    { delta: "后的", finishReason: null, accumulatedTokens: 4 } as const,
+    { delta: "文字。", finishReason: "stop", accumulatedTokens: 6 } as const,
+  ];
+
+  async function* mockStreamChat(options?: { onApiCallStarted?: () => void }) {
+    options?.onApiCallStarted?.();
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  }
+
+  return {
+    streamChat: vi
+      .fn()
+      .mockImplementation((_messages: unknown, options: { onApiCallStarted?: () => void }) =>
+        mockStreamChat(options),
+      ),
+    estimateTokens: vi.fn().mockReturnValue(10),
+    abort: vi.fn(),
+  };
+}
+
+function createMockCostTracker(
+  overrides: Partial<CostTracker> = {},
+): CostTracker {
+  return {
+    recordUsage: vi.fn().mockReturnValue({
+      requestId: "req-wb-001",
+      modelId: "default",
+      inputTokens: 10,
+      outputTokens: 6,
+      cachedTokens: 0,
+      cost: 0.012,
+      skillId: "polish",
+      timestamp: Date.now(),
+    } satisfies RequestCost),
+    getSessionCost: vi.fn().mockReturnValue({
+      totalCost: 0.012,
+      totalRequests: 1,
+      totalInputTokens: 10,
+      totalOutputTokens: 6,
+      totalCachedTokens: 0,
+      costByModel: { default: { cost: 0.012, requests: 1 } },
+      costBySkill: { polish: { cost: 0.012, requests: 1 } },
+      sessionStartedAt: 1000,
+    } satisfies SessionCostSummary),
+    getRequestCost: vi.fn().mockReturnValue(null),
+    getPricingTable: vi.fn().mockReturnValue({
+      currency: "USD",
+      lastUpdated: "2025-01-01T00:00:00.000Z",
+      prices: {},
+    } satisfies ModelPricingTable),
+    getBudgetPolicy: vi.fn().mockReturnValue({
+      warningThreshold: 1,
+      hardStopLimit: 5,
+      enabled: true,
+    } satisfies BudgetPolicy),
+    listRecords: vi.fn().mockReturnValue([]),
+    checkBudget: vi.fn().mockReturnValue(null as BudgetAlert | null),
+    estimateCost: vi.fn().mockReturnValue(0.012),
+    onBudgetAlert: vi.fn().mockReturnValue(() => {}),
+    onCostRecorded: vi.fn().mockReturnValue(() => {}),
+    updatePricingTable: vi
+      .fn()
+      .mockImplementation((_table: ModelPricingTable) => {}),
+    updateBudgetPolicy: vi
+      .fn()
+      .mockImplementation((_policy: BudgetPolicy) => {}),
+    resetSession: vi.fn(),
+    dispose: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Build OrchestratorConfig with call-order tracking on key tools */
+function buildTrackedConfig(
+  overrides: Omit<Partial<OrchestratorConfig>, "permissionGate"> & {
+    permissionGate?: Partial<OrchestratorConfig["permissionGate"]>;
+  } = {},
+) {
+  const { permissionGate: permissionGateOverride, ...restOverrides } =
+    overrides;
+  const callOrder: string[] = [];
+
+  const toolRegistry = createToolRegistry();
+
+  const documentWriteExecute = vi.fn().mockImplementation(async () => {
+    callOrder.push("documentWrite");
+    return { success: true, data: { versionId: "snap-accept-wb-001" } };
+  });
+  const versionSnapshotExecute = vi.fn().mockImplementation(async () => {
+    callOrder.push("versionSnapshot");
+    return { success: true, data: { versionId: "snap-prewrite-wb-001" } };
+  });
+
+  toolRegistry.register({
+    name: "documentRead",
+    description: "Read document text",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: "text" }),
+  });
+  toolRegistry.register({
+    name: "documentWrite",
+    description: "Write text to document",
+    isConcurrencySafe: false,
+    execute: documentWriteExecute,
+  });
+  toolRegistry.register({
+    name: "versionSnapshot",
+    description: "Create version snapshot",
+    isConcurrencySafe: false,
+    execute: versionSnapshotExecute,
+  });
+
+  const requestPermission = vi.fn().mockImplementation(async () => {
+    callOrder.push("requestPermission");
+    return true;
+  });
+  const evaluate = vi.fn().mockResolvedValue({
+    level: "preview-confirm",
+    granted: false,
+  });
+
+  const config: OrchestratorConfig = {
+    aiService: createMockAIService(),
+    toolRegistry,
+    permissionGate: {
+      confirmTimeoutMs: 120_000,
+      evaluate,
+      requestPermission,
+      releasePendingPermission: vi.fn(),
+      ...(permissionGateOverride ?? {}),
+    },
+    postWritingHooks: [],
+    defaultTimeoutMs: 30_000,
+    costTracker: createMockCostTracker(),
+    ...restOverrides,
+  };
+
+  return {
+    config,
+    callOrder,
+    mocks: {
+      documentWriteExecute,
+      versionSnapshotExecute,
+      requestPermission,
+      evaluate,
+    },
+  };
+}
+
+// ─── tests ──────────────────────────────────────────────────────────
+
+describe("Write-back Path Disambiguation (Issue #109)", () => {
+  let orchestrator: WritingOrchestrator;
+
+  afterEach(() => {
+    orchestrator?.dispose();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ── INV-1: Single canonical write-back path ────────────────────
+
+  describe("INV-1: documentWrite is the single write-back tool", () => {
+    it("only documentWrite.execute is called for the write — no other write occurs", async () => {
+      vi.useFakeTimers();
+      const { config, mocks } = buildTrackedConfig();
+      orchestrator = createWritingOrchestrator(config);
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // documentWrite was called exactly once
+      expect(mocks.documentWriteExecute).toHaveBeenCalledTimes(1);
+
+      // write-back-done event is present
+      expect(types).toContain("write-back-done");
+
+      // The write-back-done event has the versionId from documentWrite
+      const wbEvent = events.find((e) => e.type === "write-back-done") as
+        | (WritingEvent & { type: "write-back-done" })
+        | undefined;
+      expect(wbEvent).toBeDefined();
+      expect(wbEvent!.versionId).toBe("snap-accept-wb-001");
+    });
+
+    it("without documentWrite registered, write-back fails gracefully (no silent fallback)", async () => {
+      vi.useFakeTimers();
+      const { config } = buildTrackedConfig();
+      // Remove the documentWrite tool
+      const toolRegistry = createToolRegistry();
+      toolRegistry.register({
+        name: "documentRead",
+        description: "Read document text",
+        isConcurrencySafe: true,
+        execute: vi.fn().mockResolvedValue({ success: true, data: "text" }),
+      });
+      toolRegistry.register({
+        name: "versionSnapshot",
+        description: "Create version snapshot",
+        isConcurrencySafe: false,
+        execute: vi
+          .fn()
+          .mockResolvedValue({
+            success: true,
+            data: { versionId: "snap-001" },
+          }),
+      });
+      config.toolRegistry = toolRegistry;
+
+      orchestrator = createWritingOrchestrator(config);
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // No write-back-done event — the pipeline failed
+      expect(types).not.toContain("write-back-done");
+      // An error event should be present
+      expect(types).toContain("error");
+
+      // Error mentions missing documentWrite tool
+      const errorEvent = events.find((e) => e.type === "error") as
+        | (WritingEvent & { type: "error"; error: { message: string } })
+        | undefined;
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent!.error.message).toMatch(/documentWrite/);
+    });
+  });
+
+  // ── INV-1: Pre-write snapshot ordering ─────────────────────────
+
+  describe("INV-1: Pre-write snapshot precedes documentWrite", () => {
+    it("versionSnapshot is called BEFORE documentWrite", async () => {
+      vi.useFakeTimers();
+      const { config, callOrder } = buildTrackedConfig();
+      orchestrator = createWritingOrchestrator(config);
+
+      await collectEvents(orchestrator.execute(makeRequest()));
+
+      const snapshotIndex = callOrder.indexOf("versionSnapshot");
+      const writeIndex = callOrder.indexOf("documentWrite");
+
+      expect(snapshotIndex).toBeGreaterThanOrEqual(0);
+      expect(writeIndex).toBeGreaterThan(snapshotIndex);
+    });
+
+    it("permission is requested BEFORE documentWrite", async () => {
+      vi.useFakeTimers();
+      const { config, callOrder } = buildTrackedConfig();
+      orchestrator = createWritingOrchestrator(config);
+
+      await collectEvents(orchestrator.execute(makeRequest()));
+
+      const permIndex = callOrder.indexOf("requestPermission");
+      const writeIndex = callOrder.indexOf("documentWrite");
+
+      expect(permIndex).toBeGreaterThanOrEqual(0);
+      expect(writeIndex).toBeGreaterThan(permIndex);
+    });
+
+    it("full invariant ordering: snapshot → permission → write", async () => {
+      vi.useFakeTimers();
+      const { config, callOrder } = buildTrackedConfig();
+      orchestrator = createWritingOrchestrator(config);
+
+      await collectEvents(orchestrator.execute(makeRequest()));
+
+      expect(callOrder).toEqual([
+        "versionSnapshot",
+        "requestPermission",
+        "documentWrite",
+      ]);
+    });
+  });
+
+  // ── INV-1: Orchestrator as single permission authority ─────────
+
+  describe("INV-1: Orchestrator enforces permission independently of IPC", () => {
+    it("auto-allow level is escalated to preview-confirm by the orchestrator", async () => {
+      vi.useFakeTimers();
+      const { config, mocks } = buildTrackedConfig({
+        permissionGate: {
+          evaluate: vi.fn().mockResolvedValue({
+            level: "auto-allow",
+            granted: true,
+          }),
+        },
+      });
+      orchestrator = createWritingOrchestrator(config);
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Even though evaluate returned auto-allow + granted, the orchestrator
+      // should still emit permission-requested (because it escalates)
+      expect(types).toContain("permission-requested");
+
+      // requestPermission should still have been called
+      expect(mocks.requestPermission).toHaveBeenCalled();
+    });
+
+    it("permission denied → no documentWrite, no write-back-done", async () => {
+      vi.useFakeTimers();
+      const { config, mocks } = buildTrackedConfig({
+        permissionGate: {
+          requestPermission: vi.fn().mockResolvedValue(false),
+        },
+      });
+      orchestrator = createWritingOrchestrator(config);
+
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      expect(types).toContain("permission-denied");
+      expect(types).not.toContain("write-back-done");
+      expect(mocks.documentWriteExecute).not.toHaveBeenCalled();
+    });
+
+    it("request.level=auto-allow passed from IPC is still escalated by orchestrator", async () => {
+      vi.useFakeTimers();
+      // Simulate IPC passing auto-allow (as if IPC did NOT override it)
+      const { config } = buildTrackedConfig({
+        permissionGate: {
+          evaluate: vi.fn().mockResolvedValue({
+            level: "auto-allow",
+            granted: true,
+          }),
+        },
+      });
+      orchestrator = createWritingOrchestrator(config);
+
+      const events = await collectEvents(
+        orchestrator.execute(makeRequest({ level: "auto-allow" as never })),
+      );
+      const permEvent = events.find(
+        (e) => e.type === "permission-requested",
+      ) as (WritingEvent & { type: "permission-requested"; level: string }) | undefined;
+
+      // The orchestrator should have escalated auto-allow → preview-confirm
+      expect(permEvent).toBeDefined();
+      expect(permEvent!.level).not.toBe("auto-allow");
+    });
+  });
+
+  // ── INV-6: Write-back uses registered tool ─────────────────────
+
+  describe("INV-6: All write-back goes through tool registry", () => {
+    it("documentWrite tool receives the correct parameters", async () => {
+      vi.useFakeTimers();
+      const { config, mocks } = buildTrackedConfig();
+      orchestrator = createWritingOrchestrator(config);
+
+      const request = makeRequest({
+        projectId: "proj-001",
+        documentId: "doc-wb-001",
+      });
+      await collectEvents(orchestrator.execute(request));
+
+      expect(mocks.documentWriteExecute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentId: "doc-wb-001",
+          requestId: "req-wb-001",
+        }),
+      );
+    });
+
+    it("documentWrite failure produces failure event (no silent swallow)", async () => {
+      vi.useFakeTimers();
+      const { config } = buildTrackedConfig();
+
+      // Override documentWrite to fail
+      const failingToolRegistry = createToolRegistry();
+      failingToolRegistry.register({
+        name: "documentRead",
+        description: "Read document text",
+        isConcurrencySafe: true,
+        execute: vi.fn().mockResolvedValue({ success: true, data: "text" }),
+      });
+      failingToolRegistry.register({
+        name: "documentWrite",
+        description: "Write text to document",
+        isConcurrencySafe: false,
+        execute: vi.fn().mockResolvedValue({
+          success: false,
+          error: {
+            code: "DB_ERROR",
+            message: "Database write failed",
+            retryable: true,
+          },
+        }),
+      });
+      failingToolRegistry.register({
+        name: "versionSnapshot",
+        description: "Create version snapshot",
+        isConcurrencySafe: false,
+        execute: vi
+          .fn()
+          .mockResolvedValue({
+            success: true,
+            data: { versionId: "snap-001" },
+          }),
+      });
+      config.toolRegistry = failingToolRegistry;
+
+      orchestrator = createWritingOrchestrator(config);
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      expect(types).not.toContain("write-back-done");
+      expect(types).toContain("error");
+
+      const errorEvent = events.find((e) => e.type === "error") as
+        | (WritingEvent & { type: "error"; error: { code: string } })
+        | undefined;
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent!.error.code).toBe("DB_ERROR");
+    });
+  });
+
+  // ── No snapshot → no write ─────────────────────────────────────
+
+  describe("INV-1: No snapshot → no write", () => {
+    it("if versionSnapshot fails, documentWrite is never called", async () => {
+      vi.useFakeTimers();
+      const { config, mocks } = buildTrackedConfig();
+
+      // Override versionSnapshot to fail
+      const failingToolRegistry = createToolRegistry();
+      failingToolRegistry.register({
+        name: "documentRead",
+        description: "Read document text",
+        isConcurrencySafe: true,
+        execute: vi.fn().mockResolvedValue({ success: true, data: "text" }),
+      });
+      failingToolRegistry.register({
+        name: "documentWrite",
+        description: "Write text to document",
+        isConcurrencySafe: false,
+        execute: mocks.documentWriteExecute,
+      });
+      failingToolRegistry.register({
+        name: "versionSnapshot",
+        description: "Create version snapshot",
+        isConcurrencySafe: false,
+        execute: vi.fn().mockResolvedValue({
+          success: false,
+          error: {
+            code: "SNAPSHOT_FAILED",
+            message: "Could not create snapshot",
+            retryable: false,
+          },
+        }),
+      });
+      config.toolRegistry = failingToolRegistry;
+
+      orchestrator = createWritingOrchestrator(config);
+      const events = await collectEvents(orchestrator.execute(makeRequest()));
+      const types = eventTypes(events);
+
+      // Write never happened
+      expect(mocks.documentWriteExecute).not.toHaveBeenCalled();
+      expect(types).not.toContain("write-back-done");
+      expect(types).toContain("error");
+    });
+  });
+});

--- a/apps/desktop/main/src/services/skills/__tests__/writeback-path-disambiguation.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writeback-path-disambiguation.test.ts
@@ -401,7 +401,7 @@ describe("Write-back Path Disambiguation (Issue #109)", () => {
       orchestrator = createWritingOrchestrator(config);
 
       const events = await collectEvents(
-        orchestrator.execute(makeRequest({ level: "auto-allow" as never })),
+        orchestrator.execute(makeRequest({ level: "auto-allow" })),
       );
       const permEvent = events.find(
         (e) => e.type === "permission-requested",
@@ -409,7 +409,7 @@ describe("Write-back Path Disambiguation (Issue #109)", () => {
 
       // The orchestrator should have escalated auto-allow → preview-confirm
       expect(permEvent).toBeDefined();
-      expect(permEvent!.level).not.toBe("auto-allow");
+      expect(permEvent!.level).toBe("preview-confirm");
     });
   });
 

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -970,7 +970,7 @@ export function createWritingOrchestrator(
         // This is the ONLY enforcement point for permission policy.
         // The IPC layer resolves the raw permission level from the skill
         // manifest but does NOT override or enforce it — that is our job.
-        // auto-allow is intentionally unreachable for write-back operations.
+        // auto-allow is intentionally escalated to preview-confirm for write-back operations.
         const evalResult = config.permissionGate.evaluate
           ? await config.permissionGate.evaluate(request)
           : { level: "preview-confirm", granted: false };

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -1,9 +1,25 @@
 /**
- * WritingOrchestrator — 9 阶段写作管线
+ * @module WritingOrchestrator — 9-stage writing pipeline
  *
+ * ## Pipeline stages
  * intent-resolved → context-assembled → model-selected → ai-chunk* →
  * ai-done → permission-requested → permission-granted/denied →
  * write-back-done → hooks-done
+ *
+ * ## Responsibility
+ * This module is the ONLY code path that writes AI output to documents.
+ * Stage 6 enforces Permission Gate (INV-1), Stage 7 executes the write-back
+ * via the `documentWrite` tool (registered in writingTooling.ts).
+ *
+ * ## What this module does NOT do
+ * - Does not resolve which skill to run (IPC layer does that)
+ * - Does not send events to the renderer (IPC layer drains the generator)
+ *
+ * ## Key invariants
+ * - INV-1: pre-write snapshot → permission gate → documentWrite → confirmCommit
+ * - INV-2: documentWrite has isConcurrencySafe=false (serial only)
+ * - INV-6: all capabilities are Skills; write-back uses registered tool
+ * - INV-8: Stage 8 post-writing hooks run after write-back
  *
  * 权限门禁、120s 权限超时、Post-Writing Hooks、任务状态机
  */
@@ -950,7 +966,11 @@ export function createWritingOrchestrator(
           return null;
         };
 
-        // Stage 6: Permission gate
+        // Stage 6: Permission gate (SINGLE AUTHORITY — INV-1)
+        // This is the ONLY enforcement point for permission policy.
+        // The IPC layer resolves the raw permission level from the skill
+        // manifest but does NOT override or enforce it — that is our job.
+        // auto-allow is intentionally unreachable for write-back operations.
         const evalResult = config.permissionGate.evaluate
           ? await config.permissionGate.evaluate(request)
           : { level: "preview-confirm", granted: false };
@@ -1034,6 +1054,16 @@ export function createWritingOrchestrator(
           return;
         }
 
+        // ── Stage 7: Write-back (CANONICAL PATH — INV-1) ──────────────────
+        // This is the ONLY location in the entire codebase that executes
+        // AI-generated content write-back to a document.  The sequence is:
+        //   1. Pre-write snapshot (above) — ensures rollback is possible
+        //   2. Permission gate (Stage 6)  — user must approve the write
+        //   3. documentWrite tool (below) — performs the actual DB save
+        //   4. confirmCommit              — finalises the version record
+        //
+        // No other module (IPC layer, renderer, etc.) may perform document
+        // writes on behalf of AI output.  See Issue #109 for context.
         const writeTool = config.toolRegistry.get("documentWrite");
         if (!writeTool) {
           yield makeFailureEvent({


### PR DESCRIPTION
## Summary

Fixes the Skill write-back path ambiguity reported in Issue #109: both `ipc/ai.ts` and `orchestrator.ts` claimed responsibility for the `auto-allow → preview-confirm` permission policy override, creating a shadow enforcement point.

### Changes

| File | Change |
|------|--------|
| `apps/desktop/main/src/ipc/ai.ts` | Removed redundant `auto-allow → preview-confirm` override. IPC now resolves raw permission level without enforcing policy. Added read-only boundary comments at `write-back-done` event consumption points. |
| `apps/desktop/main/src/services/skills/orchestrator.ts` | Enhanced module header documenting single-authority role. Added INV-1 boundary comments at Stage 6 (permission gate) and Stage 7 (write-back). |
| `apps/desktop/main/src/services/skills/__tests__/writeback-path-disambiguation.test.ts` | **NEW** — 11 tests verifying single canonical write-back path, INV-1 compliance, ordering invariants. |

### Root Cause

`ipc/ai.ts` line ~2482 overrode `auto-allow → preview-confirm` **before** passing to the orchestrator. The orchestrator (Stage 6, line 974-977) performed the same override. This meant:
1. The IPC layer was a shadow policy enforcement point (violates separation of concerns)
2. The orchestrator's own override was dead code (IPC already replaced `auto-allow`)
3. Any future change to either site could silently break the invariant

### Fix

- **IPC layer**: Resolves permission level from skill manifest (read-only), passes it through without policy enforcement.
- **Orchestrator Stage 6**: Single authority that evaluates + enforces `auto-allow → preview-confirm` escalation.
- **Boundary comments**: Added at both layers to prevent future ambiguity.

---

Closes #109

---

## Invariant Checklist

- [x] **INV-1** Permission Gate · AI write operations go through Permission Gate + version snapshot. No snapshot = no write. ✅ Verified: orchestrator Stage 7 is the ONLY write path; pre-write snapshot → permission gate → documentWrite → confirmCommit ordering enforced by tests.
- [x] **INV-2** Concurrency · documentWrite has `isConcurrencySafe: false` (serial execution only). No change.
- [x] **INV-3** Offline-first · No network calls added. All changes are in-process IPC/orchestrator logic.
- [x] **INV-4** SQLite single-writer · No schema or DB access changes.
- [x] **INV-5** Version snapshot · Pre-write snapshot creation verified in tests (snapshot before write, snapshot failure blocks write).
- [x] **INV-6** Skill abstraction · All write-back goes through the registered `documentWrite` tool. Verified by test: missing tool → graceful error, no fallback.
- [x] **INV-7** Unified entry · IPC → orchestrator → documentWrite pipeline preserved. IPC no longer performs policy enforcement.
- [x] **INV-8** Post-writing hooks · Not modified. Stage 8 hooks run after write-back-done as before.
- [x] **INV-9** Cost tracking · Not modified. `cost-recorded` event still emitted after ai-done.
- [x] **INV-10** Agentic tool safety · `documentWrite` and `versionSnapshot` remain in `BLOCKED_TOOLS` set (agenticTools.ts). No change.

---

## Validation Evidence

### Typecheck
```
pnpm typecheck → exit 0 (zero errors)
```

### Unit Tests
```
pnpm test:unit → 143 test files, 2525 tests, ALL PASSED
```

### New Test Coverage (11 tests)
| Test | What it verifies |
|------|--------------------|
| `documentWrite.execute called exactly once` | Single write path |
| `missing documentWrite → graceful error` | No silent fallback |
| `versionSnapshot before documentWrite` | Snapshot ordering |
| `requestPermission before documentWrite` | Permission ordering |
| `snapshot → permission → write` | Full INV-1 ordering |
| `auto-allow escalated to preview-confirm` | Orchestrator enforcement |
| `permission denied → no write` | Gate blocks write |
| `auto-allow from IPC still escalated` | IPC override removed |
| `documentWrite receives correct params` | Tool registry integration |
| `documentWrite failure → error event` | No silent swallow |
| `snapshot failure → no documentWrite` | No snapshot = no write |

---

## Visual Evidence

### Embedded Screenshots

- [x] N/A（纯后端逻辑变更，无 UI 变化）

### Storybook Artifact / Link

- Link: N/A（无前端组件变更）
- Visual acceptance note: N/A（纯后端逻辑变更，无渲染器代码改动）

---

## Risk & Rollback

### Risk Assessment
**Low risk** — The removed IPC-level override was purely redundant. The orchestrator already performed the same `auto-allow → preview-confirm` escalation. No new code paths are introduced; only a redundant enforcement point is removed and boundary comments are added.

### Rollback
```
git revert <merge-commit-sha>
```

Single commit, clean revert. Reverting merely re-adds the redundant IPC check without behavioral change.

---

## 审计门禁

模型分配：

- 工程：GPT-5.3 Codex (xhigh)
- 审计 1：GPT-5.4 (xhigh)
- 审计 2：GPT-5.3 Codex (xhigh)
- 审计 3：Claude Opus 4.6 (high)
- 审计 4：Claude Sonnet 4.6 (high)
- 评论汇总：Claude Opus 4.6 (high)

审计状态：

- [ ] 审计 1（GPT-5.4）：FINAL-VERDICT pending
- [ ] 审计 2（GPT-5.3 Codex）：FINAL-VERDICT pending
- [ ] 审计 3（Claude Opus 4.6）：FINAL-VERDICT pending
- [ ] 审计 4（Claude Sonnet 4.6）：FINAL-VERDICT pending
