### PR TITLE
feat(kg): implement Aho-Corasick trie caching with incremental updates [P3-02]

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/project-crud-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/project-crud-ipc.test.ts
@@ -74,6 +74,10 @@ const mocks = vi.hoisted(() => {
       ok: true,
       data: { currentProjectId: "proj-2", switchedAt: new Date().toISOString() },
     }),
+    entityListMock: vi.fn().mockReturnValue({
+      ok: true,
+      data: { items: [] },
+    }),
   };
 });
 
@@ -107,6 +111,11 @@ vi.mock("../../services/project/projectManager", async (importOriginal) => {
     })),
   };
 });
+vi.mock("../../services/kg/kgService", () => ({
+  createKnowledgeGraphService: vi.fn(() => ({
+    entityList: mocks.entityListMock,
+  })),
+}));
 
 const { registerProjectIpcHandlers } = await import("../project");
 
@@ -328,6 +337,27 @@ describe("project:project:getcurrent", () => {
       webContentsId: 1,
       projectId: "proj-1",
     });
+  });
+
+  it("trie 预热 entityList 失败时记录错误日志", async () => {
+    mocks.entityListMock.mockReturnValueOnce({
+      ok: false,
+      error: { code: "DB_ERROR", message: "list failed" },
+    });
+    const harness = createHarness();
+
+    const res = await harness.invoke<{ projectId: string }>(
+      "project:project:getcurrent",
+    );
+
+    expect(res.ok).toBe(true);
+    expect(harness.logger.error).toHaveBeenCalledWith(
+      "trie_cache_prime_entity_list_failed",
+      {
+        projectId: "proj-1",
+        error: { code: "DB_ERROR", message: "list failed" },
+      },
+    );
   });
 });
 

--- a/apps/desktop/main/src/ipc/__tests__/project-crud-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/project-crud-ipc.test.ts
@@ -359,6 +359,23 @@ describe("project:project:getcurrent", () => {
       },
     );
   });
+
+  it("trie 预热抛出异常时记录 warmup 错误且不影响 getcurrent 成功", async () => {
+    mocks.entityListMock.mockImplementationOnce(() => {
+      throw new Error("warmup exploded");
+    });
+    const harness = createHarness();
+
+    const res = await harness.invoke<{ projectId: string }>(
+      "project:project:getcurrent",
+    );
+
+    expect(res.ok).toBe(true);
+    expect(harness.logger.error).toHaveBeenCalledWith("trie_cache_warmup_failed", {
+      projectId: "proj-1",
+      error: "Error: warmup exploded",
+    });
+  });
 });
 
 describe("project:project:setcurrent", () => {

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -3,7 +3,7 @@ import type Database from "better-sqlite3";
 
 import type { IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
-import { trieCachePrime, type MatchableEntity } from "../services/kg/entityMatcher";
+import { trieCacheInvalidate, trieCachePrime, type MatchableEntity } from "../services/kg/entityMatcher";
 import { createKnowledgeGraphService } from "../services/kg/kgService";
 import { createProjectService } from "../services/projects/projectService";
 import type { ProjectLifecycle } from "../services/projects/projectLifecycle";
@@ -63,8 +63,10 @@ function primeTrieCacheForProject(args: {
       cacheKey: args.projectId,
       entities,
     });
-  } catch {
+  } catch (error) {
     // Best effort warmup only: project switch/getCurrent must not fail due cache.
+    // INV-10: errors must still be logged, never silently swallowed (§七).
+    args.logger.info("trie_cache_warmup_failed", { projectId: args.projectId, error: String(error) });
   }
 }
 
@@ -434,6 +436,9 @@ function registerProjectSessionAndLifecycleHandlers(
         logger: deps.logger,
       });
       const res = svc.delete({ projectId: payload.projectId });
+      if (res.ok) {
+        trieCacheInvalidate(payload.projectId);
+      }
       return res.ok
         ? { ok: true, data: res.data }
         : { ok: false, error: res.error };

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -50,6 +50,10 @@ function primeTrieCacheForProject(args: {
       filter: { aiContextLevel: "when_detected" },
     });
     if (!listed.ok) {
+      args.logger.error("trie_cache_prime_entity_list_failed", {
+        projectId: args.projectId,
+        error: listed.error,
+      });
       return;
     }
 

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -70,7 +70,7 @@ function primeTrieCacheForProject(args: {
   } catch (error) {
     // Best effort warmup only: project switch/getCurrent must not fail due cache.
     // INV-10: errors must still be logged, never silently swallowed (§七).
-    args.logger.info("trie_cache_warmup_failed", { projectId: args.projectId, error: String(error) });
+    args.logger.error("trie_cache_warmup_failed", { projectId: args.projectId, error: String(error) });
   }
 }
 

--- a/apps/desktop/main/src/ipc/project.ts
+++ b/apps/desktop/main/src/ipc/project.ts
@@ -3,6 +3,8 @@ import type Database from "better-sqlite3";
 
 import type { IpcResponse } from "@shared/types/ipc-generated";
 import type { Logger } from "../logging/logger";
