### PR TITLE
feat(ai): implement INV-5 AutoCompact narrative compression

### DIFF
--- a/apps/desktop/main/src/services/ai/compact/__tests__/narrativeCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/narrativeCompact.test.ts
@@ -1,0 +1,732 @@
+/**
+ * NarrativeCompactService — INV-5 AutoCompact Narrative Compression
+ * Spec: ARCHITECTURE.md INV-5, docs/playbook/02-p3-project-intelligence.md
+ *
+ * TDD Red Phase: tests compile, fail until implementation exists.
+ * Validates:
+ *   - Priority sorting (protected > recent > referenced > old)
+ *   - Protection rules (compactable: false preserved, never compressed)
+ *   - Budget enforcement (compression stops once under budget)
+ *   - Cache hit (same content hash returns cached summary)
+ *   - CJK token counting (INV-3)
+ *   - INV-9 logging (skill_executions via CostTracker)
+ *   - INV-6 compliance (compression through builtin:auto-compact Skill)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { estimateTokens } from "@shared/tokenBudget";
+
+import {
+  createNarrativeCompactService,
+  type NarrativeCompactService,
+  type ContextFragment,
+  type FragmentPriority,
+  type SkillInvoker,
+  BUILTIN_AUTO_COMPACT_SKILL_ID,
+} from "../narrativeCompact";
+
+// ─── Mock helpers ───────────────────────────────────────────────────
+
+function createMockSkillInvoker(): SkillInvoker & { invoke: Mock } {
+  return {
+    invoke: vi.fn().mockImplementation(async (args: { input: string }) => {
+      // Default: return a short summary (roughly 30% of input)
+      const inputLen = args.input.length;
+      const summary = args.input.slice(0, Math.max(10, Math.floor(inputLen * 0.3)));
+      return {
+        output: summary,
+        usage: { promptTokens: 100, completionTokens: 30 },
+        model: "gpt-4o",
+        requestId: `req-${Date.now()}`,
+      };
+    }),
+  };
+}
+
+interface MockCostTracker {
+  recordUsage: Mock;
+}
+
+function createMockCostTracker(): MockCostTracker {
+  return {
+    recordUsage: vi.fn().mockReturnValue({
+      requestId: "mock-req",
+      modelId: "gpt-4o",
+      inputTokens: 100,
+      outputTokens: 30,
+      cachedTokens: 0,
+      cost: 0.001,
+      skillId: BUILTIN_AUTO_COMPACT_SKILL_ID,
+      timestamp: Date.now(),
+    }),
+  };
+}
+
+function makeFragment(overrides: Partial<ContextFragment> = {}): ContextFragment {
+  return {
+    id: overrides.id ?? `frag-${Math.random().toString(36).slice(2, 8)}`,
+    content: overrides.content ?? "这是一段测试文本，用于验证叙事压缩功能。",
+    priority: overrides.priority ?? "old",
+    compactable: overrides.compactable ?? true,
+    metadata: overrides.metadata,
+  };
+}
+
+/** Generate long CJK content to exceed token budgets */
+function makeLongCjkContent(charCount: number): string {
+  const base = "这是一段很长的中文测试内容用于验证压缩功能的正确性和";
+  let result = "";
+  while (result.length < charCount) {
+    result += base;
+  }
+  return result.slice(0, charCount);
+}
+
+
+
+// ─── Test suite ─────────────────────────────────────────────────────
+
+describe("NarrativeCompactService", () => {
+  let service: NarrativeCompactService;
+  let mockSkill: SkillInvoker & { invoke: Mock };
+  let mockCost: MockCostTracker;
+
+  beforeEach(() => {
+    mockSkill = createMockSkillInvoker();
+    mockCost = createMockCostTracker();
+    service = createNarrativeCompactService({
+      skillInvoker: mockSkill,
+      costTracker: mockCost,
+    });
+  });
+
+  afterEach(() => {
+    service.dispose();
+    vi.restoreAllMocks();
+  });
+
+  // ─── Priority sorting ──────────────────────────────────────────
+
+  describe("priority sorting", () => {
+    it("compresses lowest-priority fragments first (old before referenced)", async () => {
+      const oldFrag = makeFragment({
+        id: "old-1",
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const referencedFrag = makeFragment({
+        id: "ref-1",
+        content: makeLongCjkContent(200),
+        priority: "referenced",
+        compactable: true,
+      });
+      const recentFrag = makeFragment({
+        id: "recent-1",
+        content: makeLongCjkContent(200),
+        priority: "recent",
+        compactable: true,
+      });
+
+      // Budget so tight that at least one fragment must be compressed
+      const totalTokens = estimateTokens(oldFrag.content)
+        + estimateTokens(referencedFrag.content)
+        + estimateTokens(recentFrag.content);
+      const budget = Math.floor(totalTokens * 0.7);
+
+      const result = await service.compactContext(
+        [recentFrag, oldFrag, referencedFrag],
+        budget,
+      );
+
+      // "old" should be compressed first
+      const oldResult = result.fragments.find((f) => f.originalId === "old-1");
+      expect(oldResult?.wasCompressed).toBe(true);
+
+      // "recent" should remain uncompressed if budget allows
+      const recentResult = result.fragments.find((f) => f.originalId === "recent-1");
+      expect(recentResult?.wasCompressed).toBe(false);
+    });
+
+    it("respects priority order: protected > recent > referenced > old", async () => {
+      const priorities: FragmentPriority[] = ["protected", "recent", "referenced", "old"];
+      const fragments = priorities.map((p) =>
+        makeFragment({
+          id: `frag-${p}`,
+          content: makeLongCjkContent(100),
+          priority: p,
+          compactable: p !== "protected",
+        }),
+      );
+
+      // Very tight budget — forces maximum compression
+      const budget = estimateTokens(fragments[0].content) + 10;
+      const result = await service.compactContext(fragments, budget);
+
+      // Protected fragment must never be compressed
+      const protectedResult = result.fragments.find((f) => f.originalId === "frag-protected");
+      expect(protectedResult?.wasCompressed).toBe(false);
+    });
+
+    it("stops compressing once total tokens are within budget", async () => {
+      const fragments = Array.from({ length: 5 }, (_, i) =>
+        makeFragment({
+          id: `frag-${i}`,
+          content: makeLongCjkContent(100),
+          priority: "old",
+          compactable: true,
+        }),
+      );
+
+      // Set budget to fit 4 fragments uncompressed — only 1 needs compression
+      const singleTokens = estimateTokens(fragments[0].content);
+      const budget = singleTokens * 4 + Math.floor(singleTokens * 0.3);
+
+      const result = await service.compactContext(fragments, budget);
+      expect(result.totalTokens).toBeLessThanOrEqual(budget);
+      // At least one compressed, but not all
+      expect(result.compressedCount).toBeGreaterThanOrEqual(1);
+      expect(result.compressedCount).toBeLessThan(5);
+    });
+  });
+
+  // ─── Protection rules (INV-5) ─────────────────────────────────
+
+  describe("protection rules (INV-5)", () => {
+    it("never compresses fragments with compactable: false", async () => {
+      const protectedFrag = makeFragment({
+        id: "protected-kg",
+        content: makeLongCjkContent(300),
+        priority: "old",
+        compactable: false,
+      });
+      const compactableFrag = makeFragment({
+        id: "compactable-1",
+        content: makeLongCjkContent(300),
+        priority: "old",
+        compactable: true,
+      });
+
+      // Budget so tight both fragments can't fit
+      const totalTokens = estimateTokens(protectedFrag.content) + estimateTokens(compactableFrag.content);
+      const budget = Math.floor(totalTokens * 0.6);
+
+      const result = await service.compactContext([protectedFrag, compactableFrag], budget);
+
+      const protResult = result.fragments.find((f) => f.originalId === "protected-kg");
+      expect(protResult?.wasCompressed).toBe(false);
+      expect(protResult?.content).toBe(protectedFrag.content);
+    });
+
+    it("preserves KG entity definitions (sourceType: kg-entity)", async () => {
+      const kgFrag = makeFragment({
+        id: "kg-entity-1",
+        content: "林远：男，28岁，前刑警，性格冷硬。擅长推理和格斗。",
+        priority: "referenced",
+        compactable: false,
+        metadata: { sourceType: "kg-entity", entityId: "entity-lingyuan" },
+      });
+      const regularFrag = makeFragment({
+        id: "regular-1",
+        content: makeLongCjkContent(300),
+        priority: "old",
+        compactable: true,
+      });
+
+      const budget = estimateTokens(kgFrag.content) + 20;
+      const result = await service.compactContext([kgFrag, regularFrag], budget);
+
+      const kgResult = result.fragments.find((f) => f.originalId === "kg-entity-1");
+      expect(kgResult?.wasCompressed).toBe(false);
+      expect(kgResult?.content).toBe(kgFrag.content);
+      expect(result.protectedCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("preserves unresolved foreshadowing entities", async () => {
+      const foreshadowFrag = makeFragment({
+        id: "foreshadow-1",
+        content: "林远口袋中有一封未拆的信件，来自一个自称'观察者'的人。",
+        priority: "referenced",
+        compactable: false,
+        metadata: { sourceType: "foreshadowing" },
+      });
+
+      const budget = estimateTokens(foreshadowFrag.content) + 5;
+      const result = await service.compactContext([foreshadowFrag], budget);
+
+      expect(result.fragments[0].wasCompressed).toBe(false);
+    });
+
+    it("preserves world rules (magic system, laws, physics)", async () => {
+      const worldRuleFrag = makeFragment({
+        id: "world-rule-1",
+        content: "魔法体系：元素分为五行（金木水火土），每个法师只能掌握一种元素。",
+        priority: "referenced",
+        compactable: false,
+        metadata: { sourceType: "world-rule" },
+      });
+
+      const budget = estimateTokens(worldRuleFrag.content) + 5;
+      const result = await service.compactContext([worldRuleFrag], budget);
+
+      expect(result.fragments[0].wasCompressed).toBe(false);
+      expect(result.fragments[0].content).toBe(worldRuleFrag.content);
+    });
+
+    it("preserves user-marked important paragraphs", async () => {
+      const userMarkedFrag = makeFragment({
+        id: "user-marked-1",
+        content: "这段话非常重要，是整个故事的转折点。",
+        priority: "referenced",
+        compactable: false,
+        metadata: { sourceType: "user-marked" },
+      });
+
+      const budget = estimateTokens(userMarkedFrag.content) + 5;
+      const result = await service.compactContext([userMarkedFrag], budget);
+
+      expect(result.fragments[0].wasCompressed).toBe(false);
+    });
+  });
+
+  // ─── Budget enforcement ───────────────────────────────────────
+
+  describe("budget enforcement", () => {
+    it("returns all fragments uncompressed when already within budget", async () => {
+      const fragments = [
+        makeFragment({ id: "a", content: "短文本", compactable: true }),
+        makeFragment({ id: "b", content: "另一段短文本", compactable: true }),
+      ];
+
+      const totalTokens = fragments.reduce(
+        (sum, f) => sum + estimateTokens(f.content), 0,
+      );
+      const budget = totalTokens + 100;
+
+      const result = await service.compactContext(fragments, budget);
+
+      expect(result.compressedCount).toBe(0);
+      expect(result.totalTokens).toBeLessThanOrEqual(budget);
+      expect(mockSkill.invoke).not.toHaveBeenCalled();
+    });
+
+    it("returns empty result for empty fragments array", async () => {
+      const result = await service.compactContext([], 1000);
+
+      expect(result.fragments).toHaveLength(0);
+      expect(result.totalTokens).toBe(0);
+      expect(result.compressedCount).toBe(0);
+    });
+
+    it("compresses until total fits within budget", async () => {
+      const fragments = Array.from({ length: 3 }, (_, i) =>
+        makeFragment({
+          id: `f-${i}`,
+          content: makeLongCjkContent(200),
+          priority: "old",
+          compactable: true,
+        }),
+      );
+
+      const singleTokens = estimateTokens(fragments[0].content);
+      // Budget fits ~1.5 fragments worth
+      const budget = Math.floor(singleTokens * 1.5);
+
+      const result = await service.compactContext(fragments, budget);
+
+      expect(result.totalTokens).toBeLessThanOrEqual(budget);
+      expect(result.compressedCount).toBeGreaterThan(0);
+    });
+
+    it("handles the case where protected fragments alone exceed budget", async () => {
+      const protectedFrag = makeFragment({
+        id: "big-protected",
+        content: makeLongCjkContent(500),
+        priority: "protected",
+        compactable: false,
+      });
+
+      // Budget smaller than the protected fragment
+      const protectedTokens = estimateTokens(protectedFrag.content);
+      const budget = Math.floor(protectedTokens * 0.5);
+
+      const result = await service.compactContext([protectedFrag], budget);
+
+      // Protected fragments are always kept, even if over budget
+      expect(result.fragments).toHaveLength(1);
+      expect(result.fragments[0].wasCompressed).toBe(false);
+      expect(result.totalTokens).toBeGreaterThan(budget);
+    });
+  });
+
+  // ─── Cache behavior ───────────────────────────────────────────
+
+  describe("cache", () => {
+    it("returns cached summary for identical content", async () => {
+      const content = makeLongCjkContent(200);
+      const fragments1 = [
+        makeFragment({ id: "f1", content, priority: "old", compactable: true }),
+      ];
+      const fragments2 = [
+        makeFragment({ id: "f2", content, priority: "old", compactable: true }),
+      ];
+
+      // Budget forces compression
+      const budget = Math.floor(estimateTokens(content) * 0.3);
+
+      await service.compactContext(fragments1, budget);
+      const callCountAfterFirst = mockSkill.invoke.mock.calls.length;
+
+      await service.compactContext(fragments2, budget);
+      const callCountAfterSecond = mockSkill.invoke.mock.calls.length;
+
+      // Second call should NOT invoke Skill again — cache hit
+      expect(callCountAfterSecond).toBe(callCountAfterFirst);
+
+      const stats = service.getCacheStats();
+      expect(stats.hits).toBeGreaterThanOrEqual(1);
+    });
+
+    it("does NOT cache-hit when content differs", async () => {
+      const frag1 = makeFragment({
+        id: "f1",
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const frag2 = makeFragment({
+        id: "f2",
+        content: makeLongCjkContent(200) + "不同的结尾",
+        priority: "old",
+        compactable: true,
+      });
+
+      const budget = 20;
+
+      await service.compactContext([frag1], budget);
+      await service.compactContext([frag2], budget);
+
+      expect(mockSkill.invoke).toHaveBeenCalledTimes(2);
+    });
+
+    it("clearCache resets the cache", async () => {
+      const content = makeLongCjkContent(200);
+      const budget = 20;
+
+      await service.compactContext(
+        [makeFragment({ content, priority: "old", compactable: true })],
+        budget,
+      );
+
+      service.clearCache();
+      const stats = service.getCacheStats();
+      expect(stats.size).toBe(0);
+
+      await service.compactContext(
+        [makeFragment({ content, priority: "old", compactable: true })],
+        budget,
+      );
+
+      // Should invoke skill again after cache clear
+      expect(mockSkill.invoke).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── CJK token counting (INV-3) ──────────────────────────────
+
+  describe("CJK token counting (INV-3)", () => {
+    it("estimates CJK tokens at ~1.5 tokens/char", () => {
+      const cjkText = "这是中文测试";  // 6 CJK chars
+      const tokens = estimateTokens(cjkText);
+      // 6 chars × 1.5 = 9 tokens
+      expect(tokens).toBe(9);
+    });
+
+    it("estimates ASCII tokens at ~0.25 tokens/byte", () => {
+      const asciiText = "test"; // 4 bytes
+      const tokens = estimateTokens(asciiText);
+      // 4 bytes × 0.25 = 1 token
+      expect(tokens).toBe(1);
+    });
+
+    it("handles mixed CJK + ASCII content correctly", () => {
+      const mixed = "Hello世界"; // "Hello" = 5 bytes × 0.25 = 1.25, "世界" = 2 × 1.5 = 3 → ceil(4.25) = 5
+      const tokens = estimateTokens(mixed);
+      expect(tokens).toBeGreaterThan(0);
+      // Must not use UTF8_BYTES / 4 approximation
+      const utf8Bytes = new TextEncoder().encode(mixed).length;
+      const naiveEstimate = Math.ceil(utf8Bytes / 4);
+      // CJK-aware estimate should be higher than naive for CJK-heavy text
+      expect(tokens).toBeGreaterThanOrEqual(naiveEstimate);
+    });
+
+    it("uses CJK-aware estimation for budget decisions in compactContext", async () => {
+      const cjkContent = makeLongCjkContent(100);
+      const fragment = makeFragment({
+        content: cjkContent,
+        priority: "old",
+        compactable: true,
+      });
+
+      const cjkTokens = estimateTokens(cjkContent);
+      // Budget just under the CJK token count — must trigger compression
+      const budget = cjkTokens - 10;
+
+      const result = await service.compactContext([fragment], budget);
+      expect(result.compressedCount).toBe(1);
+    });
+  });
+
+  // ─── INV-6 compliance (Skill system) ──────────────────────────
+
+  describe("INV-6 compliance (Skill invocation)", () => {
+    it("calls Skill with builtin:auto-compact skill ID", async () => {
+      const fragment = makeFragment({
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await service.compactContext([fragment], budget);
+
+      expect(mockSkill.invoke).toHaveBeenCalled();
+      const callArgs = mockSkill.invoke.mock.calls[0][0];
+      expect(callArgs.skillId).toBe(BUILTIN_AUTO_COMPACT_SKILL_ID);
+    });
+
+    it("passes fragment content as Skill input", async () => {
+      const content = makeLongCjkContent(200);
+      const fragment = makeFragment({
+        content,
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await service.compactContext([fragment], budget);
+
+      const callArgs = mockSkill.invoke.mock.calls[0][0];
+      expect(callArgs.input).toContain(content);
+    });
+
+    it("never makes bare LLM calls outside Skill system", async () => {
+      const fragments = Array.from({ length: 3 }, (_, i) =>
+        makeFragment({
+          id: `f-${i}`,
+          content: makeLongCjkContent(200),
+          priority: "old",
+          compactable: true,
+        }),
+      );
+      const budget = 20;
+
+      await service.compactContext(fragments, budget);
+
+      // Every LLM interaction must go through skillInvoker.invoke
+      // The service has no other LLM integration point
+      expect(mockSkill.invoke).toHaveBeenCalled();
+      for (const call of mockSkill.invoke.mock.calls) {
+        expect(call[0].skillId).toBe(BUILTIN_AUTO_COMPACT_SKILL_ID);
+      }
+    });
+  });
+
+  // ─── INV-9 logging (cost tracking) ────────────────────────────
+
+  describe("INV-9 logging (cost tracking)", () => {
+    it("records usage via costTracker for each compression", async () => {
+      const fragment = makeFragment({
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await service.compactContext([fragment], budget);
+
+      expect(mockCost.recordUsage).toHaveBeenCalled();
+      const callArgs = mockCost.recordUsage.mock.calls[0];
+      // recordUsage(usage, modelId, requestId, skillId)
+      expect(callArgs[3]).toBe(BUILTIN_AUTO_COMPACT_SKILL_ID);
+    });
+
+    it("passes correct token counts to costTracker", async () => {
+      mockSkill.invoke.mockResolvedValueOnce({
+        output: "短摘要",
+        usage: { promptTokens: 150, completionTokens: 40 },
+        model: "gpt-4o",
+        requestId: "req-001",
+      });
+
+      const fragment = makeFragment({
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await service.compactContext([fragment], budget);
+
+      expect(mockCost.recordUsage).toHaveBeenCalledWith(
+        { promptTokens: 150, completionTokens: 40 },
+        "gpt-4o",
+        "req-001",
+        BUILTIN_AUTO_COMPACT_SKILL_ID,
+      );
+    });
+
+    it("does NOT record usage for cache hits", async () => {
+      const content = makeLongCjkContent(200);
+      const budget = 20;
+
+      await service.compactContext(
+        [makeFragment({ content, priority: "old", compactable: true })],
+        budget,
+      );
+      mockCost.recordUsage.mockClear();
+
+      await service.compactContext(
+        [makeFragment({ content, priority: "old", compactable: true })],
+        budget,
+      );
+
+      // No new cost recording on cache hit
+      expect(mockCost.recordUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Compression results ──────────────────────────────────────
+
+  describe("compression results", () => {
+    it("retains reference pointer for compressed fragments", async () => {
+      const fragment = makeFragment({
+        id: "expandable-1",
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      const result = await service.compactContext([fragment], budget);
+
+      const compressed = result.fragments.find((f) => f.originalId === "expandable-1");
+      expect(compressed?.wasCompressed).toBe(true);
+      expect(compressed?.referencePointer).toBeDefined();
+      expect(compressed?.referencePointer).toContain("expandable-1");
+    });
+
+    it("reports correct compression ratio", async () => {
+      const fragments = Array.from({ length: 3 }, (_, i) =>
+        makeFragment({
+          id: `f-${i}`,
+          content: makeLongCjkContent(200),
+          priority: "old",
+          compactable: true,
+        }),
+      );
+      const budget = 50;
+
+      const result = await service.compactContext(fragments, budget);
+
+      expect(result.compressionRatio).toBeGreaterThan(0);
+      expect(result.compressionRatio).toBeLessThanOrEqual(1);
+      expect(result.originalTotalTokens).toBeGreaterThan(result.totalTokens);
+    });
+
+    it("does not write back to original document", async () => {
+      const originalContent = makeLongCjkContent(200);
+      const fragment = makeFragment({
+        id: "no-writeback",
+        content: originalContent,
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await service.compactContext([fragment], budget);
+
+      // Original fragment's content must remain unchanged
+      expect(fragment.content).toBe(originalContent);
+    });
+  });
+
+  // ─── Error handling ───────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("propagates Skill invocation errors", async () => {
+      mockSkill.invoke.mockRejectedValueOnce(new Error("Skill execution failed"));
+
+      const fragment = makeFragment({
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await expect(
+        service.compactContext([fragment], budget),
+      ).rejects.toThrow("Skill execution failed");
+    });
+
+    it("throws after dispose", async () => {
+      service.dispose();
+
+      await expect(
+        service.compactContext([makeFragment()], 1000),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ─── Config options ───────────────────────────────────────────
+
+  describe("config options", () => {
+    it("respects custom cacheMaxSize", async () => {
+      const smallCacheService = createNarrativeCompactService({
+        skillInvoker: mockSkill,
+        costTracker: mockCost,
+        cacheMaxSize: 2,
+      });
+
+      const budget = 20;
+      // Fill cache with 3 different contents
+      for (let i = 0; i < 3; i++) {
+        await smallCacheService.compactContext(
+          [makeFragment({
+            content: makeLongCjkContent(200) + `unique-${i}`,
+            priority: "old",
+            compactable: true,
+          })],
+          budget,
+        );
+      }
+
+      const stats = smallCacheService.getCacheStats();
+      expect(stats.size).toBeLessThanOrEqual(2);
+
+      smallCacheService.dispose();
+    });
+
+    it("uses custom defaultModel in Skill invocation", async () => {
+      const customModelService = createNarrativeCompactService({
+        skillInvoker: mockSkill,
+        costTracker: mockCost,
+        defaultModel: "claude-sonnet-4",
+      });
+
+      const fragment = makeFragment({
+        content: makeLongCjkContent(200),
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      await customModelService.compactContext([fragment], budget);
+
+      const callArgs = mockSkill.invoke.mock.calls[0][0];
+      expect(callArgs.model).toBe("claude-sonnet-4");
+
+      customModelService.dispose();
+    });
+  });
+});

--- a/apps/desktop/main/src/services/ai/compact/__tests__/narrativeCompact.test.ts
+++ b/apps/desktop/main/src/services/ai/compact/__tests__/narrativeCompact.test.ts
@@ -18,6 +18,7 @@ import { estimateTokens } from "@shared/tokenBudget";
 
 import {
   createNarrativeCompactService,
+  isProtectedFragment,
   type NarrativeCompactService,
   type ContextFragment,
   type FragmentPriority,
@@ -727,6 +728,320 @@ describe("NarrativeCompactService", () => {
       expect(callArgs.model).toBe("claude-sonnet-4");
 
       customModelService.dispose();
+    });
+  });
+
+  // ─── R1 Finding 1: Fail-closed protection ────────────────────
+  //     isProtectedFragment must guard against misconfigured
+  //     compactable: true on protected sourceTypes.
+
+  describe("fail-closed protection (R1 Finding 1)", () => {
+    it("isProtectedFragment returns true for compactable:false", () => {
+      const frag = makeFragment({ compactable: false, priority: "old" });
+      expect(isProtectedFragment(frag)).toBe(true);
+    });
+
+    it("isProtectedFragment returns true for priority:protected even if compactable:true", () => {
+      const frag = makeFragment({ compactable: true, priority: "protected" });
+      expect(isProtectedFragment(frag)).toBe(true);
+    });
+
+    it("isProtectedFragment returns true for kg-entity sourceType even if compactable:true", () => {
+      const frag = makeFragment({
+        compactable: true,
+        priority: "old",
+        metadata: { sourceType: "kg-entity" },
+      });
+      expect(isProtectedFragment(frag)).toBe(true);
+    });
+
+    it("isProtectedFragment returns true for all protected sourceTypes", () => {
+      const protectedTypes = [
+        "kg-entity",
+        "character-setting",
+        "foreshadowing",
+        "world-rule",
+        "user-marked",
+      ] as const;
+
+      for (const sourceType of protectedTypes) {
+        const frag = makeFragment({
+          compactable: true,
+          priority: "old",
+          metadata: { sourceType },
+        });
+        expect(isProtectedFragment(frag)).toBe(true);
+      }
+    });
+
+    it("isProtectedFragment returns false for conversation sourceType with compactable:true", () => {
+      const frag = makeFragment({
+        compactable: true,
+        priority: "old",
+        metadata: { sourceType: "conversation" },
+      });
+      expect(isProtectedFragment(frag)).toBe(false);
+    });
+
+    it("isProtectedFragment returns false for document-excerpt sourceType with compactable:true", () => {
+      const frag = makeFragment({
+        compactable: true,
+        priority: "old",
+        metadata: { sourceType: "document-excerpt" },
+      });
+      expect(isProtectedFragment(frag)).toBe(false);
+    });
+
+    it("never compresses kg-entity even when compactable:true (misconfigured)", async () => {
+      const kgFrag = makeFragment({
+        id: "kg-misconfigured",
+        content: makeLongCjkContent(300),
+        priority: "old",
+        compactable: true, // BUG in caller — but we must still protect
+        metadata: { sourceType: "kg-entity", entityId: "entity-123" },
+      });
+      const regularFrag = makeFragment({
+        id: "regular-ok",
+        content: makeLongCjkContent(300),
+        priority: "old",
+        compactable: true,
+        metadata: { sourceType: "conversation" },
+      });
+
+      // Budget so tight that at least one must be compressed
+      const totalTokens = estimateTokens(kgFrag.content) + estimateTokens(regularFrag.content);
+      const budget = Math.floor(totalTokens * 0.6);
+
+      const result = await service.compactContext([kgFrag, regularFrag], budget);
+
+      // kg-entity must NOT be compressed even with compactable:true
+      const kgResult = result.fragments.find((f) => f.originalId === "kg-misconfigured");
+      expect(kgResult?.wasCompressed).toBe(false);
+      expect(kgResult?.content).toBe(kgFrag.content);
+
+      // regular fragment should be compressed instead
+      const regularResult = result.fragments.find((f) => f.originalId === "regular-ok");
+      expect(regularResult?.wasCompressed).toBe(true);
+
+      // protectedCount must reflect the fail-closed check
+      expect(result.protectedCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("counts protectedCount using fail-closed logic (not just compactable flag)", async () => {
+      const fragments = [
+        makeFragment({
+          id: "foreshadow-misconfig",
+          content: makeLongCjkContent(100),
+          priority: "old",
+          compactable: true,
+          metadata: { sourceType: "foreshadowing" },
+        }),
+        makeFragment({
+          id: "world-rule-misconfig",
+          content: makeLongCjkContent(100),
+          priority: "old",
+          compactable: true,
+          metadata: { sourceType: "world-rule" },
+        }),
+        makeFragment({
+          id: "regular",
+          content: makeLongCjkContent(100),
+          priority: "old",
+          compactable: true,
+          metadata: { sourceType: "conversation" },
+        }),
+      ];
+
+      // Budget so tight compression is attempted
+      const totalTokens = fragments.reduce(
+        (sum, f) => sum + estimateTokens(f.content), 0,
+      );
+      const budget = Math.floor(totalTokens * 0.5);
+
+      const result = await service.compactContext(fragments, budget);
+
+      // 2 fragments have protected sourceTypes even though compactable is true
+      expect(result.protectedCount).toBe(2);
+    });
+  });
+
+  // ─── R1 Finding 2: Inflight dedup ────────────────────────────
+  //     Concurrent compactContext calls for the same content must
+  //     share a single Skill invocation.
+
+  describe("inflight dedup (R1 Finding 2)", () => {
+    it("concurrent calls for same content trigger only one Skill invocation", async () => {
+      const content = makeLongCjkContent(200);
+      const budget = 20;
+
+      // Launch two compactContext calls concurrently with the same content
+      const [result1, result2] = await Promise.all([
+        service.compactContext(
+          [makeFragment({ id: "dup-a", content, priority: "old", compactable: true })],
+          budget,
+        ),
+        service.compactContext(
+          [makeFragment({ id: "dup-b", content, priority: "old", compactable: true })],
+          budget,
+        ),
+      ]);
+
+      // Only 1 Skill invocation for both calls
+      expect(mockSkill.invoke).toHaveBeenCalledTimes(1);
+
+      // Both got a compressed result
+      expect(result1.compressedCount).toBe(1);
+      expect(result2.compressedCount).toBe(1);
+    });
+
+    it("inflight map is cleaned up after completion (allows new calls)", async () => {
+      const content = makeLongCjkContent(200);
+      const budget = 20;
+
+      // First call
+      await service.compactContext(
+        [makeFragment({ id: "seq-1", content, priority: "old", compactable: true })],
+        budget,
+      );
+
+      // Clear cache so second call can't use it
+      service.clearCache();
+      mockSkill.invoke.mockClear();
+
+      // Second call — inflight should be cleaned up, so this is a new call
+      await service.compactContext(
+        [makeFragment({ id: "seq-2", content, priority: "old", compactable: true })],
+        budget,
+      );
+
+      // Since cache was cleared, a new Skill call must happen
+      expect(mockSkill.invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it("inflight map is cleaned up even after Skill error", async () => {
+      const content = makeLongCjkContent(200);
+      const budget = 20;
+
+      // First call fails
+      mockSkill.invoke.mockRejectedValueOnce(new Error("LLM timeout"));
+
+      await expect(
+        service.compactContext(
+          [makeFragment({ id: "err-1", content, priority: "old", compactable: true })],
+          budget,
+        ),
+      ).rejects.toThrow("LLM timeout");
+
+      // Second call should work normally (inflight cleaned up via finally)
+      mockSkill.invoke.mockImplementationOnce(async (args: { input: string }) => ({
+        output: args.input.slice(0, 10),
+        usage: { promptTokens: 100, completionTokens: 10 },
+        model: "gpt-4o",
+        requestId: "req-retry",
+      }));
+
+      const result = await service.compactContext(
+        [makeFragment({ id: "err-2", content, priority: "old", compactable: true })],
+        budget,
+      );
+
+      expect(result.compressedCount).toBe(1);
+    });
+  });
+
+  // ─── R1 Finding 3: Token-accurate summary truncation ─────────
+  //     Summary truncation must use trimUtf8ToTokenBudget (token-level)
+  //     rather than character-ratio slice.
+
+  describe("token-accurate summary truncation (R1 Finding 3)", () => {
+    it("truncates verbose LLM summary to token budget using trimUtf8ToTokenBudget", async () => {
+      // LLM returns a summary that is way too long (100% of input)
+      const originalContent = makeLongCjkContent(200);
+      const verboseSummary = makeLongCjkContent(200); // same length as input
+
+      mockSkill.invoke.mockResolvedValueOnce({
+        output: verboseSummary,
+        usage: { promptTokens: 300, completionTokens: 300 },
+        model: "gpt-4o",
+        requestId: "req-verbose",
+      });
+
+      const fragment = makeFragment({
+        id: "verbose-test",
+        content: originalContent,
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      const result = await service.compactContext([fragment], budget);
+
+      const compressed = result.fragments.find((f) => f.originalId === "verbose-test");
+      expect(compressed?.wasCompressed).toBe(true);
+
+      // Summary tokens must be at or below maxSummaryRatio (0.3) of original
+      const originalTokens = estimateTokens(originalContent);
+      const maxAllowed = Math.ceil(originalTokens * 0.3);
+      expect(compressed!.tokenCount).toBeLessThanOrEqual(maxAllowed);
+    });
+
+    it("mixed CJK/ASCII summary is trimmed to correct token count", async () => {
+      // Create content with mixed CJK/ASCII
+      const originalContent = "Hello世界 " + makeLongCjkContent(200);
+      // Return a summary with mixed CJK/ASCII that exceeds the 30% ratio
+      const mixedSummary = "Summary摘要 " + "测试".repeat(100) + " test data " + "验证".repeat(50);
+
+      mockSkill.invoke.mockResolvedValueOnce({
+        output: mixedSummary,
+        usage: { promptTokens: 300, completionTokens: 200 },
+        model: "gpt-4o",
+        requestId: "req-mixed",
+      });
+
+      const fragment = makeFragment({
+        id: "mixed-test",
+        content: originalContent,
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      const result = await service.compactContext([fragment], budget);
+
+      const compressed = result.fragments.find((f) => f.originalId === "mixed-test");
+      expect(compressed?.wasCompressed).toBe(true);
+
+      // The token count after truncation must respect the 30% cap
+      const originalTokens = estimateTokens(originalContent);
+      const maxAllowed = Math.ceil(originalTokens * 0.3);
+      expect(compressed!.tokenCount).toBeLessThanOrEqual(maxAllowed);
+    });
+
+    it("does not truncate summary that is already within ratio", async () => {
+      const originalContent = makeLongCjkContent(300);
+      const shortSummary = "简短摘要";  // very short — well within 30%
+
+      mockSkill.invoke.mockResolvedValueOnce({
+        output: shortSummary,
+        usage: { promptTokens: 400, completionTokens: 10 },
+        model: "gpt-4o",
+        requestId: "req-short",
+      });
+
+      const fragment = makeFragment({
+        id: "short-summary-test",
+        content: originalContent,
+        priority: "old",
+        compactable: true,
+      });
+      const budget = 20;
+
+      const result = await service.compactContext([fragment], budget);
+
+      const compressed = result.fragments.find((f) => f.originalId === "short-summary-test");
+      expect(compressed?.wasCompressed).toBe(true);
+      // Should not be truncated — the summary is already short
+      expect(compressed!.content).toBe(shortSummary);
     });
   });
 });

--- a/apps/desktop/main/src/services/ai/compact/index.ts
+++ b/apps/desktop/main/src/services/ai/compact/index.ts
@@ -13,6 +13,7 @@
 
 export {
   createNarrativeCompactService,
+  isProtectedFragment,
   BUILTIN_AUTO_COMPACT_SKILL_ID,
   type NarrativeCompactService,
   type NarrativeCompactConfig,

--- a/apps/desktop/main/src/services/ai/compact/index.ts
+++ b/apps/desktop/main/src/services/ai/compact/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @module compact
+ * ## Responsibilities: narrative-aware context compression (INV-5).
+ *    Compresses low-priority context fragments to stay within token budget
+ *    while preserving KG entities, character settings, foreshadowing,
+ *    world rules, and user-marked content.
+ * ## Does not do: original document modification, bare LLM calls,
+ *    conversation history compression (see compressionEngine.ts).
+ * ## Dependency direction: Skill system (INV-6), CostTracker (INV-9),
+ *    shared/tokenBudget (INV-3).
+ * ## Invariants: INV-3, INV-5, INV-6, INV-9.
+ */
+
+export {
+  createNarrativeCompactService,
+  BUILTIN_AUTO_COMPACT_SKILL_ID,
+  type NarrativeCompactService,
+  type NarrativeCompactConfig,
+  type ContextFragment,
+  type CompactedFragment,
+  type CompactedContext,
+  type FragmentPriority,
+  type SkillInvoker,
+} from "./narrativeCompact";

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -16,7 +16,7 @@
  */
 
 import { createHash } from "crypto";
-import { estimateTokens } from "@shared/tokenBudget";
+import { estimateTokens, trimUtf8ToTokenBudget } from "@shared/tokenBudget";
 
 // ─── Constants ──────────────────────────────────────────────────────
 
@@ -154,6 +154,36 @@ const PRIORITY_WEIGHT: Record<FragmentPriority, number> = {
   old: 3,
 };
 
+// Why: these sourceTypes represent narrative-critical content that must never be
+// compressed, even if the caller accidentally sets compactable: true. Fail-closed
+// approach — if it looks protected, treat it as protected.
+const PROTECTED_SOURCE_TYPES = new Set([
+  "kg-entity",
+  "character-setting",
+  "foreshadowing",
+  "world-rule",
+  "user-marked",
+] as const);
+
+/**
+ * Fail-closed protection check: returns true if a fragment must NOT be
+ * compressed. Guards against misconfigured `compactable: true` on fragments
+ * whose sourceType or priority level implies they should be preserved.
+ *
+ * A fragment is protected if ANY of these hold:
+ *  1. `compactable === false` (explicit flag)
+ *  2. `priority === "protected"` (priority level)
+ *  3. `metadata.sourceType` is in PROTECTED_SOURCE_TYPES
+ */
+export function isProtectedFragment(frag: ContextFragment): boolean {
+  if (!frag.compactable) return true;
+  if (frag.priority === "protected") return true;
+  if (frag.metadata?.sourceType && PROTECTED_SOURCE_TYPES.has(frag.metadata.sourceType as never)) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Sort fragments by compression candidacy: lowest-priority first.
  * Within the same priority, longer fragments compress first (more token savings).
@@ -193,6 +223,9 @@ export function createNarrativeCompactService(
   } = config;
 
   const cache = new Map<string, CacheEntry>();
+  // Inflight dedup: concurrent calls for the same content share a single
+  // Skill invocation instead of racing two LLM calls (Finding 2).
+  const inflight = new Map<string, Promise<{ summary: string; summaryTokens: number; fromCache: boolean }>>();
   let cacheHits = 0;
   let cacheMisses = 0;
   let disposed = false;
@@ -213,6 +246,12 @@ export function createNarrativeCompactService(
     }
   }
 
+  /**
+   * Core compression for a single fragment. Features:
+   * - Cache hit returns immediately (no Skill call)
+   * - Inflight dedup: concurrent calls for the same content share one Promise
+   * - Token-accurate summary truncation via trimUtf8ToTokenBudget (Finding 3)
+   */
   async function compressSingleFragment(
     fragment: ContextFragment,
   ): Promise<{ summary: string; summaryTokens: number; fromCache: boolean }> {
@@ -226,47 +265,63 @@ export function createNarrativeCompactService(
       return { summary: cached.summary, summaryTokens: cached.summaryTokens, fromCache: true };
     }
 
-    cacheMisses++;
-
-    // INV-6: all LLM calls through Skill system
-    const result = await skillInvoker.invoke({
-      skillId: BUILTIN_AUTO_COMPACT_SKILL_ID,
-      input: fragment.content,
-      model: defaultModel,
-    });
-
-    let summary = result.output;
-    let summaryTokens = estimateTokens(summary);
-
-    // Enforce maxSummaryRatio: if summary exceeds the ratio, truncate it.
-    // This guards against LLM returning overly verbose summaries.
-    const originalTokens = estimateTokens(fragment.content);
-    const maxAllowedTokens = Math.ceil(originalTokens * maxSummaryRatio);
-    if (summaryTokens > maxAllowedTokens && summary.length > 0) {
-      const ratio = maxAllowedTokens / summaryTokens;
-      summary = summary.slice(0, Math.max(1, Math.floor(summary.length * ratio)));
-      summaryTokens = estimateTokens(summary);
+    // Inflight dedup: if another call is already compressing the same content,
+    // wait for it rather than firing a second LLM request (Finding 2).
+    const existing = inflight.get(hash);
+    if (existing) {
+      return existing;
     }
 
-    // INV-9: record cost
-    if (result.usage && result.requestId) {
-      costTracker.recordUsage(
-        result.usage,
-        result.model ?? defaultModel,
-        result.requestId,
-        BUILTIN_AUTO_COMPACT_SKILL_ID,
-      );
+    const work = (async () => {
+      cacheMisses++;
+
+      // INV-6: all LLM calls through Skill system
+      const result = await skillInvoker.invoke({
+        skillId: BUILTIN_AUTO_COMPACT_SKILL_ID,
+        input: fragment.content,
+        model: defaultModel,
+      });
+
+      let summary = result.output;
+      let summaryTokens = estimateTokens(summary);
+
+      // Enforce maxSummaryRatio: if summary exceeds the ratio, truncate it.
+      // Finding 3: use token-accurate trimUtf8ToTokenBudget instead of
+      // character-ratio slice so mixed CJK/ASCII text respects the token cap.
+      const originalTokens = estimateTokens(fragment.content);
+      const maxAllowedTokens = Math.ceil(originalTokens * maxSummaryRatio);
+      if (summaryTokens > maxAllowedTokens && summary.length > 0) {
+        summary = trimUtf8ToTokenBudget(summary, maxAllowedTokens);
+        summaryTokens = estimateTokens(summary);
+      }
+
+      // INV-9: record cost
+      if (result.usage && result.requestId) {
+        costTracker.recordUsage(
+          result.usage,
+          result.model ?? defaultModel,
+          result.requestId,
+          BUILTIN_AUTO_COMPACT_SKILL_ID,
+        );
+      }
+
+      // Cache the result
+      cache.set(hash, {
+        summary,
+        summaryTokens,
+        lastUsed: Date.now(),
+      });
+      evictLRU();
+
+      return { summary, summaryTokens, fromCache: false };
+    })();
+
+    inflight.set(hash, work);
+    try {
+      return await work;
+    } finally {
+      inflight.delete(hash);
     }
-
-    // Cache the result
-    cache.set(hash, {
-      summary,
-      summaryTokens,
-      lastUsed: Date.now(),
-    });
-    evictLRU();
-
-    return { summary, summaryTokens, fromCache: false };
   }
 
   const service: NarrativeCompactService = {
@@ -314,7 +369,7 @@ export function createNarrativeCompactService(
           totalTokens: originalTotalTokens,
           originalTotalTokens,
           compressedCount: 0,
-          protectedCount: fragments.filter((f) => !f.compactable).length,
+          protectedCount: fragments.filter((f) => isProtectedFragment(f)).length,
           cacheHits: 0,
           compressionRatio: 1,
         };
@@ -332,8 +387,8 @@ export function createNarrativeCompactService(
       for (const frag of compressionOrder) {
         if (currentTotal <= budgetTokens) break;
 
-        // INV-5: never compress protected content
-        if (!frag.compactable) continue;
+        // INV-5: never compress protected content (fail-closed — Finding 1)
+        if (isProtectedFragment(frag)) continue;
 
         const origTokens = fragmentTokens.get(frag.id)!;
         const { summary, summaryTokens, fromCache } = await compressSingleFragment(
@@ -376,7 +431,7 @@ export function createNarrativeCompactService(
         totalTokens,
         originalTotalTokens,
         compressedCount: compressedMap.size,
-        protectedCount: fragments.filter((f) => !f.compactable).length,
+        protectedCount: fragments.filter((f) => isProtectedFragment(f)).length,
         cacheHits: localCacheHits,
         compressionRatio: originalTotalTokens > 0 ? totalTokens / originalTotalTokens : 1,
       };

--- a/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
+++ b/apps/desktop/main/src/services/ai/compact/narrativeCompact.ts
@@ -1,0 +1,402 @@
+/**
+ * @module narrativeCompact
+ * ## Responsibilities: INV-5 AutoCompact narrative compression. When context
+ *    exceeds token budget, compress low-priority fragments into summaries
+ *    while preserving KG entities, character settings, unresolved foreshadowing,
+ *    world rules, and user-marked "important" content.
+ * ## Does not do: write compressed results back to original documents —
+ *    compression only affects context injection. Does not handle L0/L1/L2
+ *    memory layer decisions. Does not perform bare LLM calls.
+ * ## Dependency direction: Skill system (INV-6) for LLM summarization,
+ *    CostTracker (INV-9) for usage logging, shared/tokenBudget (INV-3)
+ *    for CJK-aware token estimation.
+ * ## Invariants: INV-3 (CJK token counting), INV-5 (narrative preservation),
+ *    INV-6 (all LLM calls via Skill), INV-9 (cost tracking).
+ * ## Performance: single compactContext call ≤ 10s (ARCHITECTURE.md §三).
+ */
+
+import { createHash } from "crypto";
+import { estimateTokens } from "@shared/tokenBudget";
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+export const BUILTIN_AUTO_COMPACT_SKILL_ID = "builtin:auto-compact";
+
+// Why: 0.3 matches the ≤30% summary ratio enforced by compressionEngine.ts,
+// keeping the two compression paths consistent. Raising this degrades
+// narrative quality; lowering it wastes LLM calls on too-short summaries.
+const DEFAULT_MAX_SUMMARY_RATIO = 0.3;
+
+// Why: 500 matches costTracker.ts MAX_RECORDS eviction threshold.
+// Larger caches risk unbounded memory growth in long editing sessions.
+const DEFAULT_CACHE_MAX_SIZE = 500;
+
+const DEFAULT_MODEL = "gpt-4o";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+/**
+ * Fragment priority levels, ordered from highest to lowest protection.
+ * protected: KG core entities, foreshadowing, world rules, user-marked
+ * recent: recently accessed/created content
+ * referenced: content referenced by other fragments or KG queries
+ * old: stale content, first candidate for compression
+ */
+export type FragmentPriority = "protected" | "recent" | "referenced" | "old";
+
+/**
+ * @invariant INV-5: fragments with compactable=false are NEVER compressed,
+ * regardless of priority or budget pressure.
+ */
+export interface ContextFragment {
+  id: string;
+  content: string;
+  priority: FragmentPriority;
+  /** false = protected from compression (INV-5). KG entities, foreshadowing,
+   *  world rules, and user-marked paragraphs must set this to false. */
+  compactable: boolean;
+  metadata?: {
+    sourceType?:
+      | "kg-entity"
+      | "character-setting"
+      | "foreshadowing"
+      | "world-rule"
+      | "user-marked"
+      | "conversation"
+      | "document-excerpt";
+    entityId?: string;
+    lastAccessedAt?: number;
+    referenceCount?: number;
+  };
+}
+
+export interface CompactedFragment {
+  id: string;
+  originalId: string;
+  content: string;
+  tokenCount: number;
+  wasCompressed: boolean;
+  originalTokenCount: number;
+  /** Pointer to recover the original content (expandable). Only present
+   *  when wasCompressed=true. Format: "ref:<originalId>" */
+  referencePointer?: string;
+}
+
+export interface CompactedContext {
+  fragments: CompactedFragment[];
+  totalTokens: number;
+  originalTotalTokens: number;
+  compressedCount: number;
+  protectedCount: number;
+  cacheHits: number;
+  compressionRatio: number;
+}
+
+/**
+ * @invariant INV-6: all LLM calls go through this interface.
+ * The implementation must route to the Skill system, never directly to an
+ * LLM provider.
+ */
+export interface SkillInvoker {
+  invoke(args: {
+    skillId: string;
+    input: string;
+    model?: string;
+  }): Promise<{
+    output: string;
+    usage?: { promptTokens: number; completionTokens: number };
+    model?: string;
+    requestId?: string;
+  }>;
+}
+
+/**
+ * Minimal CostTracker surface used by this module.
+ * Full interface lives in services/ai/costTracker.ts.
+ */
+interface CostTrackerLike {
+  recordUsage(
+    usage: { promptTokens: number; completionTokens: number },
+    modelId: string,
+    requestId: string,
+    skillId: string,
+  ): unknown;
+}
+
+export interface NarrativeCompactConfig {
+  skillInvoker: SkillInvoker;
+  costTracker: CostTrackerLike;
+  defaultModel?: string;
+  /** Max summary / original token ratio. Default: 0.3 */
+  maxSummaryRatio?: number;
+  /** Max cache entries before LRU eviction. Default: 500 */
+  cacheMaxSize?: number;
+}
+
+export interface NarrativeCompactService {
+  compactContext(
+    fragments: ContextFragment[],
+    budgetTokens: number,
+  ): Promise<CompactedContext>;
+  clearCache(): void;
+  getCacheStats(): { size: number; hits: number; misses: number };
+  dispose(): void;
+}
+
+// ─── Priority ordering ──────────────────────────────────────────────
+
+// Why: numeric weight makes sort deterministic. Protected = 0 means they
+// sort to the front (highest priority, last to be considered for compression).
+const PRIORITY_WEIGHT: Record<FragmentPriority, number> = {
+  protected: 0,
+  recent: 1,
+  referenced: 2,
+  old: 3,
+};
+
+/**
+ * Sort fragments by compression candidacy: lowest-priority first.
+ * Within the same priority, longer fragments compress first (more token savings).
+ */
+function sortByCompressionOrder(fragments: ContextFragment[]): ContextFragment[] {
+  return [...fragments].sort((a, b) => {
+    const weightDiff = PRIORITY_WEIGHT[b.priority] - PRIORITY_WEIGHT[a.priority];
+    if (weightDiff !== 0) return weightDiff;
+    // Longer content first within same priority (more savings)
+    return estimateTokens(b.content) - estimateTokens(a.content);
+  });
+}
+
+// ─── Cache ──────────────────────────────────────────────────────────
+
+interface CacheEntry {
+  summary: string;
+  summaryTokens: number;
+  lastUsed: number;
+}
+
+function contentHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+// ─── Implementation ─────────────────────────────────────────────────
+
+export function createNarrativeCompactService(
+  config: NarrativeCompactConfig,
+): NarrativeCompactService {
+  const {
+    skillInvoker,
+    costTracker,
+    defaultModel = DEFAULT_MODEL,
+    maxSummaryRatio = DEFAULT_MAX_SUMMARY_RATIO,
+    cacheMaxSize = DEFAULT_CACHE_MAX_SIZE,
+  } = config;
+
+  const cache = new Map<string, CacheEntry>();
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  let disposed = false;
+
+  function evictLRU(): void {
+    if (cache.size <= cacheMaxSize) return;
+
+    let oldestKey: string | undefined;
+    let oldestTime = Infinity;
+    for (const [key, entry] of cache) {
+      if (entry.lastUsed < oldestTime) {
+        oldestTime = entry.lastUsed;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
+
+  async function compressSingleFragment(
+    fragment: ContextFragment,
+  ): Promise<{ summary: string; summaryTokens: number; fromCache: boolean }> {
+    const hash = contentHash(fragment.content);
+
+    // Cache lookup
+    const cached = cache.get(hash);
+    if (cached) {
+      cached.lastUsed = Date.now();
+      cacheHits++;
+      return { summary: cached.summary, summaryTokens: cached.summaryTokens, fromCache: true };
+    }
+
+    cacheMisses++;
+
+    // INV-6: all LLM calls through Skill system
+    const result = await skillInvoker.invoke({
+      skillId: BUILTIN_AUTO_COMPACT_SKILL_ID,
+      input: fragment.content,
+      model: defaultModel,
+    });
+
+    let summary = result.output;
+    let summaryTokens = estimateTokens(summary);
+
+    // Enforce maxSummaryRatio: if summary exceeds the ratio, truncate it.
+    // This guards against LLM returning overly verbose summaries.
+    const originalTokens = estimateTokens(fragment.content);
+    const maxAllowedTokens = Math.ceil(originalTokens * maxSummaryRatio);
+    if (summaryTokens > maxAllowedTokens && summary.length > 0) {
+      const ratio = maxAllowedTokens / summaryTokens;
+      summary = summary.slice(0, Math.max(1, Math.floor(summary.length * ratio)));
+      summaryTokens = estimateTokens(summary);
+    }
+
+    // INV-9: record cost
+    if (result.usage && result.requestId) {
+      costTracker.recordUsage(
+        result.usage,
+        result.model ?? defaultModel,
+        result.requestId,
+        BUILTIN_AUTO_COMPACT_SKILL_ID,
+      );
+    }
+
+    // Cache the result
+    cache.set(hash, {
+      summary,
+      summaryTokens,
+      lastUsed: Date.now(),
+    });
+    evictLRU();
+
+    return { summary, summaryTokens, fromCache: false };
+  }
+
+  const service: NarrativeCompactService = {
+    async compactContext(
+      fragments: ContextFragment[],
+      budgetTokens: number,
+    ): Promise<CompactedContext> {
+      if (disposed) {
+        throw new Error("NarrativeCompactService has been disposed");
+      }
+
+      // Empty input
+      if (fragments.length === 0) {
+        return {
+          fragments: [],
+          totalTokens: 0,
+          originalTotalTokens: 0,
+          compressedCount: 0,
+          protectedCount: 0,
+          cacheHits: 0,
+          compressionRatio: 1,
+        };
+      }
+
+      // Pre-compute token counts for all fragments
+      const fragmentTokens = new Map<string, number>();
+      let originalTotalTokens = 0;
+      for (const frag of fragments) {
+        const tokens = estimateTokens(frag.content);
+        fragmentTokens.set(frag.id, tokens);
+        originalTotalTokens += tokens;
+      }
+
+      // If already within budget, return all uncompressed
+      if (originalTotalTokens <= budgetTokens) {
+        return {
+          fragments: fragments.map((f) => ({
+            id: `compacted-${f.id}`,
+            originalId: f.id,
+            content: f.content,
+            tokenCount: fragmentTokens.get(f.id)!,
+            wasCompressed: false,
+            originalTokenCount: fragmentTokens.get(f.id)!,
+          })),
+          totalTokens: originalTotalTokens,
+          originalTotalTokens,
+          compressedCount: 0,
+          protectedCount: fragments.filter((f) => !f.compactable).length,
+          cacheHits: 0,
+          compressionRatio: 1,
+        };
+      }
+
+      // Sort by compression candidacy: lowest-priority first
+      const compressionOrder = sortByCompressionOrder(fragments);
+
+      // Track which fragments need compression
+      const compressedMap = new Map<string, { summary: string; summaryTokens: number }>();
+      let currentTotal = originalTotalTokens;
+      let localCacheHits = 0;
+
+      // Compress starting from lowest priority until under budget
+      for (const frag of compressionOrder) {
+        if (currentTotal <= budgetTokens) break;
+
+        // INV-5: never compress protected content
+        if (!frag.compactable) continue;
+
+        const origTokens = fragmentTokens.get(frag.id)!;
+        const { summary, summaryTokens, fromCache } = await compressSingleFragment(
+          frag,
+        );
+        if (fromCache) localCacheHits++;
+
+        compressedMap.set(frag.id, { summary, summaryTokens });
+        currentTotal = currentTotal - origTokens + summaryTokens;
+      }
+
+      // Build result preserving original fragment order
+      const resultFragments: CompactedFragment[] = fragments.map((frag) => {
+        const compressed = compressedMap.get(frag.id);
+        if (compressed) {
+          return {
+            id: `compacted-${frag.id}`,
+            originalId: frag.id,
+            content: compressed.summary,
+            tokenCount: compressed.summaryTokens,
+            wasCompressed: true,
+            originalTokenCount: fragmentTokens.get(frag.id)!,
+            referencePointer: `ref:${frag.id}`,
+          };
+        }
+        return {
+          id: `compacted-${frag.id}`,
+          originalId: frag.id,
+          content: frag.content,
+          tokenCount: fragmentTokens.get(frag.id)!,
+          wasCompressed: false,
+          originalTokenCount: fragmentTokens.get(frag.id)!,
+        };
+      });
+
+      const totalTokens = resultFragments.reduce((sum, f) => sum + f.tokenCount, 0);
+
+      return {
+        fragments: resultFragments,
+        totalTokens,
+        originalTotalTokens,
+        compressedCount: compressedMap.size,
+        protectedCount: fragments.filter((f) => !f.compactable).length,
+        cacheHits: localCacheHits,
+        compressionRatio: originalTotalTokens > 0 ? totalTokens / originalTotalTokens : 1,
+      };
+    },
+
+    clearCache(): void {
+      cache.clear();
+      cacheHits = 0;
+      cacheMisses = 0;
+    },
+
+    getCacheStats(): { size: number; hits: number; misses: number } {
+      return { size: cache.size, hits: cacheHits, misses: cacheMisses };
+    },
+
+    dispose(): void {
+      disposed = true;
+      cache.clear();
+    },
+  };
+
+  return service;
+}


### PR DESCRIPTION
## Summary

Implements `NarrativeCompactService` — INV-5 compliant AutoCompact narrative compression. When context exceeds token budget, low-priority fragments are compressed into summaries while preserving protected content (KG entities, character settings, unresolved foreshadowing, world rules, user-marked paragraphs).

Closes #132

## What Changed

### New Files
- `apps/desktop/main/src/services/ai/compact/narrativeCompact.ts` — Core service implementation
- `apps/desktop/main/src/services/ai/compact/index.ts` — Module entry with exports
- `apps/desktop/main/src/services/ai/compact/__tests__/narrativeCompact.test.ts` — 46 unit tests

### Architecture
- **Priority-based compression**: Fragments sorted by priority (`protected > recent > referenced > old`), compression starts from lowest priority
- **Fail-closed protection (R1 F1)**: `isProtectedFragment()` checks `compactable` flag, `priority === "protected"`, AND `metadata.sourceType` against `PROTECTED_SOURCE_TYPES` set. Misconfigured `compactable: true` on kg-entity/foreshadowing/world-rule/character-setting/user-marked is blocked
- **Inflight dedup (R1 F2)**: `inflight Map<hash, Promise>` ensures concurrent `compactContext()` calls for the same content share a single Skill invocation. Cleaned up via `finally` block even on error
- **Token-accurate truncation (R1 F3)**: Summary truncation uses `trimUtf8ToTokenBudget()` from `@shared/tokenBudget` instead of character-ratio slice, ensuring CJK/ASCII mixed text respects the 30% token cap
- **Skill system integration**: All LLM summarization via `builtin:auto-compact` Skill (INV-6)
- **In-memory cache**: SHA-256 content hash → summary cache with LRU eviction (max 500 entries)
- **CJK-aware token counting**: Uses `@shared/tokenBudget` estimator (INV-3), no `UTF8_BYTES/4`
- **Cost tracking**: Every Skill invocation logged via `CostTracker.recordUsage()` (INV-9)
- **No writeback**: Compressed results only affect context injection, never original documents

## R1 Audit Findings Addressed

| # | Severity | Finding | Fix | Tests Added |
|---|----------|---------|-----|-------------|
| F1 | BLOCKING | Protection not fail-closed — only checks `compactable` flag | Added `isProtectedFragment()` with 3-way check (flag + priority + sourceType) | 8 tests |
| F2 | BLOCKING | No inflight dedup — concurrent calls race two LLM calls | Added `inflight Map<hash, Promise>` with `finally` cleanup | 3 tests |
| F3 | NON-BLOCKING | Summary truncation uses character ratio, not token-accurate | Replaced `String.slice()` with `trimUtf8ToTokenBudget()` | 3 tests |

## Invariant Checklist

- [x] **INV-1** — N/A (no document write operations)
- [x] **INV-2** — N/A (no concurrent tool execution; compression is sequential per-call)
- [x] **INV-3** — CJK-aware token estimation via `@shared/tokenBudget.estimateTokens()`. No `UTF8_BYTES/4`
- [x] **INV-4** — N/A (does not modify memory layers or add vector storage)
- [x] **INV-5** — ✅ Core deliverable. Fail-closed `isProtectedFragment()` ensures protected fragments never compressed even with misconfigured `compactable: true`. 13 dedicated protection tests
- [x] **INV-6** — All LLM calls via `builtin:auto-compact` Skill through `SkillInvoker` interface. No bare LLM calls. 3 dedicated compliance tests
- [x] **INV-7** — N/A (no IPC handlers added)
- [x] **INV-8** — N/A (no post-writing hooks modified)
- [x] **INV-9** — Every Skill invocation records model/tokens/cost via `CostTracker.recordUsage()`. Cache hits skip recording (no duplicate cost). 3 dedicated cost tracking tests
- [x] **INV-10** — Skill invocation errors propagated, not swallowed. Disposed service throws immediately

## Validation Evidence

```
✓ pnpm typecheck — 0 errors
✓ 46/46 tests pass (narrativeCompact.test.ts)
✓ 2668/2668 full suite tests pass (148 files, 0 regressions)
✓ Duration: 257ms (transform 79ms, tests 41ms)
✓ scripts/agent_pr_preflight.sh — passed
```

## Visual Evidence

### Embedded Screenshots

N/A(backend-only service, no UI changes)

### Storybook Artifact / Link

- Link: N/A
- Visual acceptance note: N/A

## Risk & Rollback

**Risk**: Low. This is a new, isolated module with no external dependencies or IPC registrations.

**Rollback**: Delete `apps/desktop/main/src/services/ai/compact/` directory. No other files modified, no schema changes, no IPC additions, no migration required.

## Audit Gate

- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)

- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT pending
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT pending
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT pending
