### PR TITLE
refactor(INV-7): canonicalize skill write-back path

### DIFF
--- a/apps/desktop/main/src/services/skills/__tests__/writingTooling.canonical-writeback.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/writingTooling.canonical-writeback.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Logger } from "../../../logging/logger";
+import { computeSelectionTextHash } from "../../editor/prosemirrorSchema";
+
+const { applyCanonicalSkillWritebackMock } = vi.hoisted(() => ({
+  applyCanonicalSkillWritebackMock: vi.fn(),
+}));
+
+vi.mock("../canonicalWriteback", () => ({
+  applyCanonicalSkillWriteback: applyCanonicalSkillWritebackMock,
+}));
+
+const MIGRATIONS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../db/migrations",
+);
+
+function createLogger(): Logger {
+  return {
+    logPath: "<test>",
+    info: () => {},
+    error: () => {},
+  };
+}
+
+function applyAllMigrations(db: Database.Database): void {
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(".sql") && !file.includes("vec"))
+    .sort();
+  for (const file of files) {
+    db.exec(fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"));
+  }
+}
+
+async function createReadyContext() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applyAllMigrations(db);
+
+  const [{ createDocumentService }, { createWritingToolRegistry }] = await Promise.all([
+    import("../../documents/documentService"),
+    import("../writingTooling"),
+  ]);
+
+  const projectId = "proj-canonical";
+  db.prepare(
+    "INSERT INTO projects (project_id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+  ).run(projectId, "测试项目", "/worktree/test-root", Date.now(), Date.now());
+
+  const service = createDocumentService({ db, logger: createLogger() });
+  const created = service.create({
+    projectId,
+    title: "第一章",
+    type: "chapter",
+  });
+
+  if (!created.ok) {
+    throw new Error("failed to create document fixture");
+  }
+
+  const initialSave = service.save({
+    projectId,
+    documentId: created.data.documentId,
+    contentJson: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "原文甲乙丙丁" }],
+        },
+      ],
+    },
+    actor: "user",
+    reason: "manual-save",
+  });
+
+  if (!initialSave.ok) {
+    throw new Error("failed to seed document fixture");
+  }
+
+  const registry = createWritingToolRegistry({ db, logger: createLogger() });
+  const writeTool = registry.get("documentWrite");
+  if (!writeTool) {
+    throw new Error("documentWrite tool missing in registry");
+  }
+
+  return {
+    db,
+    projectId,
+    documentId: created.data.documentId,
+    writeTool,
+  };
+}
+
+describe("createWritingToolRegistry canonical write-back path", () => {
+  afterEach(() => {
+    applyCanonicalSkillWritebackMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("rewrite/polish selection write routes through applyCanonicalSkillWriteback", async () => {
+    applyCanonicalSkillWritebackMock.mockReturnValue({
+      ok: true,
+      data: {
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "改写后文本" }],
+            },
+          ],
+        },
+      },
+    });
+
+    const ctx = await createReadyContext();
+    try {
+      const result = await ctx.writeTool.execute({
+        projectId: ctx.projectId,
+        documentId: ctx.documentId,
+        requestId: "req-rewrite",
+        content: "改写后文本",
+        selection: {
+          from: 1,
+          to: 7,
+          text: "原文甲乙",
+          selectionTextHash: computeSelectionTextHash("原文甲乙"),
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(applyCanonicalSkillWritebackMock).toHaveBeenCalledTimes(1);
+      expect(applyCanonicalSkillWritebackMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          suggestion: "改写后文本",
+          selection: expect.objectContaining({ from: 1, to: 7 }),
+        }),
+      );
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  it("continue cursor write routes through applyCanonicalSkillWriteback", async () => {
+    applyCanonicalSkillWritebackMock.mockReturnValue({
+      ok: true,
+      data: {
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "原文甲续写乙丙丁" }],
+            },
+          ],
+        },
+      },
+    });
+
+    const ctx = await createReadyContext();
+    try {
+      const result = await ctx.writeTool.execute({
+        projectId: ctx.projectId,
+        documentId: ctx.documentId,
+        requestId: "req-continue",
+        content: "续写",
+        cursorPosition: 4,
+      });
+
+      expect(result.success).toBe(true);
+      expect(applyCanonicalSkillWritebackMock).toHaveBeenCalledTimes(1);
+      expect(applyCanonicalSkillWritebackMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          suggestion: "续写",
+          cursorPosition: 4,
+        }),
+      );
+    } finally {
+      ctx.db.close();
+    }
+  });
+});

--- a/apps/desktop/main/src/services/skills/canonicalWriteback.ts
+++ b/apps/desktop/main/src/services/skills/canonicalWriteback.ts
@@ -1,0 +1,38 @@
+import {
+  applySuggestionToSelection,
+  type SelectionWritebackResult,
+} from "./selectionWriteback";
+import {
+  appendSuggestionToDocument,
+  type DocumentWritebackResult,
+} from "./documentWriteback";
+
+export type CanonicalWritebackResult =
+  | SelectionWritebackResult
+  | DocumentWritebackResult;
+
+export function applyCanonicalSkillWriteback(args: {
+  contentJson: unknown;
+  suggestion: string;
+  selection?: {
+    from: number;
+    to: number;
+    text: string;
+    selectionTextHash: string;
+  };
+  cursorPosition?: number;
+}): CanonicalWritebackResult {
+  if (args.selection) {
+    return applySuggestionToSelection({
+      contentJson: args.contentJson,
+      selection: args.selection,
+      suggestion: args.suggestion,
+    });
+  }
+
+  return appendSuggestionToDocument({
+    contentJson: args.contentJson,
+    cursorPosition: args.cursorPosition,
+    suggestion: args.suggestion,
+  });
+}

