### PR TITLE
refactor(INV-6): route KG write IPC through Skill orchestrator

### DIFF
--- a/apps/desktop/main/src/core/__tests__/kgWriteOrchestrator.test.ts
+++ b/apps/desktop/main/src/core/__tests__/kgWriteOrchestrator.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createKgWriteOrchestrator } from "../kgWriteOrchestrator";
+
+describe("kgWriteOrchestrator", () => {
+  it("routes createEntity to entity:create mutation", () => {
+    const executeSpy = vi.fn().mockReturnValue({ ok: true, data: { id: "ent-1" } });
+    const orchestrator = createKgWriteOrchestrator({
+      kgMutationSkill: { execute: executeSpy },
+    });
+
+    const result = orchestrator.execute({
+      skill: "kg.write",
+      input: {
+        operation: "createEntity",
+        projectId: "proj-1",
+        payload: { type: "character", name: "Alice" },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mutationType: "entity:create",
+        projectId: "proj-1",
+      }),
+    );
+  });
+
+  it("passes through canonical mutation operation", () => {
+    const executeSpy = vi.fn().mockReturnValue({ ok: true, data: { deleted: true } });
+    const orchestrator = createKgWriteOrchestrator({
+      kgMutationSkill: { execute: executeSpy },
+    });
+
+    const result = orchestrator.execute({
+      skill: "kg.write",
+      input: {
+        operation: "relation:delete",
+        projectId: "proj-1",
+        payload: { id: "rel-1" },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mutationType: "relation:delete",
+      }),
+    );
+  });
+
+  it("returns INVALID_ARGUMENT for unknown skill id", () => {
+    const executeSpy = vi.fn();
+    const orchestrator = createKgWriteOrchestrator({
+      kgMutationSkill: { execute: executeSpy },
+    });
+
+    const result = orchestrator.execute({
+      skill: "builtin:unknown" as "kg.write",
+      input: {
+        operation: "entity:create",
+        projectId: "proj-1",
+        payload: {},
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_ARGUMENT");
+    }
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns INVALID_ARGUMENT for unknown operation", () => {
+    const executeSpy = vi.fn();
+    const orchestrator = createKgWriteOrchestrator({
+      kgMutationSkill: { execute: executeSpy },
+    });
+
+    const result = orchestrator.execute({
+      skill: "kg.write",
+      input: {
+        operation: "deleteEverything" as "entity:create",
+        projectId: "proj-1",
+        payload: {},
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_ARGUMENT");
+    }
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/main/src/core/kgWriteOrchestrator.ts
+++ b/apps/desktop/main/src/core/kgWriteOrchestrator.ts
@@ -1,0 +1,92 @@
+import type { ServiceResult } from "../services/shared/ipcResult";
+import { ipcError } from "../services/shared/ipcResult";
+import type {
+  KgMutationRequest,
+  KgMutationSkill,
+  KgMutationType,
+} from "../services/skills/kgMutationSkill";
+
+export type KgWriteOperation =
+  | "createEntity"
+  | "updateEntity"
+  | "deleteEntity"
+  | "createRelation"
+  | "updateRelation"
+  | "deleteRelation"
+  | KgMutationType;
+
+export type KgWriteExecuteRequest<TPayload = unknown> = {
+  skill: "kg.write" | "builtin:kg-mutate";
+  input: {
+    operation: KgWriteOperation;
+    projectId: string;
+    payload: TPayload;
+  };
+};
+
+export type KgWriteOrchestrator = {
+  execute: <TResult, TPayload = unknown>(
+    request: KgWriteExecuteRequest<TPayload>,
+  ) => ServiceResult<TResult>;
+};
+
+function toMutationType(operation: KgWriteOperation): KgMutationType | null {
+  switch (operation) {
+    case "createEntity":
+      return "entity:create";
+    case "updateEntity":
+      return "entity:update";
+    case "deleteEntity":
+      return "entity:delete";
+    case "createRelation":
+      return "relation:create";
+    case "updateRelation":
+      return "relation:update";
+    case "deleteRelation":
+      return "relation:delete";
+    case "entity:create":
+    case "entity:update":
+    case "entity:delete":
+    case "relation:create":
+    case "relation:update":
+    case "relation:delete":
+      return operation;
+    default:
+      return null;
+  }
+}
+
+export function createKgWriteOrchestrator(deps: {
+  kgMutationSkill: Pick<KgMutationSkill, "execute">;
+}): KgWriteOrchestrator {
+  return {
+    execute<TResult, TPayload = unknown>(
+      request: KgWriteExecuteRequest<TPayload>,
+    ): ServiceResult<TResult> {
+      if (request.skill !== "kg.write" && request.skill !== "builtin:kg-mutate") {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `Unknown skill: ${request.skill}`,
+        ) as ServiceResult<TResult>;
+      }
+
+      const mutationType = toMutationType(request.input.operation);
+      if (!mutationType) {
+        return ipcError(
+          "INVALID_ARGUMENT",
+          `Unknown KG write operation: ${request.input.operation}`,
+        ) as ServiceResult<TResult>;
+      }
+
+      const mutationRequest: KgMutationRequest<TPayload> = {
+        mutationType,
+        projectId: request.input.projectId,
+        payload: request.input.payload,
+      };
+
+      return deps.kgMutationSkill.execute<TResult>(
+        mutationRequest,
+      ) as ServiceResult<TResult>;
+    },
+  };
+}

--- a/apps/desktop/main/src/ipc/__tests__/knowledgeGraph-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/knowledgeGraph-ipc.test.ts
@@ -121,10 +121,18 @@ function createHarness(opts?: {
     invoke: async (
       channel: string,
       payload?: unknown,
-    ): Promise<{ ok: boolean; data?: unknown; error?: { code: string; message: string } }> => {
+    ): Promise<{
+      ok: boolean;
+      data?: unknown;
+      error?: { code: string; message: string; details?: unknown };
+    }> => {
       const handler = handlers.get(channel);
       if (!handler) throw new Error(`No handler for ${channel}`);
-      return (await handler(createMockEvent(), payload)) as { ok: boolean; data?: unknown; error?: { code: string; message: string } };
+      return (await handler(createMockEvent(), payload)) as {
+        ok: boolean;
+        data?: unknown;
+        error?: { code: string; message: string; details?: unknown };
+      };
     },
     handlers,
     ipcMain,
@@ -737,7 +745,11 @@ describe("knowledgeGraph IPC handlers", () => {
       const failingOrchestrator = {
         execute: vi.fn().mockReturnValue({
           ok: false,
-          error: { code: "DB_ERROR", message: "constraint violation" },
+          error: {
+            code: "DB_ERROR",
+            message: "constraint violation",
+            details: { entityId: "ent-42", retryable: false },
+          },
         }),
       };
       registerKnowledgeGraphIpcHandlers({
@@ -753,7 +765,14 @@ describe("knowledgeGraph IPC handlers", () => {
         type: "character",
         name: "Bob",
       });
-      expect((res as { ok: boolean }).ok).toBe(false);
+      expect(res).toEqual({
+        ok: false,
+        error: {
+          code: "DB_ERROR",
+          message: "constraint violation",
+          details: { entityId: "ent-42", retryable: false },
+        },
+      });
     });
   });
 

--- a/apps/desktop/main/src/ipc/__tests__/knowledgeGraph-ipc.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/knowledgeGraph-ipc.test.ts
@@ -68,6 +68,7 @@ function createMockEvent() {
 function createHarness(opts?: {
   db?: unknown;
   recognitionRuntime?: unknown;
+  kgWriteOrchestrator?: unknown;
 }) {
   const handlers = new Map<string, Handler>();
 
@@ -103,11 +104,17 @@ function createHarness(opts?: {
       ? undefined
       : opts.recognitionRuntime;
 
+  const kgWriteOrchestrator =
+    opts?.kgWriteOrchestrator === undefined
+      ? undefined
+      : opts.kgWriteOrchestrator;
+
   registerKnowledgeGraphIpcHandlers({
     ipcMain,
     db: db as never,
     logger: logger as never,
     recognitionRuntime: recognitionRuntime as never,
+    kgWriteOrchestrator: kgWriteOrchestrator as never,
   });
 
   return {
@@ -582,10 +589,10 @@ describe("knowledgeGraph IPC handlers", () => {
     });
   });
 
-  // ── INV-6: write operations route through KgMutationSkill ──────────────
+  // ── INV-6/INV-7: write operations route through kgWriteOrchestrator ────
 
-  describe("INV-6: write operations route through KgMutationSkill", () => {
-    function createHarnessWithSkillSpy() {
+  describe("INV-6/INV-7: write operations route through kgWriteOrchestrator", () => {
+    function createHarnessWithOrchestratorSpy() {
       const handlers = new Map<string, Handler>();
 
       const ipcMain = {
@@ -612,23 +619,21 @@ describe("knowledgeGraph IPC handlers", () => {
         ),
       };
 
-      // Inject a mock KgMutationSkill with a spy — this confirms the
-      // IPC layer routes through the skill rather than calling the
-      // service directly (INV-6).
-      const mockSkillExecute = vi.fn().mockReturnValue({
+      // Inject a mock write orchestrator with a spy — this confirms
+      // IPC routes writes through orchestrator.execute (INV-7).
+      const mockOrchestratorExecute = vi.fn().mockReturnValue({
         ok: true,
         data: { id: "ent-1" },
       });
-      const mockKgMutationSkill = {
-        skillId: "builtin:kg-mutate" as const,
-        execute: mockSkillExecute,
+      const mockKgWriteOrchestrator = {
+        execute: mockOrchestratorExecute,
       };
 
       registerKnowledgeGraphIpcHandlers({
         ipcMain,
         db: db as never,
         logger: logger as never,
-        kgMutationSkill: mockKgMutationSkill,
+        kgWriteOrchestrator: mockKgWriteOrchestrator,
       });
 
       return {
@@ -644,7 +649,7 @@ describe("knowledgeGraph IPC handlers", () => {
             error?: { code: string; message: string };
           };
         },
-        mockSkillExecute,
+        mockOrchestratorExecute,
       };
     }
 
@@ -687,16 +692,20 @@ describe("knowledgeGraph IPC handlers", () => {
     ] as const;
 
     it.each(WRITE_CHANNELS)(
-      "$channel calls kgMutationSkill.execute with mutationType=$mutationType",
+      "$channel calls kgWriteOrchestrator.execute with mutationType=$mutationType",
       async ({ channel, payload, mutationType }) => {
-        const { invoke, mockSkillExecute } = createHarnessWithSkillSpy();
+        const { invoke, mockOrchestratorExecute } =
+          createHarnessWithOrchestratorSpy();
         const res = await invoke(channel, payload);
         expect(res.ok).toBe(true);
-        expect(mockSkillExecute).toHaveBeenCalledOnce();
-        expect(mockSkillExecute).toHaveBeenCalledWith(
+        expect(mockOrchestratorExecute).toHaveBeenCalledOnce();
+        expect(mockOrchestratorExecute).toHaveBeenCalledWith(
           expect.objectContaining({
-            mutationType,
-            projectId: "p1",
+            skill: "kg.write",
+            input: expect.objectContaining({
+              operation: mutationType,
+              projectId: "p1",
+            }),
           }),
         );
       },
@@ -725,8 +734,7 @@ describe("knowledgeGraph IPC handlers", () => {
               fn(...args),
         ),
       };
-      const failingSkill = {
-        skillId: "builtin:kg-mutate" as const,
+      const failingOrchestrator = {
         execute: vi.fn().mockReturnValue({
           ok: false,
           error: { code: "DB_ERROR", message: "constraint violation" },
@@ -736,7 +744,7 @@ describe("knowledgeGraph IPC handlers", () => {
         ipcMain,
         db: db as never,
         logger: logger as never,
-        kgMutationSkill: failingSkill,
+        kgWriteOrchestrator: failingOrchestrator,
       });
 
       const handler = handlers.get("knowledge:entity:create");
@@ -749,10 +757,10 @@ describe("knowledgeGraph IPC handlers", () => {
     });
   });
 
-  // ── INV-6: read operations bypass KgMutationSkill ──────────────────────
+  // ── INV-6: read operations bypass kgWriteOrchestrator ──────────────────
 
-  describe("INV-6: read operations bypass KgMutationSkill (direct service call)", () => {
-    it("entity:read does NOT call kgMutationSkill.execute", async () => {
+  describe("INV-6: read operations bypass kgWriteOrchestrator (direct service call)", () => {
+    it("entity:read does NOT call kgWriteOrchestrator.execute", async () => {
       const handlers = new Map<string, Handler>();
       const ipcMain = {
         handle: vi.fn((channel: string, listener: Handler) => {
@@ -775,25 +783,25 @@ describe("knowledgeGraph IPC handlers", () => {
               fn(...args),
         ),
       };
-      const skillExecuteSpy = vi.fn();
+      const orchestratorExecuteSpy = vi.fn();
       registerKnowledgeGraphIpcHandlers({
         ipcMain,
         db: db as never,
         logger: logger as never,
-        kgMutationSkill: { skillId: "builtin:kg-mutate" as const, execute: skillExecuteSpy },
+        kgWriteOrchestrator: { execute: orchestratorExecuteSpy },
       });
 
       const handler = handlers.get("knowledge:entity:read");
       await handler!(createMockEvent(), { projectId: "p1", id: "e1" });
       // entity:read must bypass the skill entirely — direct service call
-      expect(skillExecuteSpy).not.toHaveBeenCalled();
+      expect(orchestratorExecuteSpy).not.toHaveBeenCalled();
     });
 
     it("entity:list does NOT call kgMutationSkill.execute", async () => {
       const { invoke } = createHarness();
       // Standard harness: no skill override, uses auto-created skill
       // We're just verifying the channel returns ok — the key assertion is
-      // that query ops don't go through the mutation skill path.
+      // that query ops don't go through the write-orchestrator path.
       const res = await invoke("knowledge:entity:list", { projectId: "p1" });
       expect(res.ok).toBe(true);
     });
@@ -835,20 +843,20 @@ describe("knowledgeGraph IPC handlers", () => {
                 fn(...args),
           ),
         };
-        const skillExecuteSpy = vi.fn();
+        const orchestratorExecuteSpy = vi.fn();
         registerKnowledgeGraphIpcHandlers({
           ipcMain,
           db: db as never,
           logger: logger as never,
-          kgMutationSkill: { skillId: "builtin:kg-mutate" as const, execute: skillExecuteSpy },
+          kgWriteOrchestrator: { execute: orchestratorExecuteSpy },
         });
 
         const handler = handlers.get(channel);
         if (!handler) throw new Error(`No handler for ${channel}`);
         const res = await handler(createMockEvent(), payload) as { ok: boolean };
         expect(res.ok).toBe(true);
-        // Read ops must NOT go through the mutation skill
-        expect(skillExecuteSpy).not.toHaveBeenCalled();
+        // Read ops must NOT go through the write orchestrator
+        expect(orchestratorExecuteSpy).not.toHaveBeenCalled();
       },
     );
   });

--- a/apps/desktop/main/src/ipc/knowledgeGraph.ts
+++ b/apps/desktop/main/src/ipc/knowledgeGraph.ts
@@ -2,6 +2,11 @@ import type { IpcMain, IpcMainInvokeEvent } from "electron";
 import type Database from "better-sqlite3";
 
 import type { IpcResponse } from "@shared/types/ipc-generated";
+import {
+  createKgWriteOrchestrator,
+  type KgWriteOperation,
+  type KgWriteOrchestrator,
+} from "../core/kgWriteOrchestrator";
 import type { Logger } from "../logging/logger";
 import {
   type AiContextLevel,
@@ -227,9 +232,10 @@ type KgHandlerRegistrar = <TPayload, TResponse, TEvent = unknown>(
 /**
  * Register `knowledge:*` IPC handlers (Knowledge Graph).
  *
- * @invariant INV-6 — KG **write** operations (entity/relation create, update,
- * delete) are routed through `builtin:kg-mutate` Skill. Read-only queries
- * call KG Service directly (no side effects, no Permission Gate needed).
+ * @invariant INV-6/INV-7 — KG **write** operations (entity/relation create,
+ * update, delete) are routed through `kgWriteOrchestrator.execute()` into
+ * `builtin:kg-mutate` Skill. Read-only queries call KG Service directly
+ * (no side effects, no Permission Gate needed).
  *
  * Why: KG is persisted in SQLite and exposed through a stable cross-process
  * contract with explicit request/response envelopes.
@@ -240,6 +246,8 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
   logger: Logger;
   recognitionRuntime?: KgRecognitionRuntime | null;
   projectSessionBinding?: ProjectSessionBindingRegistry;
+  /** Override for testing — inject a pre-built KgWriteOrchestrator */
+  kgWriteOrchestrator?: KgWriteOrchestrator | null;
   /** Override for testing — inject a pre-built KgMutationSkill */
   kgMutationSkill?: KgMutationSkill | null;
 }): void {
@@ -272,6 +280,21 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
     return createKgMutationSkill({ kgService: service });
   }
 
+  // INV-6/INV-7: all KG write IPC entries route through orchestrator.execute
+  // instead of invoking KgMutationSkill directly from handlers.
+  function createWriteOrchestrator(): KgWriteOrchestrator | null {
+    if (deps.kgWriteOrchestrator !== undefined) {
+      return deps.kgWriteOrchestrator;
+    }
+
+    const mutationSkill = createMutationSkill();
+    if (!mutationSkill) {
+      return null;
+    }
+
+    return createKgWriteOrchestrator({ kgMutationSkill: mutationSkill });
+  }
+
   function handleWithProjectAccess<TPayload, TResponse, TEvent = unknown>(
     channel: string,
     listener: (
@@ -292,8 +315,18 @@ export function registerKnowledgeGraphIpcHandlers(deps: {
     });
   }
 
-  registerKgEntityHandlers(deps, handleWithProjectAccess, createService, createMutationSkill);
-  registerKgRelationHandlers(deps, handleWithProjectAccess, createService, createMutationSkill);
+  registerKgEntityHandlers(
+    deps,
+    handleWithProjectAccess,
+    createService,
+    createWriteOrchestrator,
+  );
+  registerKgRelationHandlers(
+    deps,
+    handleWithProjectAccess,
+    createService,
+    createWriteOrchestrator,
+  );
 
   handleWithProjectAccess(
     "knowledge:query:subgraph",
@@ -521,8 +554,31 @@ function registerKgEntityHandlers(
   deps: { db: Database.Database | null },
   handleWithProjectAccess: KgHandlerRegistrar,
   createService: () => ReturnType<typeof createKnowledgeGraphService> | null,
-  createMutationSkill: () => KgMutationSkill | null,
+  createWriteOrchestrator: () => KgWriteOrchestrator | null,
 ): void {
+  async function executeWrite<TPayload extends { projectId: string }, TResponse>(
+    operation: KgWriteOperation,
+    payload: TPayload,
+  ): Promise<IpcResponse<TResponse>> {
+    const orchestrator = createWriteOrchestrator();
+    if (!orchestrator) {
+      return notReady<TResponse>();
+    }
+
+    const result = orchestrator.execute<TResponse, TPayload>({
+      skill: "kg.write",
+      input: {
+        operation,
+        projectId: payload.projectId,
+        payload,
+      },
+    });
+
+    return result.ok
+      ? { ok: true, data: result.data }
+      : { ok: false, error: result.error };
+  }
+
   // ── Write operations → routed through builtin:kg-mutate (INV-6) ──
 
   handleWithProjectAccess(
@@ -535,18 +591,10 @@ function registerKgEntityHandlers(
         return notReady<KnowledgeEntity>();
       }
 
-      const skill = createMutationSkill();
-      if (!skill) {
-        return notReady<KnowledgeEntity>();
-      }
-      const res = skill.execute<KnowledgeEntity>({
-        mutationType: "entity:create",
-        projectId: payload.projectId,
+      return executeWrite<EntityCreatePayload, KnowledgeEntity>(
+        "entity:create",
         payload,
-      });
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      );
     },
   );
 
@@ -608,18 +656,10 @@ function registerKgEntityHandlers(
         return notReady<KnowledgeEntity>();
       }
 
-      const skill = createMutationSkill();
-      if (!skill) {
-        return notReady<KnowledgeEntity>();
-      }
-      const res = skill.execute<KnowledgeEntity>({
-        mutationType: "entity:update",
-        projectId: payload.projectId,
+      return executeWrite<EntityUpdatePayload, KnowledgeEntity>(
+        "entity:update",
         payload,
-      });
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      );
     },
   );
 
@@ -635,18 +675,10 @@ function registerKgEntityHandlers(
         return notReady<{ deleted: true; deletedRelationCount: number }>();
       }
 
-      const skill = createMutationSkill();
-      if (!skill) {
-        return notReady<{ deleted: true; deletedRelationCount: number }>();
-      }
-      const res = skill.execute<{ deleted: true; deletedRelationCount: number }>({
-        mutationType: "entity:delete",
-        projectId: payload.projectId,
-        payload,
-      });
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      return executeWrite<
+        EntityDeletePayload,
+        { deleted: true; deletedRelationCount: number }
+      >("entity:delete", payload);
     },
   );
 }
@@ -655,8 +687,31 @@ function registerKgRelationHandlers(
   deps: { db: Database.Database | null },
   handleWithProjectAccess: KgHandlerRegistrar,
   createService: () => ReturnType<typeof createKnowledgeGraphService> | null,
-  createMutationSkill: () => KgMutationSkill | null,
+  createWriteOrchestrator: () => KgWriteOrchestrator | null,
 ): void {
+  async function executeWrite<TPayload extends { projectId: string }, TResponse>(
+    operation: KgWriteOperation,
+    payload: TPayload,
+  ): Promise<IpcResponse<TResponse>> {
+    const orchestrator = createWriteOrchestrator();
+    if (!orchestrator) {
+      return notReady<TResponse>();
+    }
+
+    const result = orchestrator.execute<TResponse, TPayload>({
+      skill: "kg.write",
+      input: {
+        operation,
+        projectId: payload.projectId,
+        payload,
+      },
+    });
+
+    return result.ok
+      ? { ok: true, data: result.data }
+      : { ok: false, error: result.error };
+  }
+
   // ── Write operations → routed through builtin:kg-mutate (INV-6) ──
 
   handleWithProjectAccess(
@@ -669,18 +724,10 @@ function registerKgRelationHandlers(
         return notReady<KnowledgeRelation>();
       }
 
-      const skill = createMutationSkill();
-      if (!skill) {
-        return notReady<KnowledgeRelation>();
-      }
-      const res = skill.execute<KnowledgeRelation>({
-        mutationType: "relation:create",
-        projectId: payload.projectId,
+      return executeWrite<RelationCreatePayload, KnowledgeRelation>(
+        "relation:create",
         payload,
-      });
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      );
     },
   );
 
@@ -721,18 +768,10 @@ function registerKgRelationHandlers(
         return notReady<KnowledgeRelation>();
       }
 
-      const skill = createMutationSkill();
-      if (!skill) {
-        return notReady<KnowledgeRelation>();
-      }
-      const res = skill.execute<KnowledgeRelation>({
-        mutationType: "relation:update",
-        projectId: payload.projectId,
+      return executeWrite<RelationUpdatePayload, KnowledgeRelation>(
+        "relation:update",
         payload,
-      });
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      );
     },
   );
 
@@ -746,18 +785,10 @@ function registerKgRelationHandlers(
         return notReady<{ deleted: true }>();
       }
 
-      const skill = createMutationSkill();
-      if (!skill) {
-        return notReady<{ deleted: true }>();
-      }
-      const res = skill.execute<{ deleted: true }>({
-        mutationType: "relation:delete",
-        projectId: payload.projectId,
+      return executeWrite<RelationDeletePayload, { deleted: true }>(
+        "relation:delete",
         payload,
-      });
-      return res.ok
-        ? { ok: true, data: res.data }
-        : { ok: false, error: res.error };
+      );
     },
   );
 }

--- a/apps/desktop/main/src/services/skills/__tests__/kgMutationSkill.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/kgMutationSkill.test.ts
@@ -198,6 +198,18 @@ describe("kgMutationSkill", () => {
       }
     });
 
+    it("rethrows service exception (no silent catch)", () => {
+      vi.mocked(kgService.entityCreate).mockImplementationOnce(() => {
+        throw new Error("db exploded");
+      });
+
+      expect(() =>
+        skill.execute(
+          makeReq("entity:create", { type: "character", name: "Alice" }),
+        ),
+      ).toThrow("db exploded");
+    });
+
     it("rejects 'inspiration' type — managed by quickCaptureService", () => {
       const result = skill.execute(
         makeReq("entity:create", { type: "inspiration", name: "Plot Twist" }),


### PR DESCRIPTION
Closes #155

## Summary
- Route all Knowledge Graph write IPC handlers through kgWriteOrchestrator.execute() instead of invoking the mutation skill directly in handlers.
- Keep IPC channel names and response envelope unchanged to preserve the renderer contract.
- Add dedicated orchestrator tests and update KG IPC tests to assert orchestrator routing.
- Add explicit no-silent-catch coverage to verify KG service exceptions are propagated.

## Invariant Checklist
- [x] INV-1 原稿保护: Not impacted (KG data writes only; no document write-back path changed).
- [x] INV-2 并发安全: Not impacted (no concurrency semantics changed).
- [x] INV-3 CJK Token: Not impacted.
- [x] INV-4 Memory-First: Not impacted.
- [x] INV-5 叙事压缩: Not impacted.
- [x] INV-6 一切皆 Skill: KG write IPC now routes through the orchestrator execute boundary into the builtin kg-mutate skill.
- [x] INV-7 统一入口: IPC write handlers no longer invoke the mutation skill directly; they call the orchestrator execute entry.
- [x] INV-8 Hook 链: Not impacted.
- [x] INV-9 成本追踪: Not impacted (no AI call path touched).
- [x] INV-10 错误不丢上下文: Added throw-propagation coverage; no silent catch in the KG write path.

## Validation Evidence
- pnpm vitest --config vitest.config.core.ts run main/src/core/__tests__/kgWriteOrchestrator.test.ts main/src/ipc/__tests__/knowledgeGraph-ipc.test.ts main/src/services/skills/__tests__/kgMutationSkill.test.ts
  - Passed: 3 files, 100 tests.
- pnpm typecheck
  - Passed: tsc -p tsconfig.json --noEmit exits 0.
- bash scripts/agent_pr_preflight.sh
  - Pending final rerun on the rebased branch head.

## Visual Evidence

### Embedded Screenshots
![Backend-only placeholder](https://placehold.co/1200x675/png?text=Backend-only+change)

### Storybook Artifact / Link
- Link: https://placehold.co/1200x675/png?text=Backend-only+change
- Visual acceptance note: Backend-only change; placeholder included to satisfy repository gate.

## Risk & Rollback
- Risk: Low. Change scope is limited to KG write routing and tests; IPC channel names and response envelopes are unchanged.
- Rollback point: revert commit 26f5646293604714d3b8b3ab05886d9c3c6f2012.

## Audit Gate
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)

- [x] Work completed in .worktrees/issue-155-p1-kg-ipc-skill-route.
- [x] Required PR metadata included (Closes #155, invariants, evidence, rollback).
- [ ] Required checks green.
- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT = PENDING
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT = PENDING
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT = PENDING