### PR TITLE
fix(INV-10): preserve orchestrator error semantics in ai:skill:run IPC

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
@@ -219,4 +219,70 @@ describe("ai:skill:run selection contract", () => {
       }),
     );
   });
+
+  it("propagates structured orchestrator error through IPC instead of flattening to INTERNAL", async () => {
+    orchestratorExecuteSpy.mockReset();
+    orchestratorExecuteSpy.mockImplementation(async function* () {
+      throw Object.assign(new Error("selection changed before writeback"), {
+        code: "WRITE_BACK_FAILED",
+        details: { phase: "writeback" },
+      });
+    });
+
+    const handlers = new Map<string, Handler>();
+    const ipcMain = {
+      handle: (channel: string, listener: Handler) => {
+        handlers.set(channel, listener);
+      },
+    } as unknown as IpcMain;
+
+    registerAiIpcHandlers({
+      ipcMain,
+      db: {} as Database.Database,
+      userDataDir: "<test-user-data>",
+      builtinSkillsDir: "<test-skills>",
+      logger: createLogger(),
+      env: process.env,
+    });
+
+    const handler = handlers.get("ai:skill:run");
+    expect(handler).toBeDefined();
+
+    const result = await handler!(
+      {
+        sender: {
+          id: 7,
+          send: () => undefined,
+        },
+      },
+      {
+        skillId: "builtin:rewrite",
+        hasSelection: true,
+        selection: {
+          from: 4,
+          to: 9,
+          text: "原文片段",
+          selectionTextHash: "abc123hash",
+        },
+        input: "原文片段",
+        mode: "ask",
+        model: "gpt-4.1-mini",
+        stream: false,
+        context: {
+          projectId: "project-1",
+          documentId: "doc-1",
+        },
+      },
+    ) as {
+      ok: boolean;
+      error?: { code: string; message: string; details?: unknown };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatchObject({
+      code: "WRITE_BACK_FAILED",
+      message: "selection changed before writeback",
+    });
+    expect(result.error?.details).toEqual({ phase: "writeback" });
+  });
 });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -756,6 +756,43 @@ export function toSkillRunResponseData(
   };
 }
 
+function normalizeSkillRunError(error: unknown): IpcError {
+  if (typeof error === "object" && error !== null) {
+    const shaped = error as {
+      code?: unknown;
+      message?: unknown;
+      details?: unknown;
+    };
+    const code =
+      typeof shaped.code === "string" && shaped.code.trim().length > 0
+        ? shaped.code
+        : "INTERNAL";
+    const message =
+      typeof shaped.message === "string" && shaped.message.trim().length > 0
+        ? shaped.message
+        : error instanceof Error
+          ? error.message
+          : "AI skill run failed";
+    return {
+      code: code as IpcError["code"],
+      message,
+      ...(shaped.details !== undefined ? { details: shaped.details } : {}),
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: "INTERNAL",
+      message: error.message,
+    };
+  }
+
+  return {
+    code: "INTERNAL",
+    message: "AI skill run failed",
+  };
+}
+
 function leafSkillId(skillId: string): string {
   const parts = skillId.split(":");
   return parts[parts.length - 1] ?? skillId;
@@ -2265,12 +2302,14 @@ function registerAiSkillRunHandler(ctx: AiIpcContext): void {
         });
       } catch (error) {
         ctx.previewSessions.delete(executionId);
+        const normalizedError = normalizeSkillRunError(error);
         ctx.deps.logger.error("ai_skill_run_ipc_failed", {
           message: error instanceof Error ? error.message : String(error),
+          code: normalizedError.code,
         });
         return {
           ok: false,
-          error: { code: "INTERNAL", message: "AI skill run failed" },
+          error: normalizedError,
         };
       }
     },


### PR DESCRIPTION
Closes #160

## Summary
- Preserve structured orchestrator error semantics in the ai:skill:run IPC handler instead of collapsing them into generic INTERNAL errors.
- Keep the editor-facing IPC protocol stable while improving end-to-end error propagation through the Skill pipeline.
- Add IPC contract regression coverage for structured error pass-through (WRITE_BACK_FAILED plus details).

## Invariant Checklist
- [x] INV-1 原稿保护: Not impacted.
- [x] INV-2 并发安全: Not impacted.
- [x] INV-3 CJK Token: Not impacted.
- [x] INV-4 Memory-First: Not impacted.
- [x] INV-5 叙事压缩: Not impacted.
- [x] INV-6 一切皆 Skill: Preserved via the orchestrator boundary.
- [x] INV-7 统一入口: Editor-triggered skill run stays on the IPC to orchestrator entry path.
- [x] INV-8 Hook 链: Not impacted.
- [x] INV-9 成本追踪: Not impacted.
- [x] INV-10 错误不丢上下文: Fixed - structured code, message, and details are preserved.

## Validation Evidence
- pnpm --filter @creonow/desktop test -- main/src/ipc/__tests__/ai-skill-run-selection.contract.test.ts
  - Passed: 3 tests.
- pnpm --filter @creonow/desktop test -- main/src/ipc/__tests__/ai-skill-orchestrator-writeback.test.ts
  - Passed: 20 tests.
- pnpm --filter @creonow/desktop typecheck
  - Passed.
- bash scripts/agent_pr_preflight.sh
  - Pending final rerun on the rebased branch head.

## Visual Evidence

### Embedded Screenshots
![Backend-only placeholder](https://placehold.co/1200x675/png?text=Backend-only+change)

### Storybook Artifact / Link
- Link: https://placehold.co/1200x675/png?text=Backend-only+change
- Visual acceptance note: Backend-only change; placeholder included to satisfy repository gate.

## Risk & Rollback
- Risk: Low. The change is limited to preserving structured error envelopes on the existing orchestrator path; IPC channel shape and editor-visible request contract stay unchanged.
- Rollback point: revert commit 8c95def309cdc5afc133115c7fb50da00f107a92.

## Audit Gate
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)

- [x] Work completed in .worktrees/issue-160-p1-editor-ipc-e2e-skill.
- [x] Required metadata included.
- [ ] Required checks green.
- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT = PENDING
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT = PENDING
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT = PENDING