--- a/apps/desktop/main/src/services/skills/writingTooling.ts
+++ b/apps/desktop/main/src/services/skills/writingTooling.ts
@@ -8,9 +8,8 @@ import type { KnowledgeGraphService } from "../kg/types";
 import { createMemoryService } from "../memory/memoryService";
 import type { MemoryService } from "../memory/memoryService";
 import { registerAgenticTools } from "./agenticTools";
-import { appendSuggestionToDocument } from "./documentWriteback";
+import { applyCanonicalSkillWriteback } from "./canonicalWriteback";
 import { buildTool, createToolRegistry, type ToolRegistry } from "./toolRegistry";
-import { applySuggestionToSelection } from "./selectionWriteback";
 
 type WritingToolingArgs = {
   db: Database.Database;
@@ -68,18 +67,14 @@ export function createWritingToolRegistry(args: WritingToolingArgs): ToolRegistr
           };
         }
 
-        const applied = ctx.selection
-          ? applySuggestionToSelection({
-              contentJson: parsedContent,
-              selection: ctx.selection,
-              suggestion,
-            })
-          : appendSuggestionToDocument({
-              contentJson: parsedContent,
-              cursorPosition:
-                typeof ctx.cursorPosition === "number" ? ctx.cursorPosition : undefined,
-              suggestion,
-            });
+        const applied = applyCanonicalSkillWriteback({
+          contentJson: parsedContent,
+          suggestion,
+          ...(ctx.selection ? { selection: ctx.selection } : {}),
+          ...(typeof ctx.cursorPosition === "number"
+            ? { cursorPosition: ctx.cursorPosition }
+            : {}),
+        });
         if (!applied.ok) {
           return {
             success: false,


### PR DESCRIPTION
Closes #158

## Summary
- Introduce a single canonical write-back entry `applyCanonicalSkillWriteback()` for skill output document mutation.
- Route `documentWrite` tool in `writingTooling.ts` through the canonical entry instead of branching inline between selection/document helpers.
- Keep renderer IPC contracts and orchestrator event semantics unchanged (`permission-requested`, `write-back-done`, preview/confirm flow).
- Add regression tests proving both rewrite/polish (selection write) and continue (cursor write) paths delegate into the canonical entry.

## Invariant Checklist
- [x] INV-1 原稿保护: unchanged flow (`versionSnapshot` + permission gate + write-back + commit confirmation).
- [x] INV-2 并发安全: `documentWrite` remains `isConcurrencySafe: false`.
- [x] INV-3 CJK Token: not impacted.
- [x] INV-4 Memory-First: not impacted.
- [x] INV-5 叙事压缩: not impacted.
- [x] INV-6 一切皆 Skill: write-back still executed via registered `documentWrite` tool.
- [x] INV-7 统一入口: write-back implementation now has a single canonical function entry; duplicate inline branching removed.
- [x] INV-8 Hook 链: not impacted.
- [x] INV-9 成本追踪: not impacted.
- [x] INV-10 错误不丢上下文: write-back error propagation unchanged; no silent fallback introduced.

## Validation Evidence
- Focused regression:
  - `pnpm test -- main/src/services/skills/__tests__/writingTooling.canonical-writeback.test.ts main/src/services/skills/__tests__/writingTooling.version-id.test.ts main/src/ipc/__tests__/ai-skill-orchestrator-writeback.test.ts`
  - Result: 3 files, 24 tests passed.
- Main process test suite:
  - `pnpm --filter @creonow/desktop test`
  - Result: 156 files, 2916 tests passed.
- Type check:
  - `pnpm --filter @creonow/desktop typecheck`
  - Result: pass.
- Preflight:
  - `bash scripts/agent_pr_preflight.sh`
  - Result: pass after PR body update.

## Visual Evidence
### Embedded Screenshots
- Backend-only refactor; no renderer UI diff in this PR. Template compliance screenshot (existing app state reference):

![Desktop shell reference screenshot](docs/references/visual-evidence/pr-42-workbench-shell-current-head.png)

### Storybook Artifact / Link
- Link: https://github.com/Leeky1017/CreoNow/blob/task/158-p1-skill-writeback-path/creonow-app/storybook-static/index.html
- Visual acceptance note: This PR does not modify renderer code or component visuals; Storybook link is provided for template compliance and baseline reference only.

## Risk & Rollback
- Risk: Low. Change is localized to write-back helper dispatch and adds tests only; no IPC schema or renderer behavior changes.
- Rollback point: revert commit `559b7ca`.

## Audit Gate
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)
- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT: PENDING
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT: PENDING
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT: PENDING
- [x] Work completed in `.worktrees/issue-158-p1-skill-writeback-path`.
- [x] PR includes `Closes #158`, invariant checklist, verification evidence, rollback point.
- [x] `scripts/agent_pr_preflight.sh` pass.
- [ ] Required checks green.
