### PR TITLE
feat(INV-6): activate Skill Manifest Loader — replace hardcoded VALID_SKILL_IDS with runtime manifest registry

### DIFF
--- a/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/continue/SKILL.md
+++ b/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/continue/SKILL.md
@@ -7,6 +7,7 @@ tags: ["writing", "continue"]
 kind: single
 scope: builtin
 packageId: pkg.creonow.builtin
+inputType: document
 context_rules:
   surrounding: 1600
   user_preferences: true

--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -316,17 +316,24 @@ describe("AI IPC channel registration", () => {
   });
 
   it("启动阶段预热 Skill registry 并检查必需内置技能", () => {
-    createHarness();
+    const harness = createHarness();
     expect(mocks.createSkillServiceMock).toHaveBeenCalled();
     expect(mocks.skillListMock).toHaveBeenCalledWith({ includeDisabled: true });
+    expect(harness.logger.info).toHaveBeenCalledWith("skill_manifest_registry_loaded", {
+      count: 0,
+      skillIds: [],
+    });
     expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
       id: "builtin:polish",
     });
     expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
-      id: "builtin:chat",
+      id: "builtin:rewrite",
     });
     expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
       id: "builtin:continue",
+    });
+    expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
+      id: "builtin:chat",
     });
   });
 
