### PR TITLE
feat(kg): replace mock recognizer with Aho-Corasick entity detection

### DIFF
--- a/apps/desktop/main/src/services/kg/__tests__/kgRecognitionRuntime-queue.test.ts
+++ b/apps/desktop/main/src/services/kg/__tests__/kgRecognitionRuntime-queue.test.ts
@@ -12,6 +12,7 @@ import { KG_SUGGESTION_CHANNEL } from "@shared/types/kg";
 import type { KgSuggestionEvent } from "@shared/types/kg";
 import {
   createKgRecognitionRuntime,
+  createMockRecognizer,
 } from "../kgRecognitionRuntime";
 import type { ServiceResult } from "../types";
 
@@ -1338,7 +1339,7 @@ describe("kgRecognitionRuntime – queue behaviour", () => {
       const rt = createKgRecognitionRuntime({
         db: runtimeDb,
         logger,
-        // No recognizer → uses built-in mock
+        recognizer: createMockRecognizer(),
       });
 
       rt.enqueue({
@@ -1369,6 +1370,7 @@ describe("kgRecognitionRuntime – queue behaviour", () => {
       const rt = createKgRecognitionRuntime({
         db: runtimeDb,
         logger,
+        recognizer: createMockRecognizer(),
       });
 
       rt.enqueue({
@@ -1390,6 +1392,7 @@ describe("kgRecognitionRuntime – queue behaviour", () => {
       const rt = createKgRecognitionRuntime({
         db: runtimeDb,
         logger,
+        recognizer: createMockRecognizer(),
       });
 
       rt.enqueue({
@@ -1413,6 +1416,7 @@ describe("kgRecognitionRuntime – queue behaviour", () => {
       const rt = createKgRecognitionRuntime({
         db: runtimeDb,
         logger,
+        recognizer: createMockRecognizer(),
       });
 
       rt.enqueue({
@@ -1436,6 +1440,7 @@ describe("kgRecognitionRuntime – queue behaviour", () => {
       const rt = createKgRecognitionRuntime({
         db: runtimeDb,
         logger,
+        recognizer: createMockRecognizer(),
       });
 
       rt.enqueue({
@@ -1704,7 +1709,7 @@ describe("kgRecognitionRuntime – queue behaviour", () => {
       const rt = createKgRecognitionRuntime({
         db: runtimeDb,
         logger,
-        // Uses built-in mock recognizer
+        recognizer: createMockRecognizer(),
       });
 
       // Separate names with punctuation to avoid greedy CJK matching overlap

--- a/apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts
+++ b/apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts
@@ -816,6 +816,12 @@ export function createKgRecognitionRuntime(args: {
     db: args.db,
     logger: args.logger,
   });
+
+  // Architecture note (P3-01 scope): Aho-Corasick matches KNOWN entities only.
+  // processTask dedup filters these out → no new-entity suggestions in this path.
+  // This is by design per Playbook §P3-01 ("只能匹配已知实体 → ✅ 主路径").
+  // New entity discovery will be added via LLM Skill in P3-03 hook chain (kg-update
+  // hook, slot #2). Trie caching addressed in P3-02.
   const recognizer = args.recognizer ?? createAhoCorasickRecognizer({ kgService });
 
   function safeSendSuggestion(

--- a/apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts
+++ b/apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts
@@ -895,11 +895,17 @@ export function createKgRecognitionRuntime(args: {
       });
     }
 
-    const existingKeys = new Set(
-      listRes.data.items.map((entity) =>
+    const existingKeys = new Set<string>();
+    for (const entity of listRes.data.items) {
+      existingKeys.add(
         normalizeSuggestionKey({ name: entity.name, type: entity.type }),
-      ),
-    );
+      );
+      for (const alias of entity.aliases ?? []) {
+        existingKeys.add(
+          normalizeSuggestionKey({ name: alias, type: entity.type }),
+        );
+      }
+    }
 
     const sessionState = getOrCreateRecognitionSession(
       sessions,

--- a/apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts
+++ b/apps/desktop/main/src/services/kg/kgRecognitionRuntime.ts
@@ -9,10 +9,12 @@ import {
 } from "@shared/types/kg";
 import type { IpcErrorCode } from "@shared/types/ipc-generated";
 import type { Logger } from "../../logging/logger";
+import { matchEntities } from "./entityMatcher";
 import {
   createKnowledgeGraphService,
   type KnowledgeEntity,
   type KnowledgeEntityType,
+  type KnowledgeGraphService,
   type ServiceResult,
 } from "./kgService";
 
@@ -78,7 +80,7 @@ type RecognitionMetrics = {
   canceledTaskIds: string[];
 };
 
-type Recognizer = {
+export type Recognizer = {
   recognize: (args: {
     projectId: string;
     documentId: string;
@@ -398,6 +400,94 @@ const ITEM_SUFFIXES =
   /(之剑|之刃|神剑|宝剑|法杖|令牌|秘籍|宝典|圣物|神器|法宝|灵石|丹药|卷轴|古籍)$/u;
 
 /**
+ * Create an Aho-Corasick recognizer that detects real KG entity references in text.
+ *
+ * Why: replaces regex-based mock patterns with deterministic multi-pattern matching
+ * against the project's actual Knowledge Graph entities. Uses Option B from the spec:
+ * matchEntities() handles when_detected filtering; always entities are added
+ * unconditionally as candidates.
+ *
+ * @invariant INV-4 — KG+FTS5 as primary retrieval path
+ */
+export function createAhoCorasickRecognizer(deps: {
+  kgService: KnowledgeGraphService;
+}): Recognizer {
+  return {
+    recognize: async ({ projectId, contentText }) => {
+      const listRes = deps.kgService.entityList({ projectId });
+      if (!listRes.ok) {
+        return toErr(
+          "KG_RECOGNITION_UNAVAILABLE",
+          `failed to load entities: ${listRes.error.message}`,
+        );
+      }
+
+      const allEntities = listRes.data.items;
+      if (allEntities.length === 0) {
+        return { ok: true, data: { candidates: [], degraded: false } };
+      }
+
+      // Build entity lookup for mapping MatchResult.entityId → KnowledgeEntity
+      const entityById = new Map<string, KnowledgeEntity>(
+        allEntities.map((entity) => [entity.id, entity]),
+      );
+
+      // matchEntities() filters to when_detected internally (entityMatcher.ts L114).
+      // Passing all entities is safe — non-when_detected entities are skipped.
+      const matches = matchEntities(contentText, allEntities);
+
+      const candidates = new Map<string, RecognitionCandidate>();
+
+      // Aho-Corasick matches for when_detected entities
+      for (const match of matches) {
+        const entity = entityById.get(match.entityId);
+        if (!entity) {
+          continue;
+        }
+        const key = normalizeSuggestionKey({
+          name: match.matchedTerm,
+          type: entity.type,
+        });
+        if (!candidates.has(key)) {
+          candidates.set(key, {
+            name: match.matchedTerm,
+            type: entity.type,
+            evidence: { source: "pattern", matchedText: match.matchedTerm },
+          });
+        }
+      }
+
+      // Always-level entities are unconditionally added regardless of text content
+      // (Option B: don't modify entityMatcher.ts, handle always entities separately)
+      for (const entity of allEntities) {
+        if (entity.aiContextLevel !== "always") {
+          continue;
+        }
+        const key = normalizeSuggestionKey({
+          name: entity.name,
+          type: entity.type,
+        });
+        if (!candidates.has(key)) {
+          candidates.set(key, {
+            name: entity.name,
+            type: entity.type,
+            evidence: { source: "context", matchedText: entity.name },
+          });
+        }
+      }
+
+      return {
+        ok: true,
+        data: {
+          candidates: [...candidates.values()],
+          degraded: false,
+        },
+      };
+    },
+  };
+}
+
+/**
  * Create a deterministic mock recognizer for KG suggestions.
  *
  * Why: tests must avoid real LLM calls while still exercising async recognition
@@ -405,7 +495,7 @@ const ITEM_SUFFIXES =
  *
  * Enhanced with broader Chinese name pattern matching and evidence chain.
  */
-function createMockRecognizer(): Recognizer {
+export function createMockRecognizer(): Recognizer {
   return {
     recognize: async ({ contentText }) => {
       if (process.env.CREONOW_KG_RECOGNITION_FORCE_UNAVAILABLE === "1") {
@@ -706,7 +796,6 @@ export function createKgRecognitionRuntime(args: {
   recognizer?: Recognizer;
   maxConcurrency?: number;
 }): KgRecognitionRuntime {
-  const recognizer = args.recognizer ?? createMockRecognizer();
   const maxConcurrency = Math.max(1, Math.floor(args.maxConcurrency ?? 4));
 
   const queue: RecognitionTask[] = [];
@@ -720,10 +809,14 @@ export function createKgRecognitionRuntime(args: {
     completionOrder: [],
     canceledTaskIds: [],
   };
+
+  // kgService must be created before the recognizer so createAhoCorasickRecognizer
+  // can query entities from the same DB that processTask uses for deduplication.
   const kgService = createKnowledgeGraphService({
     db: args.db,
     logger: args.logger,
   });
+  const recognizer = args.recognizer ?? createAhoCorasickRecognizer({ kgService });
 
   function safeSendSuggestion(
     sender: Electron.WebContents | null,

--- a/apps/desktop/tests/helpers/kg/harness.ts
+++ b/apps/desktop/tests/helpers/kg/harness.ts
@@ -4,6 +4,10 @@ import Database from "better-sqlite3";
 import type { IpcMain } from "electron";
 
 import { registerKnowledgeGraphIpcHandlers } from "../../../main/src/ipc/knowledgeGraph";
+import {
+  createKgRecognitionRuntime,
+  type Recognizer,
+} from "../../../main/src/services/kg/kgRecognitionRuntime";
 import type { Logger } from "../../../main/src/logging/logger";
 
 export type KgIpcResult<T> =
@@ -188,10 +192,16 @@ async function waitForPushCount(args: {
 
 /**
  * Create a ready-to-use KG test harness.
+ *
+ * @param args.recognizer — optional custom recognizer. If provided, a
+ * KgRecognitionRuntime is built with this recognizer and injected into the IPC
+ * handlers. This lets existing tests keep the mock recognizer while new
+ * integration tests can use `createAhoCorasickRecognizer`.
  */
 export function createKnowledgeGraphIpcHarness(args?: {
   projectId?: string;
   rendererId?: number;
+  recognizer?: Recognizer;
 }): {
   db: Database.Database;
   projectId: string;
@@ -223,10 +233,21 @@ export function createKnowledgeGraphIpcHarness(args?: {
     error: [],
   };
 
+  // Build a runtime with the provided recognizer if present, so the IPC
+  // handlers use it instead of the default Aho-Corasick recognizer.
+  const recognitionRuntime = args?.recognizer
+    ? createKgRecognitionRuntime({
+        db,
+        logger: createLogger(logs),
+        recognizer: args.recognizer,
+      })
+    : undefined;
+
   registerKnowledgeGraphIpcHandlers({
     ipcMain: ipcMain as unknown as IpcMain,
     db,
     logger: createLogger(logs),
+    recognitionRuntime,
   });
 
   return {

--- a/apps/desktop/tests/integration/kg/aho-corasick-recognition.test.ts
+++ b/apps/desktop/tests/integration/kg/aho-corasick-recognition.test.ts
@@ -1,0 +1,470 @@
+/**
+ * P3-01 — Aho-Corasick Entity Recognition Integration Tests
+ *
+ * These tests exercise the real Aho-Corasick recognizer (createAhoCorasickRecognizer)
+ * wired into the full IPC pipeline. No mock recognizer is used: every entity is
+ * pre-created in the in-memory SQLite DB and then matched by the Aho-Corasick
+ * automaton inside `matchEntities()`.
+ *
+ * T1: Happy-path — alias-based matches bypass dedup, produce push events
+ * T2: Alias matching — entity detected via alias, not canonical name
+ * T3: never-excluded — entity with aiContextLevel "never" produces no suggestion
+ * T4: always-unconditional — entity with aiContextLevel "always" yields candidate
+ *     even without text mention (tested via recognizer directly)
+ * T5: Empty DB — no entities → empty candidates, degraded: false
+ * T6: Dedup — entity name appears in text → matched, but deduplicated by processTask
+ * T7: Mixed entity types — character + location + item with aliases → all detected
+ */
+import assert from "node:assert/strict";
+
+import {
+  KG_SUGGESTION_CHANNEL,
+  type KgSuggestionEvent,
+} from "@shared/types/kg";
+import { createAhoCorasickRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
+import { createKnowledgeGraphService } from "../../../main/src/services/kg/kgService";
+import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
+
+type RecognitionEnqueueDto = {
+  taskId: string;
+  status: "started" | "queued";
+  queuePosition: number;
+};
+
+type EntityDto = {
+  id: string;
+  projectId: string;
+  type: "character" | "location" | "event" | "item" | "faction";
+  name: string;
+  description: string;
+  aliases: string[];
+  aiContextLevel: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// T1 — Happy-path: alias matches bypass dedup, produce push events
+// ---------------------------------------------------------------------------
+// Three entities with aliases. Text uses the aliases (not canonical names).
+// Because matchedTerm (alias) ≠ entity.name (canonical), dedup cannot
+// filter them → 3 push events expected.
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    // Create 3 entities with aliases and when_detected level
+    const entitySpecs = [
+      {
+        type: "character" as const,
+        name: "林小雨",
+        aliases: ["小雨"],
+        aiContextLevel: "when_detected" as const,
+      },
+      {
+        type: "location" as const,
+        name: "龙脊山脉",
+        aliases: ["龙脊"],
+        aiContextLevel: "when_detected" as const,
+      },
+      {
+        type: "item" as const,
+        name: "天火淬炼剑",
+        aliases: ["天火剑"],
+        aiContextLevel: "when_detected" as const,
+      },
+    ];
+
+    for (const spec of entitySpecs) {
+      const createRes = await harness.invoke<EntityDto>(
+        "knowledge:entity:create",
+        {
+          projectId: harness.projectId,
+          ...spec,
+        },
+      );
+      assert.equal(createRes.ok, true, `create ${spec.name}`);
+    }
+
+    // Enqueue recognition using aliases in the text (NOT canonical names)
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t1",
+        sessionId: "session-t1",
+        contentText: "小雨手持天火剑登上龙脊，迎风而立。",
+        traceId: "trace-t1",
+      },
+    );
+
+    assert.equal(enqueueRes.ok, true);
+    if (!enqueueRes.ok) {
+      assert.fail("expected enqueue success");
+    }
+
+    // Wait for push events (one per unique candidate that passes dedup)
+    const hasPush = await harness.waitForPushCount(
+      KG_SUGGESTION_CHANNEL,
+      3,
+      2_000,
+    );
+    assert.equal(hasPush, true, "expected 3 suggestion push events");
+
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(pushEvents.length, 3);
+
+    // Collect suggestion names — should be the ALIASES (matchedTerm)
+    const names = new Set(pushEvents.map((event) => event.payload.name));
+    assert.ok(names.has("小雨"), "expected alias 小雨");
+    assert.ok(names.has("天火剑"), "expected alias 天火剑");
+    assert.ok(names.has("龙脊"), "expected alias 龙脊");
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T2 — Alias matching: entity detected via alias in text
+// ---------------------------------------------------------------------------
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    const createRes = await harness.invoke<EntityDto>(
+      "knowledge:entity:create",
+      {
+        projectId: harness.projectId,
+        type: "character",
+        name: "云中君",
+        aliases: ["云君", "小云"],
+        aiContextLevel: "when_detected",
+      },
+    );
+    assert.equal(createRes.ok, true);
+
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t2",
+        sessionId: "session-t2",
+        contentText: "小云静静地站在那里。",
+        traceId: "trace-t2",
+      },
+    );
+    assert.equal(enqueueRes.ok, true);
+
+    const hasPush = await harness.waitForPushCount(
+      KG_SUGGESTION_CHANNEL,
+      1,
+      2_000,
+    );
+    assert.equal(hasPush, true, "expected 1 suggestion for alias match");
+
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(pushEvents.length, 1);
+    assert.equal(pushEvents[0]?.payload.name, "小云");
+    assert.equal(pushEvents[0]?.payload.type, "character");
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T3 — never-excluded: entity with aiContextLevel "never" produces no suggestion
+// ---------------------------------------------------------------------------
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    // Create an entity with "never" — should be skipped by matchEntities
+    const createRes = await harness.invoke<EntityDto>(
+      "knowledge:entity:create",
+      {
+        projectId: harness.projectId,
+        type: "character",
+        name: "影子刺客",
+        aliases: ["影子"],
+        aiContextLevel: "never",
+      },
+    );
+    assert.equal(createRes.ok, true);
+
+    // Also create a when_detected entity so we can verify recognition runs
+    const controlCreate = await harness.invoke<EntityDto>(
+      "knowledge:entity:create",
+      {
+        projectId: harness.projectId,
+        type: "location",
+        name: "暗影谷",
+        aliases: ["暗谷"],
+        aiContextLevel: "when_detected",
+      },
+    );
+    assert.equal(controlCreate.ok, true);
+
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t3",
+        sessionId: "session-t3",
+        contentText: "影子在暗谷中穿行。",
+        traceId: "trace-t3",
+      },
+    );
+    assert.equal(enqueueRes.ok, true);
+
+    // Only the "暗谷" alias should produce a push event (not "影子")
+    const hasPush = await harness.waitForPushCount(
+      KG_SUGGESTION_CHANNEL,
+      1,
+      2_000,
+    );
+    assert.equal(hasPush, true, "expected exactly 1 push event (暗谷)");
+
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(pushEvents.length, 1);
+    assert.equal(pushEvents[0]?.payload.name, "暗谷");
+
+    // Small grace period to ensure no additional push comes for the "never" entity
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+    const extra = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(extra.length, 0, "never entity should produce no suggestion");
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T4 — always-unconditional: tested via recognizer directly
+// ---------------------------------------------------------------------------
+// "always" entities are added as candidates even when their names don't appear
+// in the text. However, processTask deduplicates against existing entities by
+// (name, type), so an "always" entity whose name matches an existing entity
+// will be filtered out in the IPC pipeline. We test the recognizer directly
+// to verify the candidate is emitted.
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    const createRes = await harness.invoke<EntityDto>(
+      "knowledge:entity:create",
+      {
+        projectId: harness.projectId,
+        type: "character",
+        name: "世界观旁白",
+        aiContextLevel: "always",
+      },
+    );
+    assert.equal(createRes.ok, true);
+
+    // Build a real Aho-Corasick recognizer against the same DB
+    const kgService = createKnowledgeGraphService({
+      db: harness.db,
+      logger: {
+        logPath: ":memory:",
+        info: () => {},
+        error: () => {},
+      },
+    });
+    const recognizer = createAhoCorasickRecognizer({ kgService });
+
+    // Text does NOT mention "世界观旁白" at all
+    const result = await recognizer.recognize({
+      projectId: harness.projectId,
+      documentId: "doc-t4",
+      sessionId: "session-t4",
+      contentText: "这是一段完全无关的文字。",
+      traceId: "trace-t4",
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) {
+      assert.fail("expected recognition success");
+    }
+    assert.equal(result.data.degraded, false);
+    assert.ok(
+      result.data.candidates.length >= 1,
+      "always entity should produce at least 1 candidate",
+    );
+
+    const alwaysCandidate = result.data.candidates.find(
+      (candidate) => candidate.name === "世界观旁白",
+    );
+    assert.ok(alwaysCandidate, "expected 世界观旁白 as candidate");
+    assert.equal(alwaysCandidate?.type, "character");
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T5 — Empty DB: no entities → no candidates, degraded: false
+// ---------------------------------------------------------------------------
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    // No entities created — enqueue recognition immediately
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t5",
+        sessionId: "session-t5",
+        contentText: "这段文字里没有任何实体。",
+        traceId: "trace-t5",
+      },
+    );
+    assert.equal(enqueueRes.ok, true);
+
+    // Give recognition time to complete — no push events should appear
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(pushEvents.length, 0, "empty DB should produce no push events");
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T6 — Dedup: canonical name match is deduplicated by processTask
+// ---------------------------------------------------------------------------
+// Entity "林远" exists. Text contains "林远". matchedTerm = "林远" = entity.name.
+// processTask's dedup logic at L785-809 will filter this candidate because
+// normalizeSuggestionKey matches an existing entity → no push event.
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    const createRes = await harness.invoke<EntityDto>(
+      "knowledge:entity:create",
+      {
+        projectId: harness.projectId,
+        type: "character",
+        name: "林远",
+        aiContextLevel: "when_detected",
+      },
+    );
+    assert.equal(createRes.ok, true);
+
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t6",
+        sessionId: "session-t6",
+        contentText: "林远走出山门，踏入风雪。",
+        traceId: "trace-t6",
+      },
+    );
+    assert.equal(enqueueRes.ok, true);
+
+    // Give recognition time to complete — candidate should be deduplicated
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(
+      pushEvents.length,
+      0,
+      "canonical name match should be deduplicated (entity already exists)",
+    );
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T7 — Mixed entity types: character + location + item with aliases
+// ---------------------------------------------------------------------------
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    const specs = [
+      {
+        type: "character" as const,
+        name: "风无痕",
+        aliases: ["无痕"],
+        aiContextLevel: "when_detected" as const,
+      },
+      {
+        type: "location" as const,
+        name: "碧水湖",
+        aliases: ["碧湖"],
+        aiContextLevel: "when_detected" as const,
+      },
+      {
+        type: "item" as const,
+        name: "破界之弓",
+        aliases: ["破界弓"],
+        aiContextLevel: "when_detected" as const,
+      },
+      {
+        type: "faction" as const,
+        name: "星辰教",
+        aliases: ["星教"],
+        aiContextLevel: "when_detected" as const,
+      },
+    ];
+
+    for (const spec of specs) {
+      const createRes = await harness.invoke<EntityDto>(
+        "knowledge:entity:create",
+        {
+          projectId: harness.projectId,
+          ...spec,
+        },
+      );
+      assert.equal(createRes.ok, true, `create ${spec.name}`);
+    }
+
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t7",
+        sessionId: "session-t7",
+        contentText: "无痕手持破界弓站在碧湖畔，星教教众在远方集结。",
+        traceId: "trace-t7",
+      },
+    );
+    assert.equal(enqueueRes.ok, true);
+
+    const hasPush = await harness.waitForPushCount(
+      KG_SUGGESTION_CHANNEL,
+      4,
+      2_000,
+    );
+    assert.equal(hasPush, true, "expected 4 suggestion push events");
+
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(pushEvents.length, 4);
+
+    const byName = new Map(
+      pushEvents.map((event) => [event.payload.name, event.payload.type]),
+    );
+    assert.equal(byName.get("无痕"), "character");
+    assert.equal(byName.get("碧湖"), "location");
+    assert.equal(byName.get("破界弓"), "item");
+    assert.equal(byName.get("星教"), "faction");
+  } finally {
+    harness.close();
+  }
+}

--- a/apps/desktop/tests/integration/kg/aho-corasick-recognition.test.ts
+++ b/apps/desktop/tests/integration/kg/aho-corasick-recognition.test.ts
@@ -6,14 +6,16 @@
  * pre-created in the in-memory SQLite DB and then matched by the Aho-Corasick
  * automaton inside `matchEntities()`.
  *
- * T1: Happy-path — alias-based matches bypass dedup, produce push events
- * T2: Alias matching — entity detected via alias, not canonical name
- * T3: never-excluded — entity with aiContextLevel "never" produces no suggestion
+ * T1: Happy-path — recognizer detects 3 aliases; pipeline deduplicates them all
+ * T2: Alias matching — recognizer detects alias; pipeline deduplicates it
+ * T3: never-excluded — entity with aiContextLevel "never" produces no candidate
  * T4: always-unconditional — entity with aiContextLevel "always" yields candidate
  *     even without text mention (tested via recognizer directly)
  * T5: Empty DB — no entities → empty candidates, degraded: false
  * T6: Dedup — entity name appears in text → matched, but deduplicated by processTask
- * T7: Mixed entity types — character + location + item with aliases → all detected
+ * T7: Mixed entity types — character + location + item + faction → all detected
+ * T8: Alias-dedup regression — alias match is deduplicated (prevents duplicate
+ *     entity creation when user accepts)
  */
 import assert from "node:assert/strict";
 
@@ -45,16 +47,15 @@ type EntityDto = {
 };
 
 // ---------------------------------------------------------------------------
-// T1 — Happy-path: alias matches bypass dedup, produce push events
+// T1 — Happy-path: recognizer detects 3 aliases; pipeline deduplicates all
 // ---------------------------------------------------------------------------
 // Three entities with aliases. Text uses the aliases (not canonical names).
-// Because matchedTerm (alias) ≠ entity.name (canonical), dedup cannot
-// filter them → 3 push events expected.
+// The recognizer produces candidates for each alias. processTask dedup now
+// includes aliases → all candidates are filtered → 0 push events.
 {
   const harness = createKnowledgeGraphIpcHarness();
 
   try {
-    // Create 3 entities with aliases and when_detected level
     const entitySpecs = [
       {
         type: "character" as const,
@@ -87,48 +88,68 @@ type EntityDto = {
       assert.equal(createRes.ok, true, `create ${spec.name}`);
     }
 
-    // Enqueue recognition using aliases in the text (NOT canonical names)
+    // Verify recognizer DETECTS all 3 aliases (direct recognizer test)
+    const kgService = createKnowledgeGraphService({
+      db: harness.db,
+      logger: {
+        logPath: ":memory:",
+        info: () => {},
+        error: () => {},
+      },
+    });
+    const recognizer = createAhoCorasickRecognizer({ kgService });
+
+    const result = await recognizer.recognize({
+      projectId: harness.projectId,
+      documentId: "doc-t1",
+      sessionId: "session-t1",
+      contentText: "小雨手持天火剑登上龙脊，迎风而立。",
+      traceId: "trace-t1",
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) {
+      assert.fail("expected recognition success");
+    }
+    assert.equal(result.data.degraded, false);
+
+    const candidateNames = new Set(
+      result.data.candidates.map((c) => c.name),
+    );
+    assert.ok(candidateNames.has("小雨"), "recognizer should detect alias 小雨");
+    assert.ok(candidateNames.has("天火剑"), "recognizer should detect alias 天火剑");
+    assert.ok(candidateNames.has("龙脊"), "recognizer should detect alias 龙脊");
+
+    // Verify pipeline DEDUPLICATES all (aliases now in dedup set)
     const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
       "knowledge:recognition:enqueue",
       {
         projectId: harness.projectId,
-        documentId: "doc-t1",
-        sessionId: "session-t1",
+        documentId: "doc-t1-ipc",
+        sessionId: "session-t1-ipc",
         contentText: "小雨手持天火剑登上龙脊，迎风而立。",
-        traceId: "trace-t1",
+        traceId: "trace-t1-ipc",
       },
     );
-
     assert.equal(enqueueRes.ok, true);
-    if (!enqueueRes.ok) {
-      assert.fail("expected enqueue success");
-    }
 
-    // Wait for push events (one per unique candidate that passes dedup)
-    const hasPush = await harness.waitForPushCount(
-      KG_SUGGESTION_CHANNEL,
-      3,
-      2_000,
-    );
-    assert.equal(hasPush, true, "expected 3 suggestion push events");
-
+    // Give recognition time to complete — all candidates deduplicated → 0 push events
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
     const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
       KG_SUGGESTION_CHANNEL,
     );
-    assert.equal(pushEvents.length, 3);
-
-    // Collect suggestion names — should be the ALIASES (matchedTerm)
-    const names = new Set(pushEvents.map((event) => event.payload.name));
-    assert.ok(names.has("小雨"), "expected alias 小雨");
-    assert.ok(names.has("天火剑"), "expected alias 天火剑");
-    assert.ok(names.has("龙脊"), "expected alias 龙脊");
+    assert.equal(
+      pushEvents.length,
+      0,
+      "alias matches should be deduplicated (aliases belong to existing entities)",
+    );
   } finally {
     harness.close();
   }
 }
 
 // ---------------------------------------------------------------------------
-// T2 — Alias matching: entity detected via alias in text
+// T2 — Alias matching: recognizer detects alias; pipeline deduplicates it
 // ---------------------------------------------------------------------------
 {
   const harness = createKnowledgeGraphIpcHarness();
@@ -146,38 +167,64 @@ type EntityDto = {
     );
     assert.equal(createRes.ok, true);
 
+    // Verify recognizer detects the alias
+    const kgService = createKnowledgeGraphService({
+      db: harness.db,
+      logger: {
+        logPath: ":memory:",
+        info: () => {},
+        error: () => {},
+      },
+    });
+    const recognizer = createAhoCorasickRecognizer({ kgService });
+
+    const result = await recognizer.recognize({
+      projectId: harness.projectId,
+      documentId: "doc-t2",
+      sessionId: "session-t2",
+      contentText: "小云静静地站在那里。",
+      traceId: "trace-t2",
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) {
+      assert.fail("expected recognition success");
+    }
+    const aliasCandidate = result.data.candidates.find(
+      (c) => c.name === "小云",
+    );
+    assert.ok(aliasCandidate, "recognizer should detect alias 小云");
+    assert.equal(aliasCandidate?.type, "character");
+
+    // Verify pipeline deduplicates the alias match
     const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
       "knowledge:recognition:enqueue",
       {
         projectId: harness.projectId,
-        documentId: "doc-t2",
-        sessionId: "session-t2",
+        documentId: "doc-t2-ipc",
+        sessionId: "session-t2-ipc",
         contentText: "小云静静地站在那里。",
-        traceId: "trace-t2",
+        traceId: "trace-t2-ipc",
       },
     );
     assert.equal(enqueueRes.ok, true);
 
-    const hasPush = await harness.waitForPushCount(
-      KG_SUGGESTION_CHANNEL,
-      1,
-      2_000,
-    );
-    assert.equal(hasPush, true, "expected 1 suggestion for alias match");
-
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
     const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
       KG_SUGGESTION_CHANNEL,
     );
-    assert.equal(pushEvents.length, 1);
-    assert.equal(pushEvents[0]?.payload.name, "小云");
-    assert.equal(pushEvents[0]?.payload.type, "character");
+    assert.equal(
+      pushEvents.length,
+      0,
+      "alias 小云 should be deduplicated (belongs to existing entity 云中君)",
+    );
   } finally {
     harness.close();
   }
 }
 
 // ---------------------------------------------------------------------------
-// T3 — never-excluded: entity with aiContextLevel "never" produces no suggestion
+// T3 — never-excluded: entity with aiContextLevel "never" produces no candidate
 // ---------------------------------------------------------------------------
 {
   const harness = createKnowledgeGraphIpcHarness();
@@ -196,7 +243,7 @@ type EntityDto = {
     );
     assert.equal(createRes.ok, true);
 
-    // Also create a when_detected entity so we can verify recognition runs
+    // Also create a when_detected entity to verify recognition runs
     const controlCreate = await harness.invoke<EntityDto>(
       "knowledge:entity:create",
       {
@@ -209,38 +256,64 @@ type EntityDto = {
     );
     assert.equal(controlCreate.ok, true);
 
+    // Verify recognizer: "影子" NOT detected, "暗谷" IS detected
+    const kgService = createKnowledgeGraphService({
+      db: harness.db,
+      logger: {
+        logPath: ":memory:",
+        info: () => {},
+        error: () => {},
+      },
+    });
+    const recognizer = createAhoCorasickRecognizer({ kgService });
+
+    const result = await recognizer.recognize({
+      projectId: harness.projectId,
+      documentId: "doc-t3",
+      sessionId: "session-t3",
+      contentText: "影子在暗谷中穿行。",
+      traceId: "trace-t3",
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) {
+      assert.fail("expected recognition success");
+    }
+
+    const candidateNames = new Set(
+      result.data.candidates.map((c) => c.name),
+    );
+    assert.ok(
+      !candidateNames.has("影子"),
+      "never-entity alias should NOT be detected",
+    );
+    assert.ok(
+      !candidateNames.has("影子刺客"),
+      "never-entity name should NOT be detected",
+    );
+    assert.ok(
+      candidateNames.has("暗谷"),
+      "when_detected entity alias should be detected",
+    );
+
+    // Verify pipeline: 0 push events (暗谷 is deduplicated as alias of existing entity)
     const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
       "knowledge:recognition:enqueue",
       {
         projectId: harness.projectId,
-        documentId: "doc-t3",
-        sessionId: "session-t3",
+        documentId: "doc-t3-ipc",
+        sessionId: "session-t3-ipc",
         contentText: "影子在暗谷中穿行。",
-        traceId: "trace-t3",
+        traceId: "trace-t3-ipc",
       },
     );
     assert.equal(enqueueRes.ok, true);
 
-    // Only the "暗谷" alias should produce a push event (not "影子")
-    const hasPush = await harness.waitForPushCount(
-      KG_SUGGESTION_CHANNEL,
-      1,
-      2_000,
-    );
-    assert.equal(hasPush, true, "expected exactly 1 push event (暗谷)");
-
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
     const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
       KG_SUGGESTION_CHANNEL,
     );
-    assert.equal(pushEvents.length, 1);
-    assert.equal(pushEvents[0]?.payload.name, "暗谷");
-
-    // Small grace period to ensure no additional push comes for the "never" entity
-    await new Promise<void>((resolve) => setTimeout(resolve, 200));
-    const extra = harness.takePushEvents<KgSuggestionEvent>(
-      KG_SUGGESTION_CHANNEL,
-    );
-    assert.equal(extra.length, 0, "never entity should produce no suggestion");
+    assert.equal(pushEvents.length, 0, "no push events expected");
   } finally {
     harness.close();
   }
@@ -344,7 +417,7 @@ type EntityDto = {
 // T6 — Dedup: canonical name match is deduplicated by processTask
 // ---------------------------------------------------------------------------
 // Entity "林远" exists. Text contains "林远". matchedTerm = "林远" = entity.name.
-// processTask's dedup logic at L785-809 will filter this candidate because
+// processTask's dedup logic will filter this candidate because
 // normalizeSuggestionKey matches an existing entity → no push event.
 {
   const harness = createKnowledgeGraphIpcHarness();
@@ -389,7 +462,7 @@ type EntityDto = {
 }
 
 // ---------------------------------------------------------------------------
-// T7 — Mixed entity types: character + location + item with aliases
+// T7 — Mixed entity types: character + location + item + faction → all detected
 // ---------------------------------------------------------------------------
 {
   const harness = createKnowledgeGraphIpcHarness();
@@ -433,37 +506,137 @@ type EntityDto = {
       assert.equal(createRes.ok, true, `create ${spec.name}`);
     }
 
+    // Verify recognizer detects all 4 entity types via aliases
+    const kgService = createKnowledgeGraphService({
+      db: harness.db,
+      logger: {
+        logPath: ":memory:",
+        info: () => {},
+        error: () => {},
+      },
+    });
+    const recognizer = createAhoCorasickRecognizer({ kgService });
+
+    const result = await recognizer.recognize({
+      projectId: harness.projectId,
+      documentId: "doc-t7",
+      sessionId: "session-t7",
+      contentText: "无痕手持破界弓站在碧湖畔，星教教众在远方集结。",
+      traceId: "trace-t7",
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) {
+      assert.fail("expected recognition success");
+    }
+
+    const byName = new Map(
+      result.data.candidates.map((c) => [c.name, c.type]),
+    );
+    assert.equal(byName.get("无痕"), "character", "recognizer should detect character alias");
+    assert.equal(byName.get("碧湖"), "location", "recognizer should detect location alias");
+    assert.equal(byName.get("破界弓"), "item", "recognizer should detect item alias");
+    assert.equal(byName.get("星教"), "faction", "recognizer should detect faction alias");
+
+    // Verify pipeline deduplicates all alias matches
     const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
       "knowledge:recognition:enqueue",
       {
         projectId: harness.projectId,
-        documentId: "doc-t7",
-        sessionId: "session-t7",
+        documentId: "doc-t7-ipc",
+        sessionId: "session-t7-ipc",
         contentText: "无痕手持破界弓站在碧湖畔，星教教众在远方集结。",
-        traceId: "trace-t7",
+        traceId: "trace-t7-ipc",
       },
     );
     assert.equal(enqueueRes.ok, true);
 
-    const hasPush = await harness.waitForPushCount(
-      KG_SUGGESTION_CHANNEL,
-      4,
-      2_000,
-    );
-    assert.equal(hasPush, true, "expected 4 suggestion push events");
-
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
     const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
       KG_SUGGESTION_CHANNEL,
     );
-    assert.equal(pushEvents.length, 4);
-
-    const byName = new Map(
-      pushEvents.map((event) => [event.payload.name, event.payload.type]),
+    assert.equal(
+      pushEvents.length,
+      0,
+      "all alias matches should be deduplicated (aliases belong to existing entities)",
     );
-    assert.equal(byName.get("无痕"), "character");
-    assert.equal(byName.get("碧湖"), "location");
-    assert.equal(byName.get("破界弓"), "item");
-    assert.equal(byName.get("星教"), "faction");
+  } finally {
+    harness.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T8 — Alias-dedup regression: alias match must NOT create duplicate entity
+// ---------------------------------------------------------------------------
+// Reproduces the exact Duck audit finding:
+//   1. Entity "林小雨" with alias "小雨" exists
+//   2. Text mentions "小雨"
+//   3. Recognizer emits candidate name: "小雨"
+//   4. Before fix: dedup only checked canonical name "林小雨" → alias "小雨"
+//      bypassed dedup → suggestion pushed → accepting creates duplicate entity
+//   5. After fix: dedup includes aliases → "小雨" is in dedup set → filtered
+{
+  const harness = createKnowledgeGraphIpcHarness();
+
+  try {
+    const createRes = await harness.invoke<EntityDto>(
+      "knowledge:entity:create",
+      {
+        projectId: harness.projectId,
+        type: "character",
+        name: "林小雨",
+        aliases: ["小雨", "雨儿"],
+        aiContextLevel: "when_detected",
+      },
+    );
+    assert.equal(createRes.ok, true);
+
+    // Use alias "小雨" in text — should be detected but deduplicated
+    const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t8",
+        sessionId: "session-t8",
+        contentText: "小雨站在窗前，望着远方。",
+        traceId: "trace-t8",
+      },
+    );
+    assert.equal(enqueueRes.ok, true);
+
+    // Wait — should get 0 push events (alias is deduplicated)
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+    const pushEvents = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(
+      pushEvents.length,
+      0,
+      "alias match 小雨 must NOT produce suggestion (prevents duplicate entity creation)",
+    );
+
+    // Also try "雨儿" alias
+    const enqueueRes2 = await harness.invoke<RecognitionEnqueueDto>(
+      "knowledge:recognition:enqueue",
+      {
+        projectId: harness.projectId,
+        documentId: "doc-t8b",
+        sessionId: "session-t8b",
+        contentText: "雨儿轻声叹了口气。",
+        traceId: "trace-t8b",
+      },
+    );
+    assert.equal(enqueueRes2.ok, true);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+    const pushEvents2 = harness.takePushEvents<KgSuggestionEvent>(
+      KG_SUGGESTION_CHANNEL,
+    );
+    assert.equal(
+      pushEvents2.length,
+      0,
+      "alias match 雨儿 must NOT produce suggestion (prevents duplicate entity creation)",
+    );
   } finally {
     harness.close();
   }

--- a/apps/desktop/tests/integration/kg/auto-recognition-autosave.test.ts
+++ b/apps/desktop/tests/integration/kg/auto-recognition-autosave.test.ts
@@ -5,6 +5,7 @@ import {
   KG_SUGGESTION_CHANNEL,
   type KgSuggestionEvent,
 } from "@shared/types/kg";
+import { createMockRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
 import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
 
 type RecognitionEnqueueDto = {
@@ -16,7 +17,9 @@ type RecognitionEnqueueDto = {
 // KG3-R1-S1
 // should trigger background recognition after autosave without blocking editor input
 {
-  const harness = createKnowledgeGraphIpcHarness();
+  const harness = createKnowledgeGraphIpcHarness({
+    recognizer: createMockRecognizer(),
+  });
 
   try {
     const startedAt = performance.now();

--- a/apps/desktop/tests/integration/kg/recognition-backpressure.test.ts
+++ b/apps/desktop/tests/integration/kg/recognition-backpressure.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 
+import { createMockRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
 import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
 
 type EnqueueDto = {
@@ -24,7 +25,9 @@ type RecognitionStatsDto = {
   const prevDelayMs = process.env.CREONOW_KG_RECOGNITION_MOCK_DELAY_MS;
   process.env.CREONOW_KG_RECOGNITION_MOCK_DELAY_MS = "50";
 
-  const harness = createKnowledgeGraphIpcHarness();
+  const harness = createKnowledgeGraphIpcHarness({
+    recognizer: createMockRecognizer(),
+  });
 
   try {
     const tasks: EnqueueDto[] = [];

--- a/apps/desktop/tests/integration/kg/recognition-query-failure-degrade.test.ts
+++ b/apps/desktop/tests/integration/kg/recognition-query-failure-degrade.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import { KG_SUGGESTION_CHANNEL } from "@shared/types/kg";
+import { createMockRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
 import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
 
 type RelevantQueryDto = {
@@ -42,7 +43,9 @@ async function waitForCondition(
   process.env.CREONOW_KG_RECOGNITION_FORCE_UNAVAILABLE = "1";
   process.env.CREONOW_KG_FORCE_RELEVANT_QUERY_FAIL = "1";
 
-  const harness = createKnowledgeGraphIpcHarness();
+  const harness = createKnowledgeGraphIpcHarness({
+    recognizer: createMockRecognizer(),
+  });
 
   try {
     const enqueueRes = await harness.invoke<{ taskId: string }>(

--- a/apps/desktop/tests/integration/kg/recognition-queue-cancel.test.ts
+++ b/apps/desktop/tests/integration/kg/recognition-queue-cancel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 
+import { createMockRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
 import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
 
 type EnqueueDto = {
@@ -24,7 +25,9 @@ type RecognitionStatsDto = {
   const prevDelayMs = process.env.CREONOW_KG_RECOGNITION_MOCK_DELAY_MS;
   process.env.CREONOW_KG_RECOGNITION_MOCK_DELAY_MS = "70";
 
-  const harness = createKnowledgeGraphIpcHarness();
+  const harness = createKnowledgeGraphIpcHarness({
+    recognizer: createMockRecognizer(),
+  });
 
   try {
     const enqueued: EnqueueDto[] = [];

--- a/apps/desktop/tests/integration/kg/suggestion-accept-create-entity.test.ts
+++ b/apps/desktop/tests/integration/kg/suggestion-accept-create-entity.test.ts
@@ -4,6 +4,7 @@ import {
   KG_SUGGESTION_CHANNEL,
   type KgSuggestionEvent,
 } from "@shared/types/kg";
+import { createMockRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
 import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
 
 type RecognitionEnqueueDto = {
@@ -27,7 +28,9 @@ type EntityDto = {
 // KG3-R1-S2
 // should create entity via knowledge:suggestion:accept and open entity detail
 {
-  const harness = createKnowledgeGraphIpcHarness();
+  const harness = createKnowledgeGraphIpcHarness({
+    recognizer: createMockRecognizer(),
+  });
 
   try {
     const enqueueRes = await harness.invoke<RecognitionEnqueueDto>(

--- a/apps/desktop/tests/integration/kg/suggestion-dismiss-dedupe.test.ts
+++ b/apps/desktop/tests/integration/kg/suggestion-dismiss-dedupe.test.ts
@@ -4,6 +4,7 @@ import {
   KG_SUGGESTION_CHANNEL,
   type KgSuggestionEvent,
 } from "@shared/types/kg";
+import { createMockRecognizer } from "../../../main/src/services/kg/kgRecognitionRuntime";
 import { createKnowledgeGraphIpcHarness } from "../../helpers/kg/harness";
 
 type RecognitionEnqueueDto = {
@@ -15,7 +16,9 @@ type RecognitionEnqueueDto = {
 // KG3-R1-S3
 // should suppress repeated suggestion in same session after dismiss
 {
-  const harness = createKnowledgeGraphIpcHarness();
+  const harness = createKnowledgeGraphIpcHarness({
+    recognizer: createMockRecognizer(),
+  });
 
   try {
     const firstEnqueue = await harness.invoke<RecognitionEnqueueDto>(


### PR DESCRIPTION
## Summary
- Replace the regex-based mock recognizer in kgRecognitionRuntime.ts with a deterministic Aho-Corasick entity matcher (entityMatcher.ts). The new createAhoCorasickRecognizer() queries all entities from the KG database and runs them through the Aho-Corasick automaton for O(n+m+z) multi-pattern matching.
- **Audit fix (Round 1):** Expand processTask() dedup set to include entity aliases alongside canonical names. Previously, alias matches bypassed dedup because matchedTerm (alias) ≠ entity.name (canonical), allowing duplicate entity creation when a user accepted the suggestion.

Closes #126

## Impact Scope
- KG entity recognition pipeline: mock regex recognizer replaced with production Aho-Corasick matcher
- processTask() dedup logic hardened to cover entity aliases (prevents duplicate entity creation)
- No schema changes, no renderer/frontend changes, no external dependencies

## Invariant Checklist

- [x] **INV-1** — Single source of truth: SQLite remains SSOT; kgService.entityList() queries the same DB that processTask() uses for dedup
- [x] **INV-2** — Schema migration discipline: no schema changes in this PR
- [x] **INV-3** — Offline-first: Aho-Corasick runs entirely in-process, no network calls
- [x] **INV-4** — KG+FTS5 as primary retrieval: entities fetched from SQLite KG, recognition is deterministic
- [x] **INV-5** — Test-gated delivery: 2598 unit + 21 integration tests pass, 8 new integration tests added (T1-T8)
- [x] **INV-6** — Error boundary: toErr(KG_RECOGNITION_UNAVAILABLE) returned if entityList() fails
- [x] **INV-7** — Type safety: all exports typed, tsc --noEmit clean
- [x] **INV-8** — Audit trail: commit message references #126, PR body has full checklist
- [x] **INV-9** — No shared mutable state: recognizer is a pure function factory, no globals
- [x] **INV-10** — Backward compatibility: existing tests pass with explicit mock injection, no API breaking changes

## Validation Evidence
- TypeScript: tsc --noEmit — 0 errors
- Unit tests: 2598/2598 passed (147 files)
- Integration tests: 21/21 KG integration tests passed (8 new Aho-Corasick T1-T8 + 13 existing with explicit mock)
- No files outside scope modified: only kgRecognitionRuntime.ts, harness.ts, and test files touched; entityMatcher.ts untouched
- **Round 1 audit fix verified**: T8 regression test confirms alias "小雨" of entity "林小雨" is properly deduplicated (0 push events), preventing duplicate entity creation

## Visual Evidence

### Embedded Screenshots
N/A

### Storybook Artifact / Link
- Link: N/A
- Visual acceptance note: N/A

- [x] This PR does NOT touch apps/desktop/renderer/ or apps/desktop/.storybook/ — visual evidence is not applicable.

## Test Coverage
- 8 new integration tests (T1-T8) in aho-corasick-recognition.test.ts
  - T1: Happy-path — recognizer detects 3 aliases; pipeline deduplicates them all
  - T2: Alias matching — recognizer detects alias; pipeline deduplicates it
  - T3: never-excluded — entity with aiContextLevel "never" produces no candidate
  - T4: always-unconditional — "always" entity yields candidate even without text mention
  - T5: Empty DB — no entities → no candidates
  - T6: Canonical name dedup — entity name match is deduplicated by processTask
  - T7: Mixed entity types — character + location + item + faction → all detected and deduplicated
  - T8: **Alias-dedup regression** — exact Duck repro case (entity "林小雨" alias "小雨"; text mentions "小雨" → 0 push events)
- 12 existing tests fixed to use explicit mock recognizer (6 integration + 6 unit)
- All 2598 unit tests + 21 integration tests pass

## Risk & Rollback
- Worst case if not fixed: entity recognition remains on mock regex, no production Aho-Corasick matching
- Rollback ref: revert commits 82660b5..4c937f4 or set recognizer: createMockRecognizer() in createKgRecognitionRuntime()
- Recovery note: mock recognizer is still exported and fully functional; reverting is a two-commit revert with zero side effects

## 审计门禁

<- [ ] Dual Audit: ACCEPT × 以下由审计流程自动填写，PR 作者不要修改 -->

**审计模型配置（1+1+1+Duck）：**
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)

- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT ___
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT ___
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT ___

<- [ ] Dual Audit: ACCEPT × 3 路都 ACCEPT 才可合并 -->