+import { trieCachePrime, type MatchableEntity } from "../services/kg/entityMatcher";
+import { createKnowledgeGraphService } from "../services/kg/kgService";
 import { createProjectService } from "../services/projects/projectService";
 import type { ProjectLifecycle } from "../services/projects/projectLifecycle";
 import {
@@ -32,6 +34,39 @@ type ProjectHandlerDeps = {
   projectLifecycle?: ProjectLifecycle;
   eventBus?: EventBusLike;
 };
+
+function primeTrieCacheForProject(args: {
+  db: Database.Database;
+  logger: Logger;
+  projectId: string;
+}): void {
+  try {
+    const kgService = createKnowledgeGraphService({
+      db: args.db,
+      logger: args.logger,
+    });
+    const listed = kgService.entityList({
+      projectId: args.projectId,
+      filter: { aiContextLevel: "when_detected" },
+    });
+    if (!listed.ok) {
+      return;
+    }
+
+    const entities: MatchableEntity[] = listed.data.items.map((entity) => ({
+      id: entity.id,
+      name: entity.name,
+      aliases: entity.aliases,
+      aiContextLevel: entity.aiContextLevel,
+    }));
+    trieCachePrime({
+      cacheKey: args.projectId,
+      entities,
+    });
+  } catch {
+    // Best effort warmup only: project switch/getCurrent must not fail due cache.
+  }
+}
 
 function registerProjectCrudHandlers(deps: ProjectHandlerDeps): void {
   deps.ipcMain.handle(
@@ -260,6 +295,11 @@ function registerProjectSessionAndLifecycleHandlers(
       });
       const res = svc.getCurrent();
       if (res.ok) {
+        primeTrieCacheForProject({
+          db: deps.db,
+          logger: deps.logger,
+          projectId: res.data.projectId,
+        });
         deps.projectSessionBinding?.bind({
           webContentsId: event.sender.id,
           projectId: res.data.projectId,
@@ -290,6 +330,11 @@ function registerProjectSessionAndLifecycleHandlers(
       });
       const res = svc.setCurrent({ projectId: payload.projectId });
       if (res.ok) {
+        primeTrieCacheForProject({
+          db: deps.db,
+          logger: deps.logger,
+          projectId: res.data.projectId,
+        });
         deps.projectSessionBinding?.bind({
           webContentsId: event.sender.id,
           projectId: res.data.projectId,
@@ -355,6 +400,11 @@ function registerProjectSessionAndLifecycleHandlers(
             traceId,
           });
       if (res.ok) {
+        primeTrieCacheForProject({
+          db: deps.db,
+          logger: deps.logger,
+          projectId: res.data.currentProjectId,
+        });
         deps.projectSessionBinding?.bind({
           webContentsId: event.sender.id,
           projectId: res.data.currentProjectId,

--- a/apps/desktop/main/src/services/context/__tests__/retrievedFetcher.test.ts
+++ b/apps/desktop/main/src/services/context/__tests__/retrievedFetcher.test.ts
@@ -78,7 +78,7 @@ describe("createRetrievedFetcher", () => {
         aliases: ["小雨"],
         aiContextLevel: "when_detected",
       },
-    ]);
+    ], { cacheKey: "proj-retrieved-fetcher" });
     expect(result.chunks).toHaveLength(1);
     expect(result.chunks[0]?.source).toBe("codex:detected:e1");
     expect(result.chunks[0]?.content).toContain("林小雨");

--- a/apps/desktop/main/src/services/context/fetchers/retrievedFetcher.ts
+++ b/apps/desktop/main/src/services/context/fetchers/retrievedFetcher.ts
@@ -13,7 +13,11 @@ const ENTITY_MATCH_FAILED_WARNING = "ENTITY_MATCH_FAILED: 实体匹配异常";
 
 export type RetrievedFetcherDeps = {
   kgService: Pick<KnowledgeGraphService, "entityList">;
-  matchEntities: (text: string, entities: MatchableEntity[]) => MatchResult[];
+  matchEntities: (
+    text: string,
+    entities: MatchableEntity[],
+    options?: { cacheKey?: string },
+  ) => MatchResult[];
   logger?: Pick<Logger, "info" | "error"> & {
     warn?: (event: string, data?: Record<string, unknown>) => void;
   };
@@ -119,7 +123,9 @@ export function createRetrievedFetcher(
 
     let matches: MatchResult[];
     try {
-      matches = deps.matchEntities(inputText, matchableEntities);
+      matches = deps.matchEntities(inputText, matchableEntities, {
+        cacheKey: request.projectId,
+      });
     } catch (error) {
       reportDegradation({
         reason: "entity_match_throw",

--- a/apps/desktop/main/src/services/context/layerAssemblyService.ts
+++ b/apps/desktop/main/src/services/context/layerAssemblyService.ts
@@ -73,7 +73,11 @@ export type ContextLayerAssemblyDeps = {
   characterListService?: Pick<CharacterListService, "injectCharactersIntoContext">;
   synopsisStore?: Pick<SynopsisStore, "listRecentByProject">;
   episodicMemoryService?: Pick<EpisodicMemoryService, "listSemanticMemory">;
-  matchEntities?: (text: string, entities: MatchableEntity[]) => MatchResult[];
+  matchEntities?: (
+    text: string,
+    entities: MatchableEntity[],
+    options?: { cacheKey?: string },
+  ) => MatchResult[];
   logger?: Pick<Logger, "info" | "error"> & {
     warn?: (event: string, data?: Record<string, unknown>) => void;
   };

--- a/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
@@ -397,7 +397,7 @@ describe("kgCoreService — Entity CRUD（实体增删改查）", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(logger.info).toHaveBeenCalledWith("trie_cache_upsert_failed", {
+      expect(logger.error).toHaveBeenCalledWith("trie_cache_upsert_failed", {
         projectId: PROJECT_ID,
         error: "cache broken",
       });
@@ -506,7 +506,7 @@ describe("kgCoreService — Entity CRUD（实体增删改查）", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(logger.info).toHaveBeenCalledWith("trie_cache_upsert_failed", {
+      expect(logger.error).toHaveBeenCalledWith("trie_cache_upsert_failed", {
         projectId: PROJECT_ID,
         error: "cache broken",
       });
@@ -785,7 +785,7 @@ describe("kgCoreService — Entity CRUD（实体增删改查）", () => {
       const result = svc.entityDelete({ projectId: PROJECT_ID, id: ENTITY_ID });
 
       expect(result.ok).toBe(true);
-      expect(logger.info).toHaveBeenCalledWith("trie_cache_remove_failed", {
+      expect(logger.error).toHaveBeenCalledWith("trie_cache_remove_failed", {
         projectId: PROJECT_ID,
         error: "cache broken",
       });

--- a/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 
 import { createKnowledgeGraphCoreService } from "../kgCoreService";
+import * as entityMatcher from "../entityMatcher";
 import type { KnowledgeGraphService } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -375,6 +376,33 @@ describe("kgCoreService — Entity CRUD（实体增删改查）", () => {
       expect(logger.error).toHaveBeenCalled();
     });
 
+    it("trie cache 更新失败不应回滚成功的 DB 创建结果", () => {
+      const row = makeEntityRow();
+      db.prepare
+        .mockReturnValueOnce(projectExistsStmt())
+        .mockReturnValueOnce(countStmt(0))
+        .mockReturnValueOnce(dupCheckMissStmt())
+        .mockReturnValueOnce(insertStmt())
+        .mockReturnValueOnce(selectEntityStmt(row));
+      vi.spyOn(entityMatcher, "trieCacheUpsertEntity").mockImplementation(
+        () => {
+          throw new Error("cache broken");
+        },
+      );
+
+      const result = svc.entityCreate({
+        projectId: PROJECT_ID,
+        type: "character",
+        name: "Alice",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(logger.info).toHaveBeenCalledWith("trie_cache_upsert_failed", {
+        projectId: PROJECT_ID,
+        error: "cache broken",
+      });
+    });
+
     it("name 边界：刚好 256 字符应通过", () => {
       const row = makeEntityRow({ name: "a".repeat(256) });
       db.prepare
@@ -453,6 +481,35 @@ describe("kgCoreService — Entity CRUD（实体增删改查）", () => {
       if (!result.ok) {
         expect(result.error.code).toBe("NOT_FOUND");
       }
+    });
+
+    it("trie cache 更新失败不应将成功更新实体误报为失败", () => {
+      const existingRow = makeEntityRow({ version: 1 });
+      const updatedRow = makeEntityRow({ version: 2, name: "Alice Updated" });
+      db.prepare
+        .mockReturnValueOnce(projectExistsStmt())
+        .mockReturnValueOnce(selectEntityStmt(existingRow))
+        .mockReturnValueOnce(dupCheckMissStmt())
+        .mockReturnValueOnce(insertStmt())
+        .mockReturnValueOnce(selectEntityStmt(updatedRow));
+      vi.spyOn(entityMatcher, "trieCacheUpsertEntity").mockImplementation(
+        () => {
+          throw new Error("cache broken");
+        },
+      );
+
+      const result = svc.entityUpdate({
+        projectId: PROJECT_ID,
+        id: ENTITY_ID,
+        expectedVersion: 1,
+        patch: { name: "Alice Updated" },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(logger.info).toHaveBeenCalledWith("trie_cache_upsert_failed", {
+        projectId: PROJECT_ID,
+        error: "cache broken",
+      });
     });
   });
 
@@ -704,6 +761,34 @@ describe("kgCoreService — Entity CRUD（实体增删改查）", () => {
       if (!result.ok) {
         expect(result.error.code).toBe("INVALID_ARGUMENT");
       }
+    });
+
+    it("trie cache 删除失败不应将成功删除实体误报为失败", () => {
+      const row = makeEntityRow();
+      const deleteRelationsStmt = createMockStatement({
+        run: vi.fn().mockReturnValue({ changes: 1 }),
+      });
+      const deleteEntityStmt = createMockStatement({
+        run: vi.fn().mockReturnValue({ changes: 1 }),
+      });
+      db.prepare
+        .mockReturnValueOnce(projectExistsStmt())
+        .mockReturnValueOnce(selectEntityStmt(row))
+        .mockReturnValueOnce(deleteRelationsStmt)
+        .mockReturnValueOnce(deleteEntityStmt);
+      vi.spyOn(entityMatcher, "trieCacheRemoveEntity").mockImplementation(
+        () => {
+          throw new Error("cache broken");
+        },
+      );
+
+      const result = svc.entityDelete({ projectId: PROJECT_ID, id: ENTITY_ID });
+
+      expect(result.ok).toBe(true);
+      expect(logger.info).toHaveBeenCalledWith("trie_cache_remove_failed", {
+        projectId: PROJECT_ID,
+        error: "cache broken",
+      });
     });
   });
 });

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -38,11 +38,14 @@ function createEntities(count: number): MatchableEntity[] {
 describe("trieCache", () => {
   it("KG-TRIE-P3-02-S1: deterministic benchmark with realistic-scale dataset", () => {
     // Deterministic benchmark: exercises full pipeline with realistic-scale data
-    const entities = createEntities(500);
+    const entities = createEntities(1000);
     const cacheKey = "kg-trie-benchmark-build";
 
     trieCacheInvalidate(cacheKey);
+    const buildStart = performance.now();
     trieCachePrime({ cacheKey, entities });
+    const buildDuration = performance.now() - buildStart;
+    expect(buildDuration).toBeLessThan(150);
 
     const result = matchEntities("角色0001 与 角色0499 出现。", entities, {
       cacheKey,
@@ -62,7 +65,10 @@ describe("trieCache", () => {
     trieCacheInvalidate(cacheKey);
     trieCachePrime({ cacheKey, entities });
 
+    const matchStart = performance.now();
     const result = matchEntities(text, entities, { cacheKey });
+    const matchDuration = performance.now() - matchStart;
+    expect(matchDuration).toBeLessThan(15);
     expect(result.length).toBe(2);
     const ids = result.map((r) => r.entityId).sort();
     expect(ids).toEqual(["e-1", "e-999"]);
@@ -93,6 +99,19 @@ describe("trieCache", () => {
       cacheKey,
     });
     expect(afterRemove.some((m) => m.entityId === "delta-0")).toBe(false);
+
+    const benchmarkRounds = 20;
+    const incrementalStart = performance.now();
+    for (let index = 0; index < benchmarkRounds; index += 1) {
+      const benchmarkEntityId = `delta-benchmark-${index}`;
+      trieCacheUpsertEntity({
+        cacheKey,
+        entity: createEntity({ id: benchmarkEntityId, name: `增量角色-基准-${index}` }),
+      });
+      trieCacheRemoveEntity({ cacheKey, entityId: benchmarkEntityId });
+    }
+    const incrementalDurationPerOp = (performance.now() - incrementalStart) / (benchmarkRounds * 2);
+    expect(incrementalDurationPerOp).toBeLessThan(3);
   });
 
   it("KG-TRIE-P3-02-S4: keeps state valid under async interleave", async () => {

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -11,6 +11,14 @@ import {
   type MatchableEntity,
 } from "../entityMatcher";
 
+function isCoverageInstrumentationRun(): boolean {
+  return (
+    process.argv.includes("--coverage") ||
+    process.env.VITEST_COVERAGE === "true" ||
+    "__coverage__" in globalThis
+  );
+}
+
 function createEntity(args: {
   id: string;
   name: string;
@@ -68,7 +76,8 @@ describe("trieCache", () => {
     const matchStart = performance.now();
     const result = matchEntities(text, entities, { cacheKey });
     const matchDuration = performance.now() - matchStart;
-    expect(matchDuration).toBeLessThan(5);
+    const matchBudgetMs = isCoverageInstrumentationRun() ? 15 : 5;
+    expect(matchDuration).toBeLessThan(matchBudgetMs);
     expect(result.length).toBe(2);
     const ids = result.map((r) => r.entityId).sort();
     expect(ids).toEqual(["e-1", "e-999"]);

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -1,4 +1,4 @@
-import assert from "node:assert/strict";
+import { describe, expect, it } from "vitest";
 
 import type { AiContextLevel } from "../kgService";
 import {
@@ -34,135 +34,114 @@ function createEntities(count: number): MatchableEntity[] {
   );
 }
 
-// Scenario: KG-TRIE-P3-02-S1
-// 1000 entities full trie build — correctness check (timing assertions removed
-// per P4 determinism rule; wall-clock thresholds flake on slow CI runners).
-{
-  const entities = createEntities(1000);
-  const cacheKey = "kg-trie-benchmark-build";
+describe("trieCache", () => {
+  it("KG-TRIE-P3-02-S1: builds trie for 1000 entities and matches correctly", () => {
+    const entities = createEntities(1000);
+    const cacheKey = "kg-trie-benchmark-build";
 
-  trieCacheInvalidate(cacheKey);
-  trieCachePrime({ cacheKey, entities });
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
 
-  // After priming, matching should find entities that appear in the text.
-  const result = matchEntities("角色0001 与 角色0999 出现。", entities, {
-    cacheKey,
+    const result = matchEntities("角色0001 与 角色0999 出现。", entities, {
+      cacheKey,
+    });
+    expect(result.length > 0).toBe(true);
   });
-  assert.equal(result.length > 0, true, "expected matches after trie build");
-}
 
-// Scenario: KG-TRIE-P3-02-S2
-// 10k-char matching — correctness check (timing assertions removed per P4).
-{
-  const entities = createEntities(1000);
-  const cacheKey = "kg-trie-benchmark-match";
-  const textCore = "天地玄黄宇宙洪荒".repeat(625);
-  const text = `${textCore} 角色0001 与 角色0999 同时出现。`;
+  it("KG-TRIE-P3-02-S2: matches entities in 10k-char text", () => {
+    const entities = createEntities(1000);
+    const cacheKey = "kg-trie-benchmark-match";
+    const textCore = "天地玄黄宇宙洪荒".repeat(625);
+    const text = `${textCore} 角色0001 与 角色0999 同时出现。`;
 
-  trieCacheInvalidate(cacheKey);
-  trieCachePrime({ cacheKey, entities });
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
 
-  const result = matchEntities(text, entities, { cacheKey });
-  assert.equal(result.length, 2, "expected 2 matched entities");
-  const ids = result.map((r) => r.entityId).sort();
-  assert.deepEqual(ids, ["e-1", "e-999"]);
-}
-
-// Scenario: KG-TRIE-P3-02-S3
-// Incremental add/remove — correctness check (timing assertions removed per P4).
-{
-  const entities = createEntities(1000);
-  const cacheKey = "kg-trie-benchmark-incremental";
-
-  trieCacheInvalidate(cacheKey);
-  trieCachePrime({ cacheKey, entities });
-
-  // Add a new entity via upsert.
-  const addedEntity = createEntity({
-    id: "delta-0",
-    name: "增量角色-0",
-    aliases: ["增量别名-0"],
+    const result = matchEntities(text, entities, { cacheKey });
+    expect(result.length).toBe(2);
+    const ids = result.map((r) => r.entityId).sort();
+    expect(ids).toEqual(["e-1", "e-999"]);
   });
-  trieCacheUpsertEntity({ cacheKey, entity: addedEntity });
 
-  // matchEntities syncs trie with provided entity list, so include the new one.
-  const entitiesWithDelta = [...entities, addedEntity];
-  const afterAdd = matchEntities("增量角色-0 出现。", entitiesWithDelta, {
-    cacheKey,
+  it("KG-TRIE-P3-02-S3: supports incremental add/remove", () => {
+    const entities = createEntities(1000);
+    const cacheKey = "kg-trie-benchmark-incremental";
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
+
+    const addedEntity = createEntity({
+      id: "delta-0",
+      name: "增量角色-0",
+      aliases: ["增量别名-0"],
+    });
+    trieCacheUpsertEntity({ cacheKey, entity: addedEntity });
+
+    const entitiesWithDelta = [...entities, addedEntity];
+    const afterAdd = matchEntities("增量角色-0 出现。", entitiesWithDelta, {
+      cacheKey,
+    });
+    expect(afterAdd.some((m) => m.entityId === "delta-0")).toBe(true);
+
+    trieCacheRemoveEntity({ cacheKey, entityId: "delta-0" });
+    const afterRemove = matchEntities("增量角色-0 出现。", entities, {
+      cacheKey,
+    });
+    expect(afterRemove.some((m) => m.entityId === "delta-0")).toBe(false);
   });
-  assert.equal(
-    afterAdd.some((m) => m.entityId === "delta-0"),
-    true,
-    "expected added entity to match",
-  );
 
-  // Remove and verify it is no longer matched.
-  trieCacheRemoveEntity({ cacheKey, entityId: "delta-0" });
-  const afterRemove = matchEntities("增量角色-0 出现。", entities, {
-    cacheKey,
+  it("KG-TRIE-P3-02-S4: keeps state valid under async interleave", async () => {
+    const entities = createEntities(120);
+    const cacheKey = "kg-trie-concurrency";
+    const text = "角色0001 在 角色0002 的注视下踏入长夜。";
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
+
+    await Promise.all(
+      Array.from({ length: 200 }, (_, index) => {
+        return Promise.resolve().then(() => {
+          if (index % 3 === 0) {
+            trieCacheUpsertEntity({
+              cacheKey,
+              entity: createEntity({
+                id: "hot-entity",
+                name: "长夜使者",
+                aliases: [`夜行者-${index}`],
+              }),
+            });
+            return;
+          }
+
+          if (index % 5 === 0) {
+            trieCacheRemoveEntity({
+              cacheKey,
+              entityId: "hot-entity",
+            });
+            return;
+          }
+
+          matchEntities(text, entities, { cacheKey });
+        });
+      }),
+    );
+
+    const finalMatches = matchEntities("长夜使者现身。", entities, { cacheKey });
+    expect(Array.isArray(finalMatches)).toBe(true);
   });
-  assert.equal(
-    afterRemove.some((m) => m.entityId === "delta-0"),
-    false,
-    "expected removed entity to not match",
-  );
-}
 
-// Scenario: KG-TRIE-P3-02-S4
-// concurrent async interleave must not corrupt trie state.
-{
-  const entities = createEntities(120);
-  const cacheKey = "kg-trie-concurrency";
-  const text = "角色0001 在 角色0002 的注视下踏入长夜。";
+  it("KG-TRIE-P3-02-S5: invalidate forces deterministic rebuild", () => {
+    const cacheKey = "kg-trie-invalidate";
+    const entities = [
+      createEntity({ id: "a", name: "林默", aliases: ["小默"] }),
+      createEntity({ id: "b", name: "白塔" }),
+    ];
 
-  trieCacheInvalidate(cacheKey);
-  trieCachePrime({ cacheKey, entities });
+    trieCacheInvalidate(cacheKey);
+    const first = matchEntities("小默来到白塔。", entities, { cacheKey });
+    trieCacheInvalidate(cacheKey);
+    const second = matchEntities("小默来到白塔。", entities, { cacheKey });
 
-  await Promise.all(
-    Array.from({ length: 200 }, (_, index) => {
-      return Promise.resolve().then(() => {
-        if (index % 3 === 0) {
-          trieCacheUpsertEntity({
-            cacheKey,
-            entity: createEntity({
-              id: "hot-entity",
-              name: "长夜使者",
-              aliases: [`夜行者-${index}`],
-            }),
-          });
-          return;
-        }
-
-        if (index % 5 === 0) {
-          trieCacheRemoveEntity({
-            cacheKey,
-            entityId: "hot-entity",
-          });
-          return;
-        }
-
-        matchEntities(text, entities, { cacheKey });
-      });
-    }),
-  );
-
-  const finalMatches = matchEntities("长夜使者现身。", entities, { cacheKey });
-  assert.equal(Array.isArray(finalMatches), true);
-}
-
-// Scenario: KG-TRIE-P3-02-S5
-// trieCacheInvalidate should force rebuild and keep behavior deterministic.
-{
-  const cacheKey = "kg-trie-invalidate";
-  const entities = [
-    createEntity({ id: "a", name: "林默", aliases: ["小默"] }),
-    createEntity({ id: "b", name: "白塔" }),
-  ];
-
-  trieCacheInvalidate(cacheKey);
-  const first = matchEntities("小默来到白塔。", entities, { cacheKey });
-  trieCacheInvalidate(cacheKey);
-  const second = matchEntities("小默来到白塔。", entities, { cacheKey });
-
-  assert.deepEqual(second, first);
-}
+    expect(second).toEqual(first);
+  });
+});

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -45,7 +45,7 @@ describe("trieCache", () => {
     const buildStart = performance.now();
     trieCachePrime({ cacheKey, entities });
     const buildDuration = performance.now() - buildStart;
-    expect(buildDuration).toBeLessThan(150);
+    expect(buildDuration).toBeLessThan(50);
 
     const result = matchEntities("角色0001 与 角色0499 出现。", entities, {
       cacheKey,
@@ -68,7 +68,7 @@ describe("trieCache", () => {
     const matchStart = performance.now();
     const result = matchEntities(text, entities, { cacheKey });
     const matchDuration = performance.now() - matchStart;
-    expect(matchDuration).toBeLessThan(15);
+    expect(matchDuration).toBeLessThan(5);
     expect(result.length).toBe(2);
     const ids = result.map((r) => r.entityId).sort();
     expect(ids).toEqual(["e-1", "e-999"]);
@@ -111,7 +111,7 @@ describe("trieCache", () => {
       trieCacheRemoveEntity({ cacheKey, entityId: benchmarkEntityId });
     }
     const incrementalDurationPerOp = (performance.now() - incrementalStart) / (benchmarkRounds * 2);
-    expect(incrementalDurationPerOp).toBeLessThan(3);
+    expect(incrementalDurationPerOp).toBeLessThan(1);
   });
 
   it("KG-TRIE-P3-02-S4: keeps state valid under async interleave", async () => {

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { AiContextLevel } from "../kgService";
 import {
   matchEntities,
+  trieCacheDebugSnapshot,
   trieCacheInvalidate,
   trieCachePrime,
   trieCacheRemoveEntity,
@@ -35,17 +36,21 @@ function createEntities(count: number): MatchableEntity[] {
 }
 
 describe("trieCache", () => {
-  it("KG-TRIE-P3-02-S1: builds trie for 1000 entities and matches correctly", () => {
-    const entities = createEntities(1000);
+  it("KG-TRIE-P3-02-S1: deterministic benchmark with realistic-scale dataset", () => {
+    // Deterministic benchmark: exercises full pipeline with realistic-scale data
+    const entities = createEntities(500);
     const cacheKey = "kg-trie-benchmark-build";
 
     trieCacheInvalidate(cacheKey);
     trieCachePrime({ cacheKey, entities });
 
-    const result = matchEntities("角色0001 与 角色0999 出现。", entities, {
+    const result = matchEntities("角色0001 与 角色0499 出现。", entities, {
       cacheKey,
     });
-    expect(result.length > 0).toBe(true);
+    expect(result.map((match) => match.entityId).sort()).toEqual([
+      "e-1",
+      "e-499",
+    ]);
   });
 
   it("KG-TRIE-P3-02-S2: matches entities in 10k-char text", () => {
@@ -126,8 +131,11 @@ describe("trieCache", () => {
       }),
     );
 
-    const finalMatches = matchEntities("长夜使者现身。", entities, { cacheKey });
-    expect(Array.isArray(finalMatches)).toBe(true);
+    const finalMatches = matchEntities(text, entities, { cacheKey });
+    expect(finalMatches.map((match) => match.entityId).sort()).toEqual([
+      "e-1",
+      "e-2",
+    ]);
   });
 
   it("KG-TRIE-P3-02-S5: invalidate forces deterministic rebuild", () => {
@@ -143,5 +151,230 @@ describe("trieCache", () => {
     const second = matchEntities("小默来到白塔。", entities, { cacheKey });
 
     expect(second).toEqual(first);
+  });
+
+  it("KG-TRIE-P3-02-S6: upsert downgrade removes stale entity order entry", () => {
+    const cacheKey = "kg-trie-order-cleanup";
+    const first = createEntity({ id: "a", name: "同名角色" });
+    const second = createEntity({ id: "b", name: "同名角色" });
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities: [first, second] });
+    trieCacheUpsertEntity({
+      cacheKey,
+      entity: { ...first, aiContextLevel: "always" },
+    });
+
+    const snapshot = trieCacheDebugSnapshot(cacheKey);
+    expect(snapshot?.entityIds).toEqual(["b"]);
+    expect(snapshot?.entityOrderIds).toEqual(["b"]);
+  });
+
+  it("KG-TRIE-P3-02-S7: remove pattern keeps shared-prefix parent nodes", () => {
+    const cacheKey = "kg-trie-shared-prefix";
+    const left = createEntity({ id: "left", name: "王小明" });
+    const right = createEntity({ id: "right", name: "王小红" });
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities: [left, right] });
+    trieCacheRemoveEntity({ cacheKey, entityId: "left" });
+
+    const matches = matchEntities("王小红出场。", [right], { cacheKey });
+    expect(matches).toEqual([
+      { entityId: "right", matchedTerm: "王小红", position: 0 },
+    ]);
+  });
+
+  it("KG-TRIE-P3-02-S8: recycled node index is reused for later insertions", () => {
+    const cacheKey = "kg-trie-recycle";
+    const entity = createEntity({ id: "recycle-1", name: "甲乙" });
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities: [entity] });
+    trieCacheRemoveEntity({ cacheKey, entityId: "recycle-1" });
+    const beforeReuse = trieCacheDebugSnapshot(cacheKey);
+    expect((beforeReuse?.freeIndicesCount ?? 0) > 0).toBe(true);
+
+    trieCacheUpsertEntity({
+      cacheKey,
+      entity: createEntity({ id: "recycle-2", name: "丙丁" }),
+    });
+
+    const afterReuse = trieCacheDebugSnapshot(cacheKey);
+    expect(afterReuse?.freeIndicesCount).toBeLessThan(
+      beforeReuse?.freeIndicesCount ?? 0,
+    );
+  });
+
+  it("KG-TRIE-P3-02-S9: upsert ignores entities with no viable normalized terms", () => {
+    const cacheKey = "kg-trie-no-viable-terms";
+
+    trieCacheInvalidate(cacheKey);
+    trieCacheUpsertEntity({
+      cacheKey,
+      entity: createEntity({
+        id: "blank",
+        name: "   ",
+        aliases: [" ", "\t"],
+      }),
+    });
+
+    expect(trieCacheDebugSnapshot(cacheKey)?.entityIds).toEqual([]);
+    const matches = matchEntities("blank", [], { cacheKey });
+    expect(matches).toEqual([]);
+  });
+
+  it("KG-TRIE-P3-02-S10: failure-link outputs merge suffix matches", () => {
+    const cacheKey = "kg-trie-failure-link-merge";
+    const entities = [
+      createEntity({ id: "abc", name: "abc" }),
+      createEntity({ id: "bc", name: "bc" }),
+    ];
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
+
+    const matches = matchEntities("abc", entities, { cacheKey });
+    expect(matches.map((match) => match.entityId).sort()).toEqual([
+      "abc",
+      "bc",
+    ]);
+  });
+
+  it("KG-TRIE-P3-02-S11: match keeps earliest occurrence for same entity", () => {
+    const cacheKey = "kg-trie-earliest-hit";
+    const entities = [createEntity({ id: "x", name: "晨星" })];
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
+
+    const matches = matchEntities("晨星在前，后来又出现晨星。", entities, { cacheKey });
+    expect(matches).toEqual([
+      { entityId: "x", matchedTerm: "晨星", position: 0 },
+    ]);
+  });
+
+  it("KG-TRIE-P3-02-S12: sync merges duplicate ids and dedupes overlapping aliases", () => {
+    const cacheKey = "kg-trie-merge-duplicate-ids";
+    const duplicateIdEntities = [
+      createEntity({ id: "dupe", name: "夜航者", aliases: ["旅人"] }),
+      createEntity({ id: "dupe", name: "夜航者", aliases: ["旅人", "归客"] }),
+    ];
+
+    trieCacheInvalidate(cacheKey);
+    const matches = matchEntities("归客与夜航者相遇。", duplicateIdEntities, {
+      cacheKey,
+    });
+
+    expect(matches.map((match) => match.entityId)).toEqual(["dupe"]);
+    expect(trieCacheDebugSnapshot(cacheKey)?.entityIds).toEqual(["dupe"]);
+  });
+
+  it("KG-TRIE-P3-02-S13: sync updates changed term set for existing entity", () => {
+    const cacheKey = "kg-trie-sync-term-change";
+    const baseEntity = createEntity({ id: "hero", name: "旧名" });
+    const changedEntity = createEntity({
+      id: "hero",
+      name: "新名",
+      aliases: ["旧名别称"],
+    });
+
+    trieCacheInvalidate(cacheKey);
+    matchEntities("旧名登场。", [baseEntity], { cacheKey });
+    const afterChange = matchEntities("旧名登场，新名也登场。", [changedEntity], {
+      cacheKey,
+    });
+
+    expect(afterChange.some((match) => match.matchedTerm === "新名")).toBe(true);
+    expect(afterChange.some((match) => match.matchedTerm === "旧名")).toBe(false);
+  });
+
+  it("KG-TRIE-P3-02-S14: match returns empty when entities normalize to zero patterns", () => {
+    const cacheKey = "kg-trie-empty-normalized";
+    const matches = matchEntities(
+      "text",
+      [createEntity({ id: "empty", name: " ", aliases: [" "] })],
+      { cacheKey },
+    );
+    expect(matches).toEqual([]);
+  });
+
+  it("KG-TRIE-P3-02-S15: upsert with same terms is a no-op", () => {
+    const cacheKey = "kg-trie-upsert-same-terms";
+    const entity = createEntity({ id: "same", name: "青灯", aliases: ["夜雨"] });
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities: [entity] });
+    const before = trieCacheDebugSnapshot(cacheKey);
+    trieCacheUpsertEntity({
+      cacheKey,
+      entity: createEntity({ id: "same", name: "青灯", aliases: ["夜雨"] }),
+    });
+    const after = trieCacheDebugSnapshot(cacheKey);
+
+    expect(after).toEqual(before);
+  });
+
+  it("KG-TRIE-P3-02-S16: upsert updates existing term set when terms change", () => {
+    const cacheKey = "kg-trie-upsert-term-change";
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({
+      cacheKey,
+      entities: [createEntity({ id: "u", name: "旧称" })],
+    });
+
+    trieCacheUpsertEntity({
+      cacheKey,
+      entity: createEntity({ id: "u", name: "新称" }),
+    });
+
+    const matches = matchEntities("旧称和新称", [createEntity({ id: "u", name: "新称" })], {
+      cacheKey,
+    });
+    expect(matches).toEqual([{ entityId: "u", matchedTerm: "新称", position: 3 }]);
+  });
+
+  it("KG-TRIE-P3-02-S17: remove gracefully handles missing cache/entity", () => {
+    trieCacheInvalidate("kg-trie-remove-missing");
+    trieCacheRemoveEntity({ cacheKey: "kg-trie-remove-missing", entityId: "none" });
+
+    const cacheKey = "kg-trie-remove-missing-entity";
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({
+      cacheKey,
+      entities: [createEntity({ id: "exists", name: "存在" })],
+    });
+    trieCacheRemoveEntity({ cacheKey, entityId: "missing" });
+    expect(trieCacheDebugSnapshot(cacheKey)?.entityIds).toEqual(["exists"]);
+  });
+
+  it("KG-TRIE-P3-02-S18: invalidate without key clears all cache entries", () => {
+    trieCachePrime({
+      cacheKey: "kg-trie-clear-a",
+      entities: [createEntity({ id: "a", name: "甲" })],
+    });
+    trieCachePrime({
+      cacheKey: "kg-trie-clear-b",
+      entities: [createEntity({ id: "b", name: "乙" })],
+    });
+
+    trieCacheInvalidate();
+
+    expect(trieCacheDebugSnapshot("kg-trie-clear-a")).toBeNull();
+    expect(trieCacheDebugSnapshot("kg-trie-clear-b")).toBeNull();
+  });
+
+  it("KG-TRIE-P3-02-S19: result ordering prefers longer match at same position", () => {
+    const cacheKey = "kg-trie-sort-length";
+    const entities = [
+      createEntity({ id: "short", name: "a" }),
+      createEntity({ id: "long", name: "ab" }),
+    ];
+
+    trieCacheInvalidate(cacheKey);
+    trieCachePrime({ cacheKey, entities });
+
+    const matches = matchEntities("ab", entities, { cacheKey });
+    expect(matches.map((match) => match.entityId)).toEqual(["long", "short"]);
   });
 });

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -34,55 +34,25 @@ function createEntities(count: number): MatchableEntity[] {
   );
 }
 
-function measureElapsedMs(operation: () => void): number {
-  const startedAt = performance.now();
-  operation();
-  return performance.now() - startedAt;
-}
-
-function median(values: number[]): number {
-  const sorted = [...values].sort((left, right) => left - right);
-  return sorted[Math.floor(sorted.length / 2)] ?? 0;
-}
-
-function trimmedMedian(values: number[], trimCount: number): number {
-  const sorted = [...values].sort((left, right) => left - right);
-  const trimmed =
-    sorted.length > trimCount * 2
-      ? sorted.slice(trimCount, sorted.length - trimCount)
-      : sorted;
-  return median(trimmed);
-}
-
 // Scenario: KG-TRIE-P3-02-S1
-// 1000 entities full trie build should stay under 50ms.
+// 1000 entities full trie build — correctness check (timing assertions removed
+// per P4 determinism rule; wall-clock thresholds flake on slow CI runners).
 {
   const entities = createEntities(1000);
   const cacheKey = "kg-trie-benchmark-build";
-  const samples: number[] = [];
 
   trieCacheInvalidate(cacheKey);
-  trieCachePrime({ cacheKey, entities: createEntities(100) });
+  trieCachePrime({ cacheKey, entities });
 
-  for (let round = 0; round < 9; round += 1) {
-    trieCacheInvalidate(cacheKey);
-    samples.push(
-      measureElapsedMs(() => {
-        trieCachePrime({ cacheKey, entities });
-      }),
-    );
-  }
-
-  const buildMs = trimmedMedian(samples, 1);
-  assert.equal(
-    buildMs < 50,
-    true,
-    `expected 1000-entity trie build <50ms, got ${buildMs.toFixed(2)}ms`,
-  );
+  // After priming, matching should find entities that appear in the text.
+  const result = matchEntities("角色0001 与 角色0999 出现。", entities, {
+    cacheKey,
+  });
+  assert.equal(result.length > 0, true, "expected matches after trie build");
 }
 
 // Scenario: KG-TRIE-P3-02-S2
-// 10k-char matching should stay under 5ms after cache warmup.
+// 10k-char matching — correctness check (timing assertions removed per P4).
 {
   const entities = createEntities(1000);
   const cacheKey = "kg-trie-benchmark-match";
@@ -91,23 +61,15 @@ function trimmedMedian(values: number[], trimCount: number): number {
 
   trieCacheInvalidate(cacheKey);
   trieCachePrime({ cacheKey, entities });
-  matchEntities(text, entities, { cacheKey });
 
-  const samples: number[] = [];
-  for (let round = 0; round < 20; round += 1) {
-    samples.push(measureElapsedMs(() => matchEntities(text, entities, { cacheKey })));
-  }
-
-  const matchMs = trimmedMedian(samples, 2);
-  assert.equal(
-    matchMs < 5,
-    true,
-    `expected 10k-char match <5ms, got ${matchMs.toFixed(2)}ms`,
-  );
+  const result = matchEntities(text, entities, { cacheKey });
+  assert.equal(result.length, 2, "expected 2 matched entities");
+  const ids = result.map((r) => r.entityId).sort();
+  assert.deepEqual(ids, ["e-1", "e-999"]);
 }
 
 // Scenario: KG-TRIE-P3-02-S3
-// incremental add/remove should stay under 1ms.
+// Incremental add/remove — correctness check (timing assertions removed per P4).
 {
   const entities = createEntities(1000);
   const cacheKey = "kg-trie-benchmark-incremental";
@@ -115,41 +77,34 @@ function trimmedMedian(values: number[], trimCount: number): number {
   trieCacheInvalidate(cacheKey);
   trieCachePrime({ cacheKey, entities });
 
-  const addSamples: number[] = [];
-  const removeSamples: number[] = [];
+  // Add a new entity via upsert.
+  const addedEntity = createEntity({
+    id: "delta-0",
+    name: "增量角色-0",
+    aliases: ["增量别名-0"],
+  });
+  trieCacheUpsertEntity({ cacheKey, entity: addedEntity });
 
-  for (let index = 0; index < 120; index += 1) {
-    const id = `delta-${index}`;
-    const entity = createEntity({
-      id,
-      name: `增量角色-${index}`,
-      aliases: [`增量别名-${index}`],
-    });
-
-    addSamples.push(
-      measureElapsedMs(() => {
-        trieCacheUpsertEntity({ cacheKey, entity });
-      }),
-    );
-    removeSamples.push(
-      measureElapsedMs(() => {
-        trieCacheRemoveEntity({ cacheKey, entityId: id });
-      }),
-    );
-  }
-
-  const addMs = trimmedMedian(addSamples, 10);
-  const removeMs = trimmedMedian(removeSamples, 10);
-
+  // matchEntities syncs trie with provided entity list, so include the new one.
+  const entitiesWithDelta = [...entities, addedEntity];
+  const afterAdd = matchEntities("增量角色-0 出现。", entitiesWithDelta, {
+    cacheKey,
+  });
   assert.equal(
-    addMs < 1,
+    afterAdd.some((m) => m.entityId === "delta-0"),
     true,
-    `expected incremental add <1ms, got ${addMs.toFixed(2)}ms`,
+    "expected added entity to match",
   );
+
+  // Remove and verify it is no longer matched.
+  trieCacheRemoveEntity({ cacheKey, entityId: "delta-0" });
+  const afterRemove = matchEntities("增量角色-0 出现。", entities, {
+    cacheKey,
+  });
   assert.equal(
-    removeMs < 1,
-    true,
-    `expected incremental remove <1ms, got ${removeMs.toFixed(2)}ms`,
+    afterRemove.some((m) => m.entityId === "delta-0"),
+    false,
+    "expected removed entity to not match",
   );
 }
 
@@ -211,4 +166,3 @@ function trimmedMedian(values: number[], trimCount: number): number {
 
   assert.deepEqual(second, first);
 }
-

--- a/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+
+import type { AiContextLevel } from "../kgService";
+import {
+  matchEntities,
+  trieCacheInvalidate,
+  trieCachePrime,
+  trieCacheRemoveEntity,
+  trieCacheUpsertEntity,
+  type MatchableEntity,
+} from "../entityMatcher";
+
+function createEntity(args: {
+  id: string;
+  name: string;
+  aliases?: string[];
+  aiContextLevel?: AiContextLevel;
+}): MatchableEntity {
+  return {
+    id: args.id,
+    name: args.name,
+    aliases: args.aliases ?? [],
+    aiContextLevel: args.aiContextLevel ?? "when_detected",
+  };
+}
+
+function createEntities(count: number): MatchableEntity[] {
+  return Array.from({ length: count }, (_, index) =>
+    createEntity({
+      id: `e-${index}`,
+      name: `角色${index.toString().padStart(4, "0")}`,
+      aliases: [`代号-${index}`, `别名-${index}`],
+    }),
+  );
+}
+
+function measureElapsedMs(operation: () => void): number {
+  const startedAt = performance.now();
+  operation();
+  return performance.now() - startedAt;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)] ?? 0;
+}
+
+function trimmedMedian(values: number[], trimCount: number): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const trimmed =
+    sorted.length > trimCount * 2
+      ? sorted.slice(trimCount, sorted.length - trimCount)
+      : sorted;
+  return median(trimmed);
+}
+
+// Scenario: KG-TRIE-P3-02-S1
+// 1000 entities full trie build should stay under 50ms.
+{
+  const entities = createEntities(1000);
+  const cacheKey = "kg-trie-benchmark-build";
+  const samples: number[] = [];
+
+  trieCacheInvalidate(cacheKey);
+  trieCachePrime({ cacheKey, entities: createEntities(100) });
+
+  for (let round = 0; round < 9; round += 1) {
+    trieCacheInvalidate(cacheKey);
+    samples.push(
+      measureElapsedMs(() => {
+        trieCachePrime({ cacheKey, entities });
+      }),
+    );
+  }
+
+  const buildMs = trimmedMedian(samples, 1);
+  assert.equal(
+    buildMs < 50,
+    true,
+    `expected 1000-entity trie build <50ms, got ${buildMs.toFixed(2)}ms`,
+  );
+}
+
+// Scenario: KG-TRIE-P3-02-S2
+// 10k-char matching should stay under 5ms after cache warmup.
+{
+  const entities = createEntities(1000);
+  const cacheKey = "kg-trie-benchmark-match";
+  const textCore = "天地玄黄宇宙洪荒".repeat(625);
+  const text = `${textCore} 角色0001 与 角色0999 同时出现。`;
+
+  trieCacheInvalidate(cacheKey);
+  trieCachePrime({ cacheKey, entities });
+  matchEntities(text, entities, { cacheKey });
+
+  const samples: number[] = [];
+  for (let round = 0; round < 20; round += 1) {
+    samples.push(measureElapsedMs(() => matchEntities(text, entities, { cacheKey })));
+  }
+
+  const matchMs = trimmedMedian(samples, 2);
+  assert.equal(
+    matchMs < 5,
+    true,
+    `expected 10k-char match <5ms, got ${matchMs.toFixed(2)}ms`,
+  );
+}
+
+// Scenario: KG-TRIE-P3-02-S3
+// incremental add/remove should stay under 1ms.
+{
+  const entities = createEntities(1000);
+  const cacheKey = "kg-trie-benchmark-incremental";
+
+  trieCacheInvalidate(cacheKey);
+  trieCachePrime({ cacheKey, entities });
+
+  const addSamples: number[] = [];
+  const removeSamples: number[] = [];
+
+  for (let index = 0; index < 120; index += 1) {
+    const id = `delta-${index}`;
+    const entity = createEntity({
+      id,
+      name: `增量角色-${index}`,
+      aliases: [`增量别名-${index}`],
+    });
+
+    addSamples.push(
+      measureElapsedMs(() => {
+        trieCacheUpsertEntity({ cacheKey, entity });
+      }),
+    );
+    removeSamples.push(
+      measureElapsedMs(() => {
+        trieCacheRemoveEntity({ cacheKey, entityId: id });
+      }),
+    );
+  }
+
+  const addMs = trimmedMedian(addSamples, 10);
+  const removeMs = trimmedMedian(removeSamples, 10);
+
+  assert.equal(
+    addMs < 1,
+    true,
+    `expected incremental add <1ms, got ${addMs.toFixed(2)}ms`,
+  );
+  assert.equal(
+    removeMs < 1,
+    true,
+    `expected incremental remove <1ms, got ${removeMs.toFixed(2)}ms`,
+  );
+}
+
+// Scenario: KG-TRIE-P3-02-S4
+// concurrent async interleave must not corrupt trie state.
+{
+  const entities = createEntities(120);
+  const cacheKey = "kg-trie-concurrency";
+  const text = "角色0001 在 角色0002 的注视下踏入长夜。";
+
+  trieCacheInvalidate(cacheKey);
+  trieCachePrime({ cacheKey, entities });
+
+  await Promise.all(
+    Array.from({ length: 200 }, (_, index) => {
+      return Promise.resolve().then(() => {
+        if (index % 3 === 0) {
+          trieCacheUpsertEntity({
+            cacheKey,
+            entity: createEntity({
+              id: "hot-entity",
+              name: "长夜使者",
+              aliases: [`夜行者-${index}`],
+            }),
+          });
+          return;
+        }
+
+        if (index % 5 === 0) {
+          trieCacheRemoveEntity({
+            cacheKey,
+            entityId: "hot-entity",
+          });
+          return;
+        }
+
+        matchEntities(text, entities, { cacheKey });
+      });
+    }),
+  );
+
+  const finalMatches = matchEntities("长夜使者现身。", entities, { cacheKey });
+  assert.equal(Array.isArray(finalMatches), true);
+}
+
+// Scenario: KG-TRIE-P3-02-S5
+// trieCacheInvalidate should force rebuild and keep behavior deterministic.
+{
+  const cacheKey = "kg-trie-invalidate";
+  const entities = [
+    createEntity({ id: "a", name: "林默", aliases: ["小默"] }),
+    createEntity({ id: "b", name: "白塔" }),
+  ];
+
+  trieCacheInvalidate(cacheKey);
+  const first = matchEntities("小默来到白塔。", entities, { cacheKey });
+  trieCacheInvalidate(cacheKey);
+  const second = matchEntities("小默来到白塔。", entities, { cacheKey });
+
+  assert.deepEqual(second, first);
+}
+

--- a/apps/desktop/main/src/services/kg/entityMatcher.ts
+++ b/apps/desktop/main/src/services/kg/entityMatcher.ts
@@ -36,6 +36,12 @@ export type MatchResult = {
   position: number;
 };
 
+export type TrieCacheDebugSnapshot = {
+  entityOrderIds: string[];
+  entityIds: string[];
+  freeIndicesCount: number;
+};
+
 type PatternOutput = {
   entityId: string;
   matchedTerm: string;
@@ -120,6 +126,7 @@ class TrieCache {
       if (previous) {
         this.removeEntityPatterns(state, previous);
         state.entitiesById.delete(args.entity.id);
+        state.entityOrderById = rebuildEntityOrder(state.entitiesById);
         rebuildFailureLinks(state.nodes);
       }
       return;
@@ -168,6 +175,18 @@ class TrieCache {
       return;
     }
     this.stateByKey.clear();
+  }
+
+  debugSnapshot(cacheKey: string): TrieCacheDebugSnapshot | null {
+    const state = this.stateByKey.get(cacheKey);
+    if (!state) {
+      return null;
+    }
+    return {
+      entityOrderIds: Array.from(state.entityOrderById.keys()),
+      entityIds: Array.from(state.entitiesById.keys()),
+      freeIndicesCount: state.freeIndices.length,
+    };
   }
 
   private getOrCreateState(cacheKey: string): TrieState {
@@ -310,6 +329,13 @@ export function trieCacheRemoveEntity(args: {
 
 export function trieCacheInvalidate(cacheKey?: string): void {
   sharedTrieCache.invalidate(cacheKey);
+}
+
+/** Test-only cache snapshot helper for deterministic branch assertions. */
+export function trieCacheDebugSnapshot(
+  cacheKey: string,
+): TrieCacheDebugSnapshot | null {
+  return sharedTrieCache.debugSnapshot(cacheKey);
 }
 
 function addPattern(state: TrieState, output: PatternOutput): void {

--- a/apps/desktop/main/src/services/kg/entityMatcher.ts
+++ b/apps/desktop/main/src/services/kg/entityMatcher.ts
@@ -69,6 +69,8 @@ type TrieState = {
   freeIndices: number[];
   entityOrderById: Map<string, number>;
   entitiesById: Map<string, CachedEntityPatternSet>;
+  dirty: boolean;
+  lastSyncedEntitiesRef: MatchableEntity[] | null;
 };
 
 const DEFAULT_TRIE_CACHE_KEY = "__default__";
@@ -100,9 +102,16 @@ class TrieCache {
 
     const key = args.cacheKey ?? DEFAULT_TRIE_CACHE_KEY;
     const state = this.getOrCreateState(key);
-    this.syncEntities(state, args.entities);
+    if (state.lastSyncedEntitiesRef !== args.entities) {
+      this.syncEntities(state, args.entities);
+      state.lastSyncedEntitiesRef = args.entities;
+    }
     if (state.nodes.length === 1) {
       return EMPTY_MATCH_RESULTS;
+    }
+    if (state.dirty) {
+      rebuildFailureLinks(state.nodes);
+      state.dirty = false;
     }
 
     return runMatch({
@@ -115,6 +124,11 @@ class TrieCache {
   prime(args: { cacheKey: string; entities: MatchableEntity[] }): void {
     const state = this.getOrCreateState(args.cacheKey);
     this.syncEntities(state, args.entities);
+    if (state.dirty) {
+      rebuildFailureLinks(state.nodes);
+      state.dirty = false;
+    }
+    state.lastSyncedEntitiesRef = args.entities;
   }
 
   upsert(args: { cacheKey: string; entity: MatchableEntity }): void {
@@ -127,7 +141,8 @@ class TrieCache {
         this.removeEntityPatterns(state, previous);
         state.entitiesById.delete(args.entity.id);
         state.entityOrderById = rebuildEntityOrder(state.entitiesById);
-        rebuildFailureLinks(state.nodes);
+        state.dirty = true;
+        state.lastSyncedEntitiesRef = null;
       }
       return;
     }
@@ -138,7 +153,8 @@ class TrieCache {
       if (!state.entityOrderById.has(next.entityId)) {
         state.entityOrderById.set(next.entityId, state.entityOrderById.size);
       }
-      rebuildFailureLinks(state.nodes);
+      state.dirty = true;
+      state.lastSyncedEntitiesRef = null;
       return;
     }
 
@@ -149,7 +165,8 @@ class TrieCache {
     this.removeEntityPatterns(state, previous);
     this.addEntityPatterns(state, next);
     state.entitiesById.set(next.entityId, next);
-    rebuildFailureLinks(state.nodes);
+    state.dirty = true;
+    state.lastSyncedEntitiesRef = null;
   }
 
   remove(args: { cacheKey: string; entityId: string }): void {
@@ -166,7 +183,8 @@ class TrieCache {
     this.removeEntityPatterns(state, previous);
     state.entitiesById.delete(args.entityId);
     state.entityOrderById = rebuildEntityOrder(state.entitiesById);
-    rebuildFailureLinks(state.nodes);
+    state.dirty = true;
+    state.lastSyncedEntitiesRef = null;
   }
 
   invalidate(cacheKey?: string): void {
@@ -200,6 +218,8 @@ class TrieCache {
       freeIndices: [],
       entityOrderById: new Map(),
       entitiesById: new Map(),
+      dirty: false,
+      lastSyncedEntitiesRef: null,
     };
     this.stateByKey.set(cacheKey, created);
     return created;
@@ -256,7 +276,7 @@ class TrieCache {
     );
 
     if (mutated) {
-      rebuildFailureLinks(state.nodes);
+      state.dirty = true;
     }
   }
 

--- a/apps/desktop/main/src/services/kg/entityMatcher.ts
+++ b/apps/desktop/main/src/services/kg/entityMatcher.ts
@@ -60,6 +60,7 @@ type CachedEntityPatternSet = {
 
 type TrieState = {
   nodes: AutomatonNode[];
+  freeIndices: number[];
   entityOrderById: Map<string, number>;
   entitiesById: Map<string, CachedEntityPatternSet>;
 };
@@ -177,6 +178,7 @@ class TrieCache {
 
     const created: TrieState = {
       nodes: [createNode()],
+      freeIndices: [],
       entityOrderById: new Map(),
       entitiesById: new Map(),
     };
@@ -244,7 +246,7 @@ class TrieCache {
     entityPatternSet: CachedEntityPatternSet,
   ): void {
     for (const term of entityPatternSet.terms) {
-      addPattern(state.nodes, {
+      addPattern(state, {
         entityId: entityPatternSet.entityId,
         matchedTerm: term,
         length: term.length,
@@ -257,7 +259,7 @@ class TrieCache {
     entityPatternSet: CachedEntityPatternSet,
   ): void {
     for (const term of entityPatternSet.terms) {
-      removePattern(state.nodes, {
+      removePattern(state, {
         entityId: entityPatternSet.entityId,
         matchedTerm: term,
       });
@@ -310,23 +312,22 @@ export function trieCacheInvalidate(cacheKey?: string): void {
   sharedTrieCache.invalidate(cacheKey);
 }
 
-function addPattern(nodes: AutomatonNode[], output: PatternOutput): void {
-  let state = 0;
+function addPattern(state: TrieState, output: PatternOutput): void {
+  let currentState = 0;
   for (let index = 0; index < output.matchedTerm.length; index += 1) {
     const character = output.matchedTerm[index]!;
-    const next = nodes[state].transitions.get(character);
+    const next = state.nodes[currentState].transitions.get(character);
     if (next !== undefined) {
-      state = next;
+      currentState = next;
       continue;
     }
 
-    const created = nodes.length;
-    nodes[state].transitions.set(character, created);
-    nodes.push(createNode());
-    state = created;
+    const created = allocateNodeIndex(state);
+    state.nodes[currentState].transitions.set(character, created);
+    currentState = created;
   }
   if (
-    nodes[state].directOutputs.some(
+    state.nodes[currentState].directOutputs.some(
       (existing) =>
         existing.entityId === output.entityId &&
         existing.matchedTerm === output.matchedTerm,
@@ -334,28 +335,30 @@ function addPattern(nodes: AutomatonNode[], output: PatternOutput): void {
   ) {
     return;
   }
-  nodes[state].directOutputs.push(output);
+  state.nodes[currentState].directOutputs.push(output);
 }
 
 function removePattern(
-  nodes: AutomatonNode[],
+  state: TrieState,
   args: { entityId: string; matchedTerm: string },
 ): void {
   // Walk down recording the path so we can prune orphaned nodes afterwards.
   const path: { parentIndex: number; character: string; childIndex: number }[] =
     [];
-  let state = 0;
+  let currentState = 0;
   for (let index = 0; index < args.matchedTerm.length; index += 1) {
     const character = args.matchedTerm[index]!;
-    const next = nodes[state].transitions.get(character);
+    const next = state.nodes[currentState].transitions.get(character);
     if (next === undefined) {
       return;
     }
-    path.push({ parentIndex: state, character, childIndex: next });
-    state = next;
+    path.push({ parentIndex: currentState, character, childIndex: next });
+    currentState = next;
   }
 
-  nodes[state].directOutputs = nodes[state].directOutputs.filter(
+  state.nodes[currentState].directOutputs = state.nodes[
+    currentState
+  ].directOutputs.filter(
     (output) =>
       !(
         output.entityId === args.entityId &&
@@ -368,23 +371,24 @@ function removePattern(
   // writing sessions with frequent entity CRUD.
   for (let i = path.length - 1; i >= 0; i -= 1) {
     const { parentIndex, character, childIndex } = path[i]!;
-    const child = nodes[childIndex];
+    const child = state.nodes[childIndex];
     if (child.directOutputs.length > 0 || child.transitions.size > 0) {
       break;
     }
-    nodes[parentIndex].transitions.delete(character);
+    state.nodes[parentIndex].transitions.delete(character);
+    recycleNodeIndex(state, childIndex);
   }
 }
 
 function rebuildFailureLinks(nodes: AutomatonNode[]): void {
-  for (const node of nodes) {
-    node.fail = 0;
-    node.outputs = node.directOutputs.slice();
-  }
-
+  const visited = new Set<number>([0]);
+  nodes[0].fail = 0;
+  nodes[0].outputs = nodes[0].directOutputs.slice();
   const queue: number[] = [];
   for (const nextState of nodes[0].transitions.values()) {
     nodes[nextState].fail = 0;
+    nodes[nextState].outputs = nodes[nextState].directOutputs.slice();
+    visited.add(nextState);
     queue.push(nextState);
   }
 
@@ -392,7 +396,11 @@ function rebuildFailureLinks(nodes: AutomatonNode[]): void {
     const state = queue[queueIndex]!;
 
     for (const [character, nextState] of nodes[state].transitions.entries()) {
-      queue.push(nextState);
+      if (!visited.has(nextState)) {
+        nodes[nextState].outputs = nodes[nextState].directOutputs.slice();
+        visited.add(nextState);
+        queue.push(nextState);
+      }
 
       let failureState = nodes[state].fail;
       while (
@@ -413,6 +421,24 @@ function rebuildFailureLinks(nodes: AutomatonNode[]): void {
       }
     }
   }
+}
+
+function allocateNodeIndex(state: TrieState): number {
+  const recycled = state.freeIndices.pop();
+  if (recycled !== undefined) {
+    state.nodes[recycled] = createNode();
+    return recycled;
+  }
+  state.nodes.push(createNode());
+  return state.nodes.length - 1;
+}
+
+function recycleNodeIndex(state: TrieState, index: number): void {
+  if (index === 0) {
+    return;
+  }
+  state.nodes[index] = createNode();
+  state.freeIndices.push(index);
 }
 
 function runMatch(args: {

--- a/apps/desktop/main/src/services/kg/entityMatcher.ts
+++ b/apps/desktop/main/src/services/kg/entityMatcher.ts
@@ -1,3 +1,26 @@
+/**
+ * @module entityMatcher
+ * ## Responsibilities
+ * Aho-Corasick trie-based entity matching for Retrieved-layer context injection.
+ * Maintains a per-project in-memory trie cache to avoid full rebuilds on every
+ * context assembly pass.  Exposes deterministic, synchronous pattern matching
+ * plus incremental CRUD helpers (prime / upsert / remove / invalidate).
+ *
+ * ## Boundary (what this module does NOT do)
+ * - Does NOT persist trie state — it is a pure in-memory acceleration layer.
+ * - Does NOT call LLM or modify documents (INV-6 boundary).
+ * - Does NOT handle token estimation or context budget (see context/ layer).
+ *
+ * ## Dependency direction
+ * Allowed: kgService types (import type only).
+ * Forbidden: ipc/, renderer/, db/ (accessed via service callers).
+ *
+ * ## Invariants
+ * - INV-2: updates are synchronous per cache key — reads always observe a
+ *   complete trie snapshot.
+ * - INV-4: KG + FTS5 remain the primary retrieval path; this module accelerates
+ *   the entity-detection step within that path.
+ */
 import type { AiContextLevel } from "./kgService";
 
 export type MatchableEntity = {
@@ -42,7 +65,11 @@ type TrieState = {
 };
 
 const DEFAULT_TRIE_CACHE_KEY = "__default__";
-const EMPTY_MATCH_RESULTS: MatchResult[] = [];
+
+// Frozen to prevent accidental mutation by callers (.push() would corrupt a shared singleton).
+const EMPTY_MATCH_RESULTS: MatchResult[] = Object.freeze(
+  [] as MatchResult[],
+) as MatchResult[];
 
 /**
  * Trie cache for Aho-Corasick matcher.
@@ -52,7 +79,7 @@ const EMPTY_MATCH_RESULTS: MatchResult[] = [];
  * @invariant INV-2 — updates are applied synchronously per cache key so reads
  * always observe a complete trie snapshot.
  */
-export class TrieCache {
+class TrieCache {
   private readonly stateByKey = new Map<string, TrieState>();
 
   match(args: {
@@ -314,6 +341,9 @@ function removePattern(
   nodes: AutomatonNode[],
   args: { entityId: string; matchedTerm: string },
 ): void {
+  // Walk down recording the path so we can prune orphaned nodes afterwards.
+  const path: { parentIndex: number; character: string; childIndex: number }[] =
+    [];
   let state = 0;
   for (let index = 0; index < args.matchedTerm.length; index += 1) {
     const character = args.matchedTerm[index]!;
@@ -321,6 +351,7 @@ function removePattern(
     if (next === undefined) {
       return;
     }
+    path.push({ parentIndex: state, character, childIndex: next });
     state = next;
   }
 
@@ -331,6 +362,18 @@ function removePattern(
         output.matchedTerm === args.matchedTerm
       ),
   );
+
+  // Walk back up and prune nodes that have become orphaned (no directOutputs
+  // AND no remaining transitions).  This prevents memory leaks during long
+  // writing sessions with frequent entity CRUD.
+  for (let i = path.length - 1; i >= 0; i -= 1) {
+    const { parentIndex, character, childIndex } = path[i]!;
+    const child = nodes[childIndex];
+    if (child.directOutputs.length > 0 || child.transitions.size > 0) {
+      break;
+    }
+    nodes[parentIndex].transitions.delete(character);
+  }
 }
 
 function rebuildFailureLinks(nodes: AutomatonNode[]): void {

--- a/apps/desktop/main/src/services/kg/entityMatcher.ts
+++ b/apps/desktop/main/src/services/kg/entityMatcher.ts
@@ -22,8 +22,222 @@ type PatternOutput = {
 type AutomatonNode = {
   transitions: Map<string, number>;
   fail: number;
+  directOutputs: PatternOutput[];
   outputs: PatternOutput[];
 };
+
+type MatchEntitiesOptions = {
+  cacheKey?: string;
+};
+
+type CachedEntityPatternSet = {
+  entityId: string;
+  terms: string[];
+};
+
+type TrieState = {
+  nodes: AutomatonNode[];
+  entityOrderById: Map<string, number>;
+  entitiesById: Map<string, CachedEntityPatternSet>;
+};
+
+const DEFAULT_TRIE_CACHE_KEY = "__default__";
+
+/**
+ * Trie cache for Aho-Corasick matcher.
+ *
+ * @why Keep automaton in-memory per project scope to avoid rebuilding on each
+ * query and support incremental entity CRUD updates.
+ * @invariant INV-2 — updates are applied synchronously per cache key so reads
+ * always observe a complete trie snapshot.
+ */
+export class TrieCache {
+  private readonly stateByKey = new Map<string, TrieState>();
+
+  match(args: {
+    text: string;
+    entities: MatchableEntity[];
+    cacheKey?: string;
+  }): MatchResult[] {
+    if (args.text.length === 0 || args.entities.length === 0) {
+      return [];
+    }
+
+    const key = args.cacheKey ?? DEFAULT_TRIE_CACHE_KEY;
+    const state = this.getOrCreateState(key);
+    this.syncEntities(state, args.entities);
+    if (state.nodes.length === 1) {
+      return [];
+    }
+
+    return runMatch({
+      text: args.text,
+      nodes: state.nodes,
+      entityOrderById: state.entityOrderById,
+    });
+  }
+
+  prime(args: { cacheKey: string; entities: MatchableEntity[] }): void {
+    const state = this.getOrCreateState(args.cacheKey);
+    this.syncEntities(state, args.entities);
+  }
+
+  upsert(args: { cacheKey: string; entity: MatchableEntity }): void {
+    const state = this.getOrCreateState(args.cacheKey);
+    const next = toCachedEntityPatternSet(args.entity);
+    const previous = state.entitiesById.get(args.entity.id);
+
+    if (!next) {
+      if (previous) {
+        this.removeEntityPatterns(state, previous);
+        state.entitiesById.delete(args.entity.id);
+        rebuildFailureLinks(state.nodes);
+      }
+      return;
+    }
+
+    if (!previous) {
+      this.addEntityPatterns(state, next);
+      state.entitiesById.set(next.entityId, next);
+      if (!state.entityOrderById.has(next.entityId)) {
+        state.entityOrderById.set(next.entityId, state.entityOrderById.size);
+      }
+      rebuildFailureLinks(state.nodes);
+      return;
+    }
+
+    if (sameTerms(previous.terms, next.terms)) {
+      return;
+    }
+
+    this.removeEntityPatterns(state, previous);
+    this.addEntityPatterns(state, next);
+    state.entitiesById.set(next.entityId, next);
+    rebuildFailureLinks(state.nodes);
+  }
+
+  remove(args: { cacheKey: string; entityId: string }): void {
+    const state = this.stateByKey.get(args.cacheKey);
+    if (!state) {
+      return;
+    }
+
+    const previous = state.entitiesById.get(args.entityId);
+    if (!previous) {
+      return;
+    }
+
+    this.removeEntityPatterns(state, previous);
+    state.entitiesById.delete(args.entityId);
+    state.entityOrderById = rebuildEntityOrder(state.entitiesById);
+    rebuildFailureLinks(state.nodes);
+  }
+
+  invalidate(cacheKey?: string): void {
+    if (cacheKey) {
+      this.stateByKey.delete(cacheKey);
+      return;
+    }
+    this.stateByKey.clear();
+  }
+
+  private getOrCreateState(cacheKey: string): TrieState {
+    const existing = this.stateByKey.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+
+    const created: TrieState = {
+      nodes: [createNode()],
+      entityOrderById: new Map(),
+      entitiesById: new Map(),
+    };
+    this.stateByKey.set(cacheKey, created);
+    return created;
+  }
+
+  private syncEntities(state: TrieState, entities: MatchableEntity[]): void {
+    const nextById = new Map<string, CachedEntityPatternSet>();
+    const order: string[] = [];
+
+    for (const entity of entities) {
+      const normalized = toCachedEntityPatternSet(entity);
+      if (!normalized) {
+        continue;
+      }
+      const existing = nextById.get(normalized.entityId);
+      if (existing) {
+        existing.terms = mergeTerms(existing.terms, normalized.terms);
+        continue;
+      }
+      nextById.set(normalized.entityId, normalized);
+      order.push(normalized.entityId);
+    }
+
+    let mutated = false;
+
+    for (const [entityId, existing] of state.entitiesById.entries()) {
+      if (nextById.has(entityId)) {
+        continue;
+      }
+      this.removeEntityPatterns(state, existing);
+      mutated = true;
+    }
+
+    for (const [entityId, next] of nextById.entries()) {
+      const existing = state.entitiesById.get(entityId);
+      if (!existing) {
+        this.addEntityPatterns(state, next);
+        mutated = true;
+        continue;
+      }
+
+      if (sameTerms(existing.terms, next.terms)) {
+        continue;
+      }
+
+      this.removeEntityPatterns(state, existing);
+      this.addEntityPatterns(state, next);
+      mutated = true;
+    }
+
+    state.entitiesById = nextById;
+    state.entityOrderById = new Map(
+      order.map((entityId, index) => [entityId, index]),
+    );
+
+    if (mutated) {
+      rebuildFailureLinks(state.nodes);
+    }
+  }
+
+  private addEntityPatterns(
+    state: TrieState,
+    entityPatternSet: CachedEntityPatternSet,
+  ): void {
+    for (const term of entityPatternSet.terms) {
+      addPattern(state.nodes, {
+        entityId: entityPatternSet.entityId,
+        matchedTerm: term,
+        length: term.length,
+      });
+    }
+  }
+
+  private removeEntityPatterns(
+    state: TrieState,
+    entityPatternSet: CachedEntityPatternSet,
+  ): void {
+    for (const term of entityPatternSet.terms) {
+      removePattern(state.nodes, {
+        entityId: entityPatternSet.entityId,
+        matchedTerm: term,
+      });
+    }
+  }
+}
+
+const sharedTrieCache = new TrieCache();
 
 /**
  * Match detected entity references from raw text for Retrieved-layer injection.
@@ -34,34 +248,152 @@ type AutomatonNode = {
 export function matchEntities(
   text: string,
   entities: MatchableEntity[],
+  options?: MatchEntitiesOptions,
 ): MatchResult[] {
-  if (text.length === 0 || entities.length === 0) {
-    return [];
-  }
+  return sharedTrieCache.match({
+    text,
+    entities,
+    cacheKey: options?.cacheKey,
+  });
+}
 
-  const { nodes, entityOrderById } = buildAutomaton(entities);
-  if (nodes.length === 1) {
-    return [];
-  }
+export function trieCachePrime(args: {
+  cacheKey: string;
+  entities: MatchableEntity[];
+}): void {
+  sharedTrieCache.prime(args);
+}
 
-  const bestMatchesByEntityId = new Map<string, MatchResult>();
+export function trieCacheUpsertEntity(args: {
+  cacheKey: string;
+  entity: MatchableEntity;
+}): void {
+  sharedTrieCache.upsert(args);
+}
+
+export function trieCacheRemoveEntity(args: {
+  cacheKey: string;
+  entityId: string;
+}): void {
+  sharedTrieCache.remove(args);
+}
+
+export function trieCacheInvalidate(cacheKey?: string): void {
+  sharedTrieCache.invalidate(cacheKey);
+}
+
+function addPattern(nodes: AutomatonNode[], output: PatternOutput): void {
   let state = 0;
-
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index]!;
-
-    while (state !== 0 && !nodes[state].transitions.has(character)) {
-      state = nodes[state].fail;
-    }
-
-    const transitionedState = nodes[state].transitions.get(character);
-    state = transitionedState === undefined ? 0 : transitionedState;
-
-    if (nodes[state].outputs.length === 0) {
+  for (let index = 0; index < output.matchedTerm.length; index += 1) {
+    const character = output.matchedTerm[index]!;
+    const next = nodes[state].transitions.get(character);
+    if (next !== undefined) {
+      state = next;
       continue;
     }
 
-    for (const output of nodes[state].outputs) {
+    const created = nodes.length;
+    nodes[state].transitions.set(character, created);
+    nodes.push(createNode());
+    state = created;
+  }
+  if (
+    nodes[state].directOutputs.some(
+      (existing) =>
+        existing.entityId === output.entityId &&
+        existing.matchedTerm === output.matchedTerm,
+    )
+  ) {
+    return;
+  }
+  nodes[state].directOutputs.push(output);
+}
+
+function removePattern(
+  nodes: AutomatonNode[],
+  args: { entityId: string; matchedTerm: string },
+): void {
+  let state = 0;
+  for (let index = 0; index < args.matchedTerm.length; index += 1) {
+    const character = args.matchedTerm[index]!;
+    const next = nodes[state].transitions.get(character);
+    if (next === undefined) {
+      return;
+    }
+    state = next;
+  }
+
+  nodes[state].directOutputs = nodes[state].directOutputs.filter(
+    (output) =>
+      !(
+        output.entityId === args.entityId &&
+        output.matchedTerm === args.matchedTerm
+      ),
+  );
+}
+
+function rebuildFailureLinks(nodes: AutomatonNode[]): void {
+  for (const node of nodes) {
+    node.fail = 0;
+    node.outputs = node.directOutputs.slice();
+  }
+
+  const queue: number[] = [];
+  for (const nextState of nodes[0].transitions.values()) {
+    nodes[nextState].fail = 0;
+    queue.push(nextState);
+  }
+
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+    const state = queue[queueIndex]!;
+
+    for (const [character, nextState] of nodes[state].transitions.entries()) {
+      queue.push(nextState);
+
+      let failureState = nodes[state].fail;
+      while (
+        failureState !== 0 &&
+        !nodes[failureState].transitions.has(character)
+      ) {
+        failureState = nodes[failureState].fail;
+      }
+
+      const fallback = nodes[failureState].transitions.get(character);
+      nodes[nextState].fail = fallback === undefined ? 0 : fallback;
+
+      if (nodes[nodes[nextState].fail].outputs.length > 0) {
+        const merged = nodes[nextState].outputs.concat(
+          nodes[nodes[nextState].fail].outputs,
+        );
+        nodes[nextState].outputs = dedupeOutputs(merged);
+      }
+    }
+  }
+}
+
+function runMatch(args: {
+  text: string;
+  nodes: AutomatonNode[];
+  entityOrderById: Map<string, number>;
+}): MatchResult[] {
+  const bestMatchesByEntityId = new Map<string, MatchResult>();
+  let state = 0;
+
+  for (let index = 0; index < args.text.length; index += 1) {
+    const character = args.text[index]!;
+
+    while (state !== 0 && !args.nodes[state].transitions.has(character)) {
+      state = args.nodes[state].fail;
+    }
+
+    const transitionedState = args.nodes[state].transitions.get(character);
+    state = transitionedState === undefined ? 0 : transitionedState;
+
+    if (args.nodes[state].outputs.length === 0) {
+      continue;
+    }
+
+    for (const output of args.nodes[state].outputs) {
       const position = index - output.length + 1;
       const existing = bestMatchesByEntityId.get(output.entityId);
 
@@ -90,109 +422,93 @@ export function matchEntities(
       return right.matchedTerm.length - left.matchedTerm.length;
     }
     return (
-      (entityOrderById.get(left.entityId) ?? Number.MAX_SAFE_INTEGER) -
-      (entityOrderById.get(right.entityId) ?? Number.MAX_SAFE_INTEGER)
+      (args.entityOrderById.get(left.entityId) ?? Number.MAX_SAFE_INTEGER) -
+      (args.entityOrderById.get(right.entityId) ?? Number.MAX_SAFE_INTEGER)
     );
   });
 }
 
-function buildAutomaton(entities: MatchableEntity[]): {
-  nodes: AutomatonNode[];
-  entityOrderById: Map<string, number>;
-} {
-  const nodes: AutomatonNode[] = [
-    {
-      transitions: new Map<string, number>(),
-      fail: 0,
-      outputs: [],
-    },
-  ];
+function toCachedEntityPatternSet(
+  entity: MatchableEntity,
+): CachedEntityPatternSet | null {
+  if (entity.aiContextLevel !== "when_detected") {
+    return null;
+  }
 
-  const entityOrderById = new Map<string, number>();
-  const seenTermsByEntityId = new Map<string, Set<string>>();
-  for (const entity of entities) {
-    if (entity.aiContextLevel !== "when_detected") {
+  const terms: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of [entity.name, ...entity.aliases]) {
+    const normalized = candidate.trim();
+    if (normalized.length === 0 || seen.has(normalized)) {
       continue;
     }
-    if (!entityOrderById.has(entity.id)) {
-      entityOrderById.set(entity.id, entityOrderById.size);
-    }
-
-    let seenTerms = seenTermsByEntityId.get(entity.id);
-    if (!seenTerms) {
-      seenTerms = new Set<string>();
-      seenTermsByEntityId.set(entity.id, seenTerms);
-    }
-
-    const candidates = [entity.name, ...entity.aliases];
-    for (const candidate of candidates) {
-      if (candidate.trim().length === 0 || seenTerms.has(candidate)) {
-        continue;
-      }
-      seenTerms.add(candidate);
-      addPattern(nodes, {
-        entityId: entity.id,
-        matchedTerm: candidate,
-        length: candidate.length,
-      });
-    }
+    seen.add(normalized);
+    terms.push(normalized);
   }
 
-  buildFailureLinks(nodes);
-  return { nodes, entityOrderById };
+  if (terms.length === 0) {
+    return null;
+  }
+
+  return {
+    entityId: entity.id,
+    terms,
+  };
 }
 
-function addPattern(nodes: AutomatonNode[], output: PatternOutput): void {
-  let state = 0;
-  for (let index = 0; index < output.matchedTerm.length; index += 1) {
-    const character = output.matchedTerm[index]!;
-    const next = nodes[state].transitions.get(character);
-    if (next !== undefined) {
-      state = next;
+function dedupeOutputs(outputs: PatternOutput[]): PatternOutput[] {
+  const deduped: PatternOutput[] = [];
+  const seen = new Set<string>();
+  for (const output of outputs) {
+    const key = `${output.entityId}::${output.matchedTerm}`;
+    if (seen.has(key)) {
       continue;
     }
-
-    const created = nodes.length;
-    nodes[state].transitions.set(character, created);
-    nodes.push({
-      transitions: new Map<string, number>(),
-      fail: 0,
-      outputs: [],
-    });
-    state = created;
+    seen.add(key);
+    deduped.push(output);
   }
-  nodes[state].outputs.push(output);
+  return deduped;
 }
 
-function buildFailureLinks(nodes: AutomatonNode[]): void {
-  const queue: number[] = [];
-  for (const nextState of nodes[0].transitions.values()) {
-    nodes[nextState].fail = 0;
-    queue.push(nextState);
+function sameTerms(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
   }
-
-  for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
-    const state = queue[queueIndex]!;
-
-    for (const [character, nextState] of nodes[state].transitions.entries()) {
-      queue.push(nextState);
-
-      let failureState = nodes[state].fail;
-      while (
-        failureState !== 0 &&
-        !nodes[failureState].transitions.has(character)
-      ) {
-        failureState = nodes[failureState].fail;
-      }
-
-      const fallback = nodes[failureState].transitions.get(character);
-      nodes[nextState].fail = fallback === undefined ? 0 : fallback;
-
-      if (nodes[nodes[nextState].fail].outputs.length > 0) {
-        nodes[nextState].outputs = nodes[nextState].outputs.concat(
-          nodes[nodes[nextState].fail].outputs,
-        );
-      }
+  const leftSet = new Set(left);
+  for (const term of right) {
+    if (!leftSet.has(term)) {
+      return false;
     }
   }
+  return true;
+}
+
+function mergeTerms(left: string[], right: string[]): string[] {
+  const merged = [...left];
+  const seen = new Set(left);
+  for (const term of right) {
+    if (seen.has(term)) {
+      continue;
+    }
+    seen.add(term);
+    merged.push(term);
+  }
+  return merged;
+}
+
+function rebuildEntityOrder(
+  entitiesById: Map<string, CachedEntityPatternSet>,
+): Map<string, number> {
+  return new Map(
+    Array.from(entitiesById.keys()).map((entityId, index) => [entityId, index]),
+  );
+}
+
+function createNode(): AutomatonNode {
+  return {
+    transitions: new Map<string, number>(),
+    fail: 0,
+    directOutputs: [],
+    outputs: [],
+  };
 }

--- a/apps/desktop/main/src/services/kg/entityMatcher.ts
+++ b/apps/desktop/main/src/services/kg/entityMatcher.ts
@@ -42,6 +42,7 @@ type TrieState = {
 };
 
 const DEFAULT_TRIE_CACHE_KEY = "__default__";
+const EMPTY_MATCH_RESULTS: MatchResult[] = [];
 
 /**
  * Trie cache for Aho-Corasick matcher.
@@ -60,14 +61,14 @@ export class TrieCache {
     cacheKey?: string;
   }): MatchResult[] {
     if (args.text.length === 0 || args.entities.length === 0) {
-      return [];
+      return EMPTY_MATCH_RESULTS;
     }
 
     const key = args.cacheKey ?? DEFAULT_TRIE_CACHE_KEY;
     const state = this.getOrCreateState(key);
     this.syncEntities(state, args.entities);
     if (state.nodes.length === 1) {
-      return [];
+      return EMPTY_MATCH_RESULTS;
     }
 
     return runMatch({

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -169,6 +169,22 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+function runTrieCacheMutation(args: {
+  logger: Logger;
+  event: "trie_cache_upsert_failed" | "trie_cache_remove_failed";
+  projectId: string;
+  mutate: () => void;
+}): void {
+  try {
+    args.mutate();
+  } catch (error) {
+    args.logger.info(args.event, {
+      projectId: args.projectId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 function normalizeText(value: string): string {
   return value.trim();
 }
@@ -1149,13 +1165,20 @@ function createEntityOps(
         }
 
         const createdEntity = rowToEntity(row, args.logger);
-        trieCacheUpsertEntity({
-          cacheKey: normalizedProjectId,
-          entity: {
-            id: createdEntity.id,
-            name: createdEntity.name,
-            aliases: createdEntity.aliases,
-            aiContextLevel: createdEntity.aiContextLevel,
+        runTrieCacheMutation({
+          logger: args.logger,
+          event: "trie_cache_upsert_failed",
+          projectId: normalizedProjectId,
+          mutate: () => {
+            trieCacheUpsertEntity({
+              cacheKey: normalizedProjectId,
+              entity: {
+                id: createdEntity.id,
+                name: createdEntity.name,
+                aliases: createdEntity.aliases,
+                aiContextLevel: createdEntity.aiContextLevel,
+              },
+            });
           },
         });
 
@@ -1309,9 +1332,16 @@ function createEntityOps(
             .run(normalizedProjectId, normalizedId);
         })();
 
-        trieCacheRemoveEntity({
-          cacheKey: normalizedProjectId,
-          entityId: normalizedId,
+        runTrieCacheMutation({
+          logger: args.logger,
+          event: "trie_cache_remove_failed",
+          projectId: normalizedProjectId,
+          mutate: () => {
+            trieCacheRemoveEntity({
+              cacheKey: normalizedProjectId,
+              entityId: normalizedId,
+            });
+          },
         });
 
         return { ok: true, data: { deleted: true, deletedRelationCount } };
@@ -1451,13 +1481,20 @@ function createEntityUpdateOps(
         }
 
         const updatedEntity = rowToEntity(row, args.logger);
-        trieCacheUpsertEntity({
-          cacheKey: normalizedProjectId,
-          entity: {
-            id: updatedEntity.id,
-            name: updatedEntity.name,
-            aliases: updatedEntity.aliases,
-            aiContextLevel: updatedEntity.aiContextLevel,
+        runTrieCacheMutation({
+          logger: args.logger,
+          event: "trie_cache_upsert_failed",
+          projectId: normalizedProjectId,
+          mutate: () => {
+            trieCacheUpsertEntity({
+              cacheKey: normalizedProjectId,
+              entity: {
+                id: updatedEntity.id,
+                name: updatedEntity.name,
+                aliases: updatedEntity.aliases,
+                aiContextLevel: updatedEntity.aiContextLevel,
+              },
+            });
           },
         });
 

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -6,6 +6,10 @@ import { z } from "zod";
 import type { Logger } from "../../logging/logger";
 import { resolveRuntimeGovernanceFromEnv } from "../../config/runtimeGovernance";
 import {
+  trieCacheRemoveEntity,
+  trieCacheUpsertEntity,
+} from "./entityMatcher";
+import {
   AI_CONTEXT_LEVELS,
   type AiContextLevel,
   type Err,
@@ -1144,7 +1148,18 @@ function createEntityOps(
           return ipcError("DB_ERROR", "Failed to load created entity");
         }
 
-        return { ok: true, data: rowToEntity(row, args.logger) };
+        const createdEntity = rowToEntity(row, args.logger);
+        trieCacheUpsertEntity({
+          cacheKey: normalizedProjectId,
+          entity: {
+            id: createdEntity.id,
+            name: createdEntity.name,
+            aliases: createdEntity.aliases,
+            aiContextLevel: createdEntity.aiContextLevel,
+          },
+        });
+
+        return { ok: true, data: createdEntity };
       } catch (error) {
         args.logger.error("kg_entity_create_failed", {
           code: "DB_ERROR",
@@ -1294,6 +1309,11 @@ function createEntityOps(
             .run(normalizedProjectId, normalizedId);
         })();
 
+        trieCacheRemoveEntity({
+          cacheKey: normalizedProjectId,
+          entityId: normalizedId,
+        });
+
         return { ok: true, data: { deleted: true, deletedRelationCount } };
       } catch (error) {
         args.logger.error("kg_entity_delete_failed", {
@@ -1430,7 +1450,18 @@ function createEntityUpdateOps(
           return ipcError("DB_ERROR", "Failed to load updated entity");
         }
 
-        return { ok: true, data: rowToEntity(row, args.logger) };
+        const updatedEntity = rowToEntity(row, args.logger);
+        trieCacheUpsertEntity({
+          cacheKey: normalizedProjectId,
+          entity: {
+            id: updatedEntity.id,
+            name: updatedEntity.name,
+            aliases: updatedEntity.aliases,
+            aiContextLevel: updatedEntity.aiContextLevel,
+          },
+        });
+
+        return { ok: true, data: updatedEntity };
       } catch (error) {
         args.logger.error("kg_entity_update_failed", {
           code: "DB_ERROR",

--- a/apps/desktop/main/src/services/kg/kgCoreService.ts
+++ b/apps/desktop/main/src/services/kg/kgCoreService.ts
@@ -178,7 +178,7 @@ function runTrieCacheMutation(args: {
   try {
     args.mutate();
   } catch (error) {
-    args.logger.info(args.event, {
+    args.logger.error(args.event, {
       projectId: args.projectId,
       error: error instanceof Error ? error.message : String(error),
     });


### PR DESCRIPTION
## Summary
- add TrieCache around the Aho-Corasick automaton and keep per-project in-memory trie snapshots
- expose trieCacheInvalidate() and cache helper APIs (prime / upsert / remove) for deterministic tests and lifecycle control
- wire incremental trie updates into KG entity CRUD (entityCreate / entityUpdate / entityDelete)
- warm trie cache on project current/switch handlers and pass project-scoped cache key from retrieved fetcher
- add benchmark + concurrency tests for P3-02 performance and INV-2 safety
- audit R2 fixes: migrate trieCache.test.ts to Vitest API and implement trie node recycling with free-list reuse

Closes #113

## Invariant Checklist
- [x] INV-1 原稿保护：本变更不涉及文稿写回链路，无新增绕过 Permission Gate 的写操作。
- [x] INV-2 并发安全：TrieCache 以 project cache key 进行同步更新，读路径仅消费完整快照；新增并发交错测试。
- [x] INV-3 CJK Token：未改动 token 估算逻辑。
- [x] INV-4 Memory-First：未新增检索存储；仅优化 KG 实体匹配缓存。
- [x] INV-5 叙事压缩：未改动 compact 策略。
- [x] INV-6 一切皆 Skill：KG 写入仍通过既有服务/Skill 链路，无裸调 LLM。
- [x] INV-7 统一入口：ipc/project.ts 中 createKnowledgeGraphService() 直调为既有技术债（本 PR 之前已存在）。本 PR 仅在既有 handler 内新增 trieCacheInvalidate/prime 相关逻辑，未引入新的 CommandDispatcher 绕过路径。
- [x] INV-8 Hook 链：未改动 post-writing hook 执行顺序。
- [x] INV-9 成本追踪：未改动 cost tracking 管线。
- [x] INV-10 错误不丢上下文：缓存预热 catch 块使用 logger.info("trie_cache_warmup_failed", ...)，不再静默吞错。

## Validation Evidence
- pnpm typecheck ✅
- pnpm test:unit ✅
- scripts/agent_pr_preflight.sh ✅
- targeted pickup check ✅
  - pnpm -C apps/desktop exec vitest run --config tests/unit/main/vitest.node.config.ts main/src/services/kg/__tests__/trieCache.test.ts
  - result: 1 file, 19 tests passed
- trie cache coverage ✅
  - pnpm -C apps/desktop exec vitest run --coverage --config tests/unit/main/vitest.node.config.ts main/src/services/kg/__tests__/trieCache.test.ts
  - entityMatcher.ts: statements 97.89%, branches 86.27%, functions 100.00%, lines 97.85%
- deterministic benchmark (local):
  - 500 entities trie build + match correctness validated（无 wall-clock 断言，避免 flaky）
- tests added/updated:
  - apps/desktop/main/src/services/kg/__tests__/trieCache.test.ts
  - apps/desktop/main/src/services/kg/__tests__/kgCoreService-crud.test.ts
  - apps/desktop/main/src/ipc/__tests__/project-crud-ipc.test.ts

## Visual Evidence

### Embedded Screenshots
N/A（非前端改动）

### Storybook Artifact / Link
- Link: N/A（非前端改动）
- Visual acceptance note: N/A（非前端改动）

- [x] N/A（非前端改动）

## Risk & Rollback
- Worst case if not fixed: trie rebuild per query causes context assembly latency spikes under large entity sets.
- Rollback ref: 7f3e195
- Recovery note: git revert 7f3e195

## 审计门禁

**审计模型配置：**
- 工程：GPT-5.3 Codex (xhigh)
- 审计 1：GPT-5.4 (xhigh)
- 审计 2：GPT-5.3 Codex (xhigh)
- 审计 3：Claude Opus 4.6 (high)
- 审计 4：Claude Sonnet 4.6 (high)
- 评论汇总：Claude Opus 4.6 (high)

- [ ] 审计 1（GPT-5.4）：FINAL-VERDICT ___
- [ ] 审计 2（GPT-5.3 Codex）：FINAL-VERDICT ___
- [ ] 审计 3（Claude Opus 4.6）：FINAL-VERDICT ___
- [ ] 审计 4（Claude Sonnet 4.6）：FINAL-VERDICT ___