@@ -345,11 +352,12 @@ describe("AI IPC channel registration", () => {
   it("预热解析内置技能失败时记录 builtin_skill_missing_on_startup 错误日志", () => {
     mocks.skillResolveForRunMock
       .mockReturnValueOnce(makeResolvedSkill("builtin:polish"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:rewrite"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"))
       .mockReturnValueOnce({
         ok: false,
         error: { code: "NOT_FOUND", message: "chat missing" },
-      })
-      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"));
+      });
     const harness = createHarness();
     expect(harness.logger.error).toHaveBeenCalledWith("builtin_skill_missing_on_startup", {
       skillId: "builtin:chat",
@@ -361,8 +369,9 @@ describe("AI IPC channel registration", () => {
   it("预热解析到 disabled skill 时记录 builtin_skill_disabled_on_startup 日志", () => {
     mocks.skillResolveForRunMock
       .mockReturnValueOnce(makeResolvedSkill("builtin:polish"))
-      .mockReturnValueOnce(makeResolvedSkill("builtin:chat", false, true))
-      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"));
+      .mockReturnValueOnce(makeResolvedSkill("builtin:rewrite"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:chat", false, true));
     const harness = createHarness();
     expect(harness.logger.info).toHaveBeenCalledWith("builtin_skill_disabled_on_startup", {
       skillId: "builtin:chat",
@@ -372,6 +381,8 @@ describe("AI IPC channel registration", () => {
   it("预热解析到 invalid skill 时记录 builtin_skill_invalid_on_startup 错误日志", () => {
     mocks.skillResolveForRunMock
       .mockReturnValueOnce(makeResolvedSkill("builtin:polish"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:rewrite"))
+      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"))
       .mockReturnValueOnce({
         ok: true,
         data: {
@@ -382,8 +393,7 @@ describe("AI IPC channel registration", () => {
             error_message: "manifest invalid",
           },
         },
-      })
-      .mockReturnValueOnce(makeResolvedSkill("builtin:continue"));
+      });
     const harness = createHarness();
     expect(harness.logger.error).toHaveBeenCalledWith("builtin_skill_invalid_on_startup", {
       skillId: "builtin:chat",

--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -319,9 +319,9 @@ describe("AI IPC channel registration", () => {
     const harness = createHarness();
     expect(mocks.createSkillServiceMock).toHaveBeenCalled();
     expect(mocks.skillListMock).toHaveBeenCalledWith({ includeDisabled: true });
-    expect(harness.logger.info).toHaveBeenCalledWith("skill_manifest_registry_loaded", {
-      count: 0,
-      skillIds: [],
+    expect(harness.logger.info).toHaveBeenCalledWith("skill_registry_warmup_loaded", {
+      validSkillCount: 0,
+      builtinValidSkillCount: 0,
     });
     expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
       id: "builtin:polish",
@@ -335,6 +335,11 @@ describe("AI IPC channel registration", () => {
     expect(mocks.skillResolveForRunMock).toHaveBeenCalledWith({
       id: "builtin:chat",
     });
+    expect(mocks.createWritingOrchestratorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        validSkillIds: [],
+      }),
+    );
   });
 
   it("预热 list 失败时记录 skill_registry_warmup_failed 错误日志", () => {

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-agentic-production-loop.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-agentic-production-loop.test.ts
@@ -77,7 +77,7 @@ function createHarness(args?: {
     userDataDir: "<test-user-data>",
     builtinSkillsDir: path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),
-      "../../../skills/packages",
+      "../../../skills",
     ),
     logger: createLogger(),
     env: {

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts
@@ -151,7 +151,7 @@ function createHarness() {
     userDataDir: "<test-user-data>",
     builtinSkillsDir: path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),
-      "../../../skills/packages",
+      "../../../skills",
     ),
     logger: createLogger(),
     env: {

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts
@@ -125,7 +125,7 @@ function createHarness() {
     userDataDir: "<test-user-data>",
     builtinSkillsDir: path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),
-      "../../../skills/packages",
+      "../../../skills",
     ),
     logger: createLogger(),
     env: {

--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-writeback.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-writeback.test.ts
@@ -117,7 +117,7 @@ function createHarness(args?: {
     userDataDir: "<test-user-data>",
     builtinSkillsDir: path.resolve(
       path.dirname(fileURLToPath(import.meta.url)),
-      "../../../skills/packages",
+      "../../../skills",
     ),
     logger: createLogger(),
     env: {

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1476,8 +1476,9 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
   };
   // Skill IDs loaded from the real SKILL.md manifests at startup.
   // Passed to WritingOrchestrator to replace the legacy hardcoded VALID_SKILL_IDS whitelist.
-  // Empty array means fall back to the legacy list inside the orchestrator.
+  // Once the registry loads, even an empty list is authoritative and must fail closed.
   let manifestLoadedSkillIds: string[] = [];
+  let didLoadManifestRegistry = false;
   if (deps.db) {
     const startupSkillService = skillServiceFactory();
     const listed = startupSkillService.list({ includeDisabled: true });
@@ -1487,17 +1488,21 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         message: listed.error.message,
       });
     } else {
+      didLoadManifestRegistry = true;
       // Collect leaf IDs (without "builtin:" prefix) from all valid installed manifests.
-      // This replaces the hardcoded VALID_SKILL_IDS constant in orchestrator.ts (INV-6).
+      // Even an empty list must be forwarded so startup failures fail closed instead of
+      // silently reviving the legacy hardcoded whitelist.
       manifestLoadedSkillIds = listed.data.items
         .filter((item) => item.valid)
         .map((item) => {
           const parts = item.id.split(":");
           return parts[parts.length - 1] ?? item.id;
         });
-      deps.logger.info("skill_manifest_registry_loaded", {
-        count: manifestLoadedSkillIds.length,
-        skillIds: manifestLoadedSkillIds,
+      deps.logger.info("skill_registry_warmup_loaded", {
+        validSkillCount: manifestLoadedSkillIds.length,
+        builtinValidSkillCount: listed.data.items.filter(
+          (item) => item.scope === "builtin" && item.valid,
+        ).length,
       });
 
       const requiredBuiltinSkillIds = [
@@ -2042,8 +2047,8 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       };
     },
     // INV-6: Use real manifest-loaded skill IDs instead of the legacy hardcoded list.
-    // Falls back to legacy VALID_SKILL_IDS inside orchestrator when empty (e.g. no DB).
-    ...(manifestLoadedSkillIds.length > 0
+    // Only the "DB unavailable, registry never loaded" case keeps the legacy fallback.
+    ...(didLoadManifestRegistry
       ? { validSkillIds: manifestLoadedSkillIds }
       : {}),
   });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1474,6 +1474,10 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
       logger: deps.logger,
     });
   };
+  // Skill IDs loaded from the real SKILL.md manifests at startup.
+  // Passed to WritingOrchestrator to replace the legacy hardcoded VALID_SKILL_IDS whitelist.
+  // Empty array means fall back to the legacy list inside the orchestrator.
+  let manifestLoadedSkillIds: string[] = [];
   if (deps.db) {
     const startupSkillService = skillServiceFactory();
     const listed = startupSkillService.list({ includeDisabled: true });
@@ -1483,10 +1487,24 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         message: listed.error.message,
       });
     } else {
+      // Collect leaf IDs (without "builtin:" prefix) from all valid installed manifests.
+      // This replaces the hardcoded VALID_SKILL_IDS constant in orchestrator.ts (INV-6).
+      manifestLoadedSkillIds = listed.data.items
+        .filter((item) => item.valid)
+        .map((item) => {
+          const parts = item.id.split(":");
+          return parts[parts.length - 1] ?? item.id;
+        });
+      deps.logger.info("skill_manifest_registry_loaded", {
+        count: manifestLoadedSkillIds.length,
+        skillIds: manifestLoadedSkillIds,
+      });
+
       const requiredBuiltinSkillIds = [
         "builtin:polish",
-        "builtin:chat",
+        "builtin:rewrite",
         "builtin:continue",
+        "builtin:chat",
       ] as const;
       for (const skillId of requiredBuiltinSkillIds) {
         const resolved = startupSkillService.resolveForRun({ id: skillId });
@@ -2023,6 +2041,11 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         toolCalls: capturedToolCalls,
       };
     },
+    // INV-6: Use real manifest-loaded skill IDs instead of the legacy hardcoded list.
+    // Falls back to legacy VALID_SKILL_IDS inside orchestrator when empty (e.g. no DB).
+    ...(manifestLoadedSkillIds.length > 0
+      ? { validSkillIds: manifestLoadedSkillIds }
+      : {}),
   });
 
   // INV-7: 将 aiService + writingOrchestrator 包装为统一出口。

--- a/apps/desktop/main/src/services/ai/fakeAiServer.ts
+++ b/apps/desktop/main/src/services/ai/fakeAiServer.ts
@@ -155,25 +155,38 @@ function resolveFakeMode(args: {
 }
 
 /**
- * Extract the inner text from a `<text>...</text>` block if present.
+ * Extract the inner text from a tagged payload block if present.
  *
- * Why: built-in skills wrap user input in `<text>` blocks, but E2E assertions
- * want to treat the input as the "payload" (not the surrounding template).
+ * Why: builtin skills are migrating from hardcoded prompts to SKILL.md manifests.
+ * Older prompts use `<text>...</text>` while manifest-backed skills like
+ * builtin:continue already use `<input>...</input>`. The fake E2E provider must
+ * understand both forms so it echoes the intended payload instead of the entire
+ * assembled prompt/context blob.
  */
-function extractTextBlockPayload(userText: string): string | null {
-  const open = "<text>";
-  const close = "</text>";
+function extractTaggedPayload(args: {
+  userText: string;
+  tagName: "text" | "input";
+}): string | null {
+  const open = `<${args.tagName}>`;
+  const close = `</${args.tagName}>`;
 
-  const start = userText.lastIndexOf(open);
+  const start = args.userText.lastIndexOf(open);
   if (start < 0) {
     return null;
   }
-  const end = userText.indexOf(close, start + open.length);
+  const end = args.userText.indexOf(close, start + open.length);
   if (end < 0) {
     return null;
   }
 
-  return userText.slice(start + open.length, end).trim();
+  return args.userText.slice(start + open.length, end).trim();
+}
+
+function extractPromptPayload(userText: string): string | null {
+  return (
+    extractTaggedPayload({ userText, tagName: "text" }) ??
+    extractTaggedPayload({ userText, tagName: "input" })
+  );
 }
 
 /**
@@ -346,7 +359,7 @@ export async function startFakeAiServer(deps: {
     const payloadText = userText.includes("***REDACTED***")
       ? userText
       : (extractContextImmediatePayload(userText) ??
-        extractTextBlockPayload(userText) ??
+        extractPromptPayload(userText) ??
         userText);
     const resultText = `E2E_RESULT: ${payloadText}`.trim();
 

--- a/apps/desktop/main/src/services/skills/__tests__/skill-manifest-loader.smoke.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/skill-manifest-loader.smoke.test.ts
@@ -1,0 +1,385 @@
+/**
+ * P1-04 Smoke Test: Skill Manifest Loader
+ *
+ * Verifies that:
+ *   1. The SkillService can load real SKILL.md manifests from builtinSkillsDir
+ *   2. Core skills (rewrite, polish, continue) are resolvable and have valid prompts
+ *   3. The manifest-loaded skill IDs are compatible with the WritingOrchestrator's
+ *      validSkillIds config — i.e., `orchestrator.execute({ skillId: 'builtin:rewrite' })`
+ *      proceeds past validation without "Unknown skill" error
+ *   4. The SkillRegistry correctly rejects truly unknown skill IDs
+ *
+ * INV-6: All Skill operations must go through the Skill pipeline (not bare LLM).
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { createSkillService } from "../skillService";
+import {
+  createWritingOrchestrator,
+  type OrchestratorConfig,
+  type WritingRequest,
+  type WritingEvent,
+} from "../orchestrator";
+import { createToolRegistry } from "../toolRegistry";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function createNoopLogger() {
+  return {
+    logPath: "" as const,
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE projects (
+      project_id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      root_path TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'novel',
+      description TEXT NOT NULL DEFAULT '',
+      stage TEXT NOT NULL DEFAULT 'outline',
+      target_word_count INTEGER,
+      target_chapter_count INTEGER,
+      narrative_person TEXT NOT NULL DEFAULT 'first',
+      language_style TEXT NOT NULL DEFAULT '',
+      target_audience TEXT NOT NULL DEFAULT '',
+      default_skill_set_id TEXT,
+      knowledge_graph_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      archived_at INTEGER
+    );
+    CREATE TABLE documents (
+      document_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'chapter',
+      title TEXT NOT NULL,
+      content_json TEXT NOT NULL,
+      content_text TEXT NOT NULL,
+      content_md TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft',
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      parent_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      cover_image_url TEXT,
+      FOREIGN KEY(project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+    );
+    CREATE TABLE settings (
+      scope TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value_json TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (scope, key)
+    );
+    CREATE TABLE skills (
+      skill_id TEXT PRIMARY KEY,
+      enabled INTEGER NOT NULL,
+      valid INTEGER NOT NULL,
+      error_code TEXT,
+      error_message TEXT,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE custom_skills (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      prompt_template TEXT NOT NULL,
+      input_type TEXT NOT NULL,
+      context_rules TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      project_id TEXT,
+      enabled INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  return db;
+}
+
+/**
+ * Write a minimal SKILL.md manifest into the given builtinSkillsDir.
+ */
+function writeSkillManifest(args: {
+  builtinSkillsDir: string;
+  skillName: string;
+  skillId: string;
+  inputType?: "selection" | "document";
+}): void {
+  const filePath = path.join(
+    args.builtinSkillsDir,
+    "packages",
+    "pkg.creonow.builtin",
+    "1.0.0",
+    "skills",
+    args.skillName,
+    "SKILL.md",
+  );
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `---
+id: ${args.skillId}
+name: ${args.skillName}
+description: Smoke test skill
+version: "1.0.0"
+tags: ["test"]
+kind: single
+scope: builtin
+packageId: pkg.creonow.builtin
+context_rules:
+  surrounding: 500
+  user_preferences: true
+  style_guide: false
+  characters: false
+  outline: false
+  recent_summary: 0
+  knowledge_graph: false
+prompt:
+  system: |
+    You are a writing assistant.
+  user: |
+    Process the following text.
+
+    {{input}}
+---
+
+# ${args.skillId}
+`,
+    "utf8",
+  );
+}
+
+/** Collect all events from an async generator. */
+async function collectEvents(gen: AsyncGenerator<WritingEvent>): Promise<WritingEvent[]> {
+  const events: WritingEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Build an OrchestratorConfig with mocked AI + permission + tools. */
+function buildOrchestratorConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  const toolRegistry = createToolRegistry();
+  toolRegistry.register({
+    name: "documentRead",
+    description: "Read document text",
+    isConcurrencySafe: true,
+    execute: vi.fn().mockResolvedValue({ success: true, data: "text" }),
+  });
+  toolRegistry.register({
+    name: "documentWrite",
+    description: "Write text to document",
+    isConcurrencySafe: false,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "snap-001" } }),
+  });
+  toolRegistry.register({
+    name: "versionSnapshot",
+    description: "Create version snapshot",
+    isConcurrencySafe: false,
+    execute: vi.fn().mockResolvedValue({ success: true, data: { versionId: "snap-pre-001" } }),
+  });
+
+  return {
+    aiService: {
+      async *streamChat(_messages, options) {
+        options.onApiCallStarted?.();
+        yield { delta: "result text", finishReason: "stop", accumulatedTokens: 2 };
+        options.onComplete({ content: "result text", usage: { promptTokens: 5, completionTokens: 2, totalTokens: 7, cachedTokens: 0 }, wasRetried: false });
+      },
+      estimateTokens: (text: string) => Math.ceil(text.length / 4),
+      abort: vi.fn(),
+    },
+    toolRegistry,
+    permissionGate: {
+      confirmTimeoutMs: 120_000,
+      evaluate: vi.fn().mockResolvedValue({ level: "preview-confirm", granted: true }),
+      requestPermission: vi.fn().mockResolvedValue(true),
+      releasePendingPermission: vi.fn(),
+    },
+    postWritingHooks: [],
+    defaultTimeoutMs: 30_000,
+    ...overrides,
+  };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("P1-04 Skill Manifest Loader — smoke", () => {
+  let tmpDir: string;
+  let builtinSkillsDir: string;
+  let userDataDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "creonow-manifest-smoke-"));
+    builtinSkillsDir = path.join(tmpDir, "builtin-skills");
+    userDataDir = path.join(tmpDir, "user-data");
+    fs.mkdirSync(builtinSkillsDir, { recursive: true });
+    fs.mkdirSync(userDataDir, { recursive: true });
+  });
+
+  it("SMK-01: skillService.list() returns all installed SKILL.md manifests", () => {
+    // Write 3 manifests
+    writeSkillManifest({ builtinSkillsDir, skillName: "rewrite", skillId: "builtin:rewrite" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "polish", skillId: "builtin:polish" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "continue", skillId: "builtin:continue", inputType: "document" });
+
+    const db = createTestDb();
+    const svc = createSkillService({ db, userDataDir, builtinSkillsDir, logger: createNoopLogger() });
+
+    const listed = svc.list({ includeDisabled: false });
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+
+    const ids = listed.data.items.map((i) => i.id);
+    expect(ids).toContain("builtin:rewrite");
+    expect(ids).toContain("builtin:polish");
+    expect(ids).toContain("builtin:continue");
+  });
+
+  it("SMK-02: resolveForRun returns valid skill with prompt for rewrite/polish/continue", () => {
+    writeSkillManifest({ builtinSkillsDir, skillName: "rewrite", skillId: "builtin:rewrite" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "polish", skillId: "builtin:polish" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "continue", skillId: "builtin:continue", inputType: "document" });
+
+    const db = createTestDb();
+    const svc = createSkillService({ db, userDataDir, builtinSkillsDir, logger: createNoopLogger() });
+
+    for (const skillId of ["builtin:rewrite", "builtin:polish", "builtin:continue"]) {
+      const resolved = svc.resolveForRun({ id: skillId });
+      expect(resolved.ok, `${skillId} resolveForRun should succeed`).toBe(true);
+      if (!resolved.ok) continue;
+      expect(resolved.data.skill.valid, `${skillId} should be valid`).toBe(true);
+      expect(resolved.data.skill.prompt?.system.length, `${skillId} should have system prompt`).toBeGreaterThan(0);
+      expect(resolved.data.skill.prompt?.user.length, `${skillId} should have user prompt`).toBeGreaterThan(0);
+    }
+  });
+
+  it("SMK-03: WritingOrchestrator with manifest-loaded validSkillIds accepts rewrite/polish/continue", async () => {
+    writeSkillManifest({ builtinSkillsDir, skillName: "rewrite", skillId: "builtin:rewrite" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "polish", skillId: "builtin:polish" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "continue", skillId: "builtin:continue", inputType: "document" });
+
+    const db = createTestDb();
+    const svc = createSkillService({ db, userDataDir, builtinSkillsDir, logger: createNoopLogger() });
+    const listed = svc.list({ includeDisabled: false });
+    assert(listed.ok, "list must succeed");
+
+    // Simulate what ai.ts does: extract leaf IDs from manifests
+    const validSkillIds = listed.data.items
+      .filter((item) => item.valid)
+      .map((item) => {
+        const parts = item.id.split(":");
+        return parts[parts.length - 1] ?? item.id;
+      });
+
+    expect(validSkillIds).toContain("rewrite");
+    expect(validSkillIds).toContain("polish");
+    expect(validSkillIds).toContain("continue");
+
+    // Verify the orchestrator accepts these skill IDs
+    const orchestrator = createWritingOrchestrator(
+      buildOrchestratorConfig({ validSkillIds }),
+    );
+
+    const request: WritingRequest = {
+      requestId: "test-req-001",
+      skillId: "builtin:rewrite",
+      documentId: "doc-001",
+      input: { selectedText: "Some text to rewrite." },
+      selection: { from: 0, to: 21, text: "Some text to rewrite.", selectionTextHash: "abc" },
+    };
+
+    const events = await collectEvents(orchestrator.execute(request));
+    const errorEvent = events.find((e) => e.type === "error");
+
+    // Should NOT have SKILL_INPUT_INVALID — rewrite is now accepted
+    if (errorEvent) {
+      const err = (errorEvent as unknown as { error: { code: string } }).error;
+      expect(err.code).not.toBe("SKILL_INPUT_INVALID");
+    }
+    expect(events.some((e) => e.type === "intent-resolved")).toBe(true);
+
+    orchestrator.dispose();
+  });
+
+  it("SMK-04: WritingOrchestrator still rejects truly unknown skill IDs", async () => {
+    writeSkillManifest({ builtinSkillsDir, skillName: "rewrite", skillId: "builtin:rewrite" });
+
+    const db = createTestDb();
+    const svc = createSkillService({ db, userDataDir, builtinSkillsDir, logger: createNoopLogger() });
+    const listed = svc.list({ includeDisabled: false });
+    assert(listed.ok, "list must succeed");
+
+    const validSkillIds = listed.data.items
+      .filter((item) => item.valid)
+      .map((item) => {
+        const parts = item.id.split(":");
+        return parts[parts.length - 1] ?? item.id;
+      });
+
+    const orchestrator = createWritingOrchestrator(
+      buildOrchestratorConfig({ validSkillIds }),
+    );
+
+    const request: WritingRequest = {
+      requestId: "test-req-002",
+      skillId: "nonexistent-skill",
+      documentId: "doc-001",
+      input: { selectedText: "text" },
+    };
+
+    const events = await collectEvents(orchestrator.execute(request));
+    const errorEvent = events.find((e) => e.type === "error");
+
+    expect(errorEvent).toBeDefined();
+    const err = (errorEvent as unknown as { error: { code: string } }).error;
+    expect(err.code).toBe("SKILL_INPUT_INVALID");
+
+    orchestrator.dispose();
+  });
+
+  it("SMK-05: manifest-loaded IDs include skills beyond the legacy VALID_SKILL_IDS whitelist", () => {
+    // Write manifests for skills that were NOT in the old hardcoded list
+    writeSkillManifest({ builtinSkillsDir, skillName: "brainstorm", skillId: "builtin:brainstorm" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "chat", skillId: "builtin:chat" });
+    writeSkillManifest({ builtinSkillsDir, skillName: "shrink", skillId: "builtin:shrink" });
+
+    const db = createTestDb();
+    const svc = createSkillService({ db, userDataDir, builtinSkillsDir, logger: createNoopLogger() });
+    const listed = svc.list({ includeDisabled: false });
+    assert(listed.ok, "list must succeed");
+
+    // Verify all 3 are discovered (regardless of validity — discovery correctness is what matters here)
+    const discoveredIds = listed.data.items.map((i) => i.id);
+    expect(discoveredIds).toContain("builtin:brainstorm");
+    expect(discoveredIds).toContain("builtin:chat");
+    expect(discoveredIds).toContain("builtin:shrink");
+
+    const validSkillIds = listed.data.items
+      .filter((item) => item.valid)
+      .map((item) => {
+        const parts = item.id.split(":");
+        return parts[parts.length - 1] ?? item.id;
+      });
+
+    // All three should be present in the runtime-loaded list (all use valid minimal manifests)
+    expect(validSkillIds).toContain("brainstorm");
+    expect(validSkillIds).toContain("chat");
+    expect(validSkillIds).toContain("shrink");
+  });
+});

--- a/apps/desktop/main/src/services/skills/__tests__/skill-manifest-loader.smoke.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/skill-manifest-loader.smoke.test.ts
@@ -140,6 +140,7 @@ tags: ["test"]
 kind: single
 scope: builtin
 packageId: pkg.creonow.builtin
+inputType: ${args.inputType ?? "selection"}
 context_rules:
   surrounding: 500
   user_preferences: true
@@ -266,6 +267,9 @@ describe("P1-04 Skill Manifest Loader — smoke", () => {
       expect(resolved.data.skill.valid, `${skillId} should be valid`).toBe(true);
       expect(resolved.data.skill.prompt?.system.length, `${skillId} should have system prompt`).toBeGreaterThan(0);
       expect(resolved.data.skill.prompt?.user.length, `${skillId} should have user prompt`).toBeGreaterThan(0);
+      if (skillId === "builtin:continue") {
+        expect(resolved.data.inputType).toBe("document");
+      }
     }
   });
 
@@ -313,6 +317,30 @@ describe("P1-04 Skill Manifest Loader — smoke", () => {
       expect(err.code).not.toBe("SKILL_INPUT_INVALID");
     }
     expect(events.some((e) => e.type === "intent-resolved")).toBe(true);
+
+    orchestrator.dispose();
+  });
+
+  it("SMK-03b: empty manifest-loaded validSkillIds fails closed instead of reviving the legacy whitelist", async () => {
+    const orchestrator = createWritingOrchestrator(
+      buildOrchestratorConfig({ validSkillIds: [] }),
+    );
+
+    const request: WritingRequest = {
+      requestId: "test-req-empty-registry",
+      skillId: "builtin:rewrite",
+      documentId: "doc-001",
+      input: { selectedText: "Some text to rewrite." },
+      selection: { from: 0, to: 21, text: "Some text to rewrite.", selectionTextHash: "abc" },
+    };
+
+    const events = await collectEvents(orchestrator.execute(request));
+    const errorEvent = events.find((e) => e.type === "error");
+
+    expect(errorEvent).toBeDefined();
+    const err = (errorEvent as unknown as { error: { code: string } }).error;
+    expect(err.code).toBe("SKILL_INPUT_INVALID");
+    expect(events.some((e) => e.type === "intent-resolved")).toBe(false);
 
     orchestrator.dispose();
   });

--- a/apps/desktop/main/src/services/skills/orchestrator.ts
+++ b/apps/desktop/main/src/services/skills/orchestrator.ts
@@ -216,6 +216,17 @@ export interface OrchestratorConfig {
     /** P2: tool calls requested by the AI when finishReason === 'tool_use' */
     toolCalls?: ToolCallInfo[];
   }>;
+  /**
+   * Set of valid skill leaf IDs (without "builtin:" prefix) that this orchestrator accepts.
+   *
+   * Why: replacing the hardcoded VALID_SKILL_IDS constant with a configurable list
+   * allows the real skill manifest registry to drive validation at runtime instead of
+   * a static whitelist that drifts from the actual installed manifests (INV-6).
+   *
+   * When omitted, the orchestrator falls back to the legacy static VALID_SKILL_IDS list
+   * for backward compatibility.
+   */
+  validSkillIds?: readonly string[];
 }
 
 export interface WritingOrchestrator {
@@ -317,8 +328,10 @@ export function createWritingOrchestrator(
 
       return (async function* () {
       try {
-        // Validate skillId
-        if (!VALID_SKILL_IDS.includes(normalizeSkillId(request.skillId))) {
+        // Validate skillId: prefer the runtime-configured list (loaded from real manifests)
+        // over the legacy static whitelist. VALID_SKILL_IDS is the backward-compat fallback.
+        const allowedSkillIds = config.validSkillIds ?? VALID_SKILL_IDS;
+        if (!allowedSkillIds.includes(normalizeSkillId(request.skillId))) {
           taskStates.set(requestId, "failed");
           yield makeEvent("error", requestId, {
             error: {


### PR DESCRIPTION
## Summary

Replace the hardcoded VALID_SKILL_IDS constant in WritingOrchestrator with a runtime `validSkillIds` registry sourced from real `SKILL.md` manifests at startup.

This update also closes the fail-open hole discovered during audit and aligns the manifest-backed builtin E2E path with the real runtime contract:
- once the startup registry loads, even an empty valid-skill list is authoritative and fails closed instead of silently reviving the legacy whitelist;
- startup logging records warmup counts, not the full skill ID payload;
- manifest smoke fixtures emit `inputType` and assert the continue skill resolves as document input;
- IPC E2E harnesses now point at the real builtin skill root, fake AI payload extraction accepts both legacy `<text>` and manifest-backed `<input>` wrappers, and the builtin `continue` manifest declares `inputType: document`.

Closes #152

## Changes

- `apps/desktop/main/src/services/skills/orchestrator.ts`: `OrchestratorConfig` accepts runtime `validSkillIds`; runtime validation prefers manifest-derived IDs over the legacy static whitelist.
- `apps/desktop/main/src/ipc/ai.ts`: startup warmup derives valid skill IDs from `skillService.list()` and forwards the registry to the orchestrator even when empty so runtime validation fails closed once the registry is loaded.
- `apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts`: update required builtin warmup assertions; assert startup warmup logs and orchestrator config reflect the runtime registry.
- `apps/desktop/main/src/services/skills/__tests__/skill-manifest-loader.smoke.test.ts`: manifest smoke fixtures now emit `inputType`; add regression coverage for the empty-registry fail-closed path.
- `apps/desktop/main/src/ipc/__tests__/ai-skill-agentic-production-loop.test.ts`: point builtin skill discovery at the real builtin skills root.
- `apps/desktop/main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts`: point builtin skill discovery at the real builtin skills root.
- `apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts`: point builtin skill discovery at the real builtin skills root.
- `apps/desktop/main/src/ipc/__tests__/ai-skill-orchestrator-writeback.test.ts`: point builtin skill discovery at the real builtin skills root.
- `apps/desktop/main/src/services/ai/fakeAiServer.ts`: treat both `<text>` and `<input>` wrappers as the prompt payload during E2E assertions so manifest-backed skills echo the intended user payload instead of the full assembled prompt.
- `apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/continue/SKILL.md`: declare `inputType: document` to keep builtin continue aligned with cursor/document semantics.

## Invariant Checklist

- [x] INV-1 原稿保护: Not affected (no write operations in this PR)
- [x] INV-2 并发安全: Not affected
- [x] INV-3 CJK Token: Not affected
- [x] INV-4 Memory-First: Not affected
- [x] INV-5 叙事压缩: Not affected
- [x] INV-6 一切皆 Skill: runtime skill validation is now driven by the loaded manifest registry and fails closed when that registry is empty
- [x] INV-7 统一入口: maintained; IPC still routes through `skillOrchestrator.execute()` and only changes startup warmup wiring / manifest-backed runtime validation
- [x] INV-8 Hook 链: Not affected
- [x] INV-9 成本追踪: Not affected
- [x] INV-10 错误不丢上下文: startup warmup still emits structured missing/disabled/invalid diagnostics

## Validation Evidence

- `pnpm --filter @creonow/desktop test -- main/src/ipc/__tests__/ai-handlers-delegation.test.ts main/src/services/skills/__tests__/skill-manifest-loader.smoke.test.ts main/src/ipc/__tests__/ai-skill-cost-tracking.integration.test.ts main/src/ipc/__tests__/ai-skill-agentic-production-loop.test.ts main/src/ipc/__tests__/ai-skill-orchestrator-writeback.test.ts main/src/ipc/__tests__/ai-skill-orchestrator-cursor-propagation.test.ts`
  Result: 6 files, 60 tests passed.
- `pnpm --filter @creonow/desktop typecheck`
  Result: pass.
- `bash scripts/agent_pr_preflight.sh`
  Result: pass.
- `pnpm test:unit`
  Result: attempted locally, but execution stalls in `apps/desktop/main/src/services/ai/__tests__/quota-rate-limit-guard.test.ts`, an unchanged code path outside this diff; rely on required CI `check` for the full-suite verdict.

### Embedded Screenshots

N/A

### Storybook Artifact / Link

- Link: N/A
- Visual acceptance note: N/A

## Visual Evidence

N/A. Backend-only change; no renderer diff.

## Risk & Rollback

- Risk: Low to medium. Change scope is still localized to startup registry warmup, manifest-backed runtime validation, builtin manifest metadata, and E2E harness alignment.
- Rollback point: revert commit `d0944c6` (and `beaa463` / `49a7dd2` if a full PR rollback is required).

## Audit Gate

- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)
- [x] 审计 1（Claude Opus 4.6）：FINAL-VERDICT ACCEPT on commit `d0944c6`
- [x] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT ACCEPT on commit `d0944c6`
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT waived in-thread; checklist entry retained for repo preflight compatibility
- [ ] Required checks green on latest head
