### PR TITLE
feat(INV-8): activate P3 quality-check post-writing hook

### DIFF
--- a/apps/desktop/main/src/index.ts
+++ b/apps/desktop/main/src/index.ts
@@ -456,6 +456,7 @@ function registerIpcHandlers(deps: {
     secretStorage,
     projectSessionBinding,
     costTracker,
+    eventBus,
   });
 
   registerAiProxyIpcHandlers({

--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -95,7 +95,15 @@ const mocks = vi.hoisted(() => {
         layers: [],
       }),
     })),
-    createKnowledgeGraphServiceMock: vi.fn(() => ({})),
+    createKnowledgeGraphServiceMock: vi.fn(() => ({
+      entityList: vi.fn(() => ({
+        ok: true,
+        data: {
+          items: [] as Array<{ id: string; type: string }>,
+          totalCount: 0,
+        },
+      })),
+    })),
     createMemoryServiceMock: vi.fn(() => ({})),
     createEpisodicMemoryServiceMock: vi.fn(() => ({})),
     createSqliteEpisodeRepositoryMock: vi.fn(() => ({})),
@@ -435,6 +443,83 @@ describe("AI IPC channel registration", () => {
         documentContent: "李明在青云城门口看见了与设定不符的细节。",
       }),
     );
+  });
+
+  it("P3 bridge contextEngine 透传 skill-aware 组装参数并单独探测设定存在性", async () => {
+    const characterEntityList = vi.fn(() => ({
+      ok: true,
+      data: {
+        items: [
+          {
+            id: "ent-1",
+            type: "character",
+          },
+        ],
+        totalCount: 1,
+      },
+    }));
+    mocks.createKnowledgeGraphServiceMock.mockReturnValueOnce({
+      entityList: characterEntityList,
+    });
+
+    createHarness(false, true, true);
+    const firstExecutorCall =
+      mocks.createP3SkillExecutorMock.mock.calls[0] as unknown[] | undefined;
+    const p3Deps = firstExecutorCall?.[0] as
+      | {
+          contextEngine?: {
+            assembleContext: (params: {
+              projectId: string;
+              documentId: string;
+              skillId: string;
+              input: string;
+              selection?: { text: string };
+              injectCharacterSettings: boolean;
+              injectLocationSettings: boolean;
+              injectMemory: boolean;
+            }) => Promise<{ success: boolean; data: Record<string, unknown> }>;
+          };
+        }
+      | undefined;
+    const layerAssembly =
+      mocks.createContextLayerAssemblyServiceMock.mock.results[0]?.value as
+        | { assemble: ReturnType<typeof vi.fn> }
+        | undefined;
+
+    const result = await p3Deps?.contextEngine?.assembleContext({
+      projectId: "proj-001",
+      documentId: "doc-001",
+      skillId: "consistency-check",
+      input: "整段正文",
+      selection: { text: "选区正文" },
+      injectCharacterSettings: true,
+      injectLocationSettings: true,
+      injectMemory: false,
+    });
+
+    expect(layerAssembly?.assemble).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj-001",
+        documentId: "doc-001",
+        cursorPosition: 0,
+        skillId: "consistency-check",
+        additionalInput: "选区正文",
+        additionalInputIsSelection: true,
+      }),
+    );
+    expect(characterEntityList).toHaveBeenCalledWith({
+      projectId: "proj-001",
+      limit: 5000,
+    });
+    expect(result).toEqual({
+      success: true,
+      data: {
+        prompt: "ctx",
+        hasCharacterSettings: true,
+        hasLocationSettings: false,
+        hasMemory: false,
+      },
+    });
   });
 
   it("预热 list 失败时记录 skill_registry_warmup_failed 错误日志", () => {

--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -84,7 +84,16 @@ const mocks = vi.hoisted(() => {
       cancel: vi.fn(),
     })),
     createContextLayerAssemblyServiceMock: vi.fn(() => ({
-      assemble: vi.fn().mockReturnValue({ ok: true, data: { layers: [] } }),
+      assemble: vi.fn().mockResolvedValue({
+        prompt: "ctx",
+        tokenCount: 10,
+        stablePrefixHash: "hash",
+        stablePrefixUnchanged: false,
+        warnings: [],
+        compressionApplied: false,
+        capacityPercent: 1,
+        layers: [],
+      }),
     })),
     createKnowledgeGraphServiceMock: vi.fn(() => ({})),
     createMemoryServiceMock: vi.fn(() => ({})),
@@ -95,6 +104,14 @@ const mocks = vi.hoisted(() => {
     })),
     createDocumentServiceMock: vi.fn(() => ({
       read: vi.fn(),
+    })),
+    createP3SkillExecutorMock: vi.fn(() => ({
+      executeSkill: vi.fn().mockResolvedValue({
+        success: true,
+        data: { passed: true, issues: [] },
+      }),
+      registerSkills: vi.fn(),
+      dispose: vi.fn(),
     })),
   };
 });
@@ -140,6 +157,9 @@ vi.mock("../../services/stats/statsService", () => ({
 vi.mock("../../services/documents/documentService", () => ({
   createDocumentService: mocks.createDocumentServiceMock,
 }));
+vi.mock("../../services/skills/p3Skills", () => ({
+  createP3SkillExecutor: mocks.createP3SkillExecutorMock,
+}));
 vi.mock("../../services/skills/writingTooling", () => ({
   createWritingToolRegistry: vi.fn(() => ({ getTools: () => [] })),
   createAgenticToolRegistry: vi.fn(() => ({ getTools: () => [] })),
@@ -148,6 +168,8 @@ vi.mock("../../services/skills/toolRegistry", () => ({
   createToolRegistry: vi.fn(() => ({
     getAllTools: () => [],
     getToolsByCategory: () => [],
+    register: vi.fn(),
+    unregister: vi.fn(),
   })),
 }));
 vi.mock("../../services/skills/toolUseHandler", () => ({
@@ -199,7 +221,11 @@ interface IpcResponse<T> {
   error?: { code: string; message: string };
 }
 
-function createHarness(dbNull = false, withCostTracker = false) {
+function createHarness(
+  dbNull = false,
+  withCostTracker = false,
+  withEventBus = false,
+) {
   const handlers = new Map<string, Handler>();
 
   const ipcMain = {
@@ -249,6 +275,15 @@ function createHarness(dbNull = false, withCostTracker = false) {
               totalRequests: 0,
               budgetStatus: "ok" as const,
             })),
+          } as unknown as never,
+        }
+      : {}),
+    ...(withEventBus
+      ? {
+          eventBus: {
+            emit: vi.fn(),
+            on: vi.fn(),
+            off: vi.fn(),
           } as unknown as never,
         }
       : {}),
@@ -338,6 +373,66 @@ describe("AI IPC channel registration", () => {
     expect(mocks.createWritingOrchestratorMock).toHaveBeenCalledWith(
       expect.objectContaining({
         validSkillIds: [],
+      }),
+    );
+  });
+
+  it("提供 eventBus 时接通 quality-check post-writing hook", () => {
+    createHarness(false, true, true);
+    expect(mocks.createP3SkillExecutorMock).toHaveBeenCalledTimes(1);
+    const firstCall =
+      mocks.createWritingOrchestratorMock.mock.calls[0] as unknown[] | undefined;
+    const orchestratorConfig = firstCall?.[0] as
+      | { postWritingHooks?: Array<{ name: string }> }
+      | undefined;
+    const hookNames = (orchestratorConfig?.postWritingHooks ?? []).map(
+      (hook: { name: string }) => hook.name,
+    );
+    expect(hookNames).toContain("quality-check");
+  });
+
+  it("触发 quality-check hook 时经 P3 executor 执行 consistency-check", async () => {
+    createHarness(false, true, true);
+    const firstCall =
+      mocks.createWritingOrchestratorMock.mock.calls[0] as unknown[] | undefined;
+    const orchestratorConfig = firstCall?.[0] as
+      | {
+          postWritingHooks?: Array<{
+            name: string;
+            execute: (ctx: {
+              requestId: string;
+              documentId: string;
+              projectId?: string;
+              sessionId?: string;
+              fullText: string;
+            }) => Promise<void>;
+          }>;
+        }
+      | undefined;
+    const qualityHook = orchestratorConfig?.postWritingHooks?.find(
+      (hook) => hook.name === "quality-check",
+    );
+    const executorInstance = mocks.createP3SkillExecutorMock.mock.results[0]?.value as
+      | { executeSkill: ReturnType<typeof vi.fn> }
+      | undefined;
+
+    expect(qualityHook).toBeDefined();
+    expect(executorInstance).toBeDefined();
+
+    await qualityHook?.execute({
+      requestId: "req-001",
+      documentId: "doc-001",
+      projectId: "proj-001",
+      sessionId: "sess-001",
+      fullText: "李明在青云城门口看见了与设定不符的细节。",
+    });
+
+    expect(executorInstance?.executeSkill).toHaveBeenCalledWith(
+      "consistency-check",
+      expect.objectContaining({
+        projectId: "proj-001",
+        documentId: "doc-001",
+        documentContent: "李明在青云城门口看见了与设定不符的细节。",
       }),
     );
   });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -78,6 +78,11 @@ import { buildPostWritingHookChain } from "../services/skills/postWritingHooks";
 import { matchEntitiesCached } from "../services/kg/entityMatcher";
 import { createSessionMemoryService } from "../services/memory/sessionMemoryService";
 import { createKgMutationSkill } from "../services/skills/kgMutationSkill";
+import {
+  NOOP_EVENT_BUS,
+  type EventBusLike,
+} from "./helpers";
+import { createP3SkillExecutor } from "../services/skills/p3Skills";
 
 /**
  * Convert a ProseMirror document position to a plain-text character offset.
@@ -114,6 +119,143 @@ type SkillRunPayload = {
   promptDiagnostics?: { stablePrefixHash: string; promptHash: string };
   stream: boolean;
 };
+
+type P3ContextRequest = {
+  projectId: string;
+  documentId: string;
+  input: string;
+  skillId: string;
+  injectCharacterSettings: boolean;
+  injectLocationSettings: boolean;
+  injectMemory: boolean;
+  selection?: {
+    text: string;
+  };
+};
+
+function buildP3UserMessage(args: {
+  input: string;
+  selection?: { text: string };
+  context?: Record<string, unknown> | null;
+}): string {
+  const sections = [
+    args.context
+      ? `Context:\n${JSON.stringify(args.context, null, 2)}`
+      : "",
+    args.selection?.text ? `Selection:\n${args.selection.text}` : "",
+    `Document:\n${args.input}`,
+  ].filter((section) => section.length > 0);
+  return sections.join("\n\n");
+}
+
+function createP3AiServiceAdapter(args: {
+  bridgeAiService: ReturnType<typeof createAiServiceBridge>;
+}): {
+  complete: (params: {
+    skillId: string;
+    systemPrompt: string;
+    input: string;
+    context?: Record<string, unknown> | null;
+    selection?: { text: string };
+  }) => Promise<{ content: string }>;
+  stream: (params: Record<string, unknown>) => Promise<unknown>;
+} {
+  return {
+    complete: async (params) => {
+      const signal = AbortSignal.timeout(30_000);
+      let bridgeError: unknown = null;
+      let content = "";
+      const stream = args.bridgeAiService.streamChat(
+        [
+          { role: "system", content: params.systemPrompt },
+          {
+            role: "user",
+            content: buildP3UserMessage({
+              input: params.input,
+              selection: params.selection,
+              context: params.context,
+            }),
+          },
+        ],
+        {
+          signal,
+          skillId: params.skillId,
+          onComplete: () => undefined,
+          onError: (error) => {
+            bridgeError = error;
+          },
+        },
+      );
+      try {
+        for await (const chunk of stream) {
+          content += chunk.delta;
+        }
+      } catch (error) {
+        throw bridgeError ?? error;
+      }
+      if (bridgeError) {
+        throw bridgeError;
+      }
+      return { content };
+    },
+    stream: async (_params) => {
+      throw new Error("P3 quality-check bridge does not support stream");
+    },
+  };
+}
+
+function createP3ContextEngineAdapter(args: {
+  contextAssemblyService: ReturnType<typeof createContextLayerAssemblyService>;
+  logger: Logger;
+}): {
+  assembleContext: (params: P3ContextRequest) => Promise<{
+    success: boolean;
+    data: Record<string, unknown>;
+  }>;
+} {
+  return {
+    assembleContext: async (params) => {
+      try {
+        const assembled = await args.contextAssemblyService.assemble({
+          projectId: params.projectId,
+          documentId: params.documentId,
+          cursorPosition: 0,
+          skillId: params.skillId,
+          additionalInput: params.selection?.text ?? params.input,
+          ...(params.selection
+            ? { additionalInputIsSelection: true as const }
+            : {}),
+        });
+        return {
+          success: true,
+          data: {
+            prompt: assembled.prompt,
+            characterSettings: params.injectCharacterSettings
+              ? assembled.prompt
+              : "",
+            locationSettings: params.injectLocationSettings
+              ? assembled.prompt
+              : "",
+            memory: params.injectMemory
+              ? assembled.prompt
+              : "",
+          },
+        };
+      } catch (error) {
+        args.logger.error("p3_context_engine_assembly_failed", {
+          message: error instanceof Error ? error.message : String(error),
+          projectId: params.projectId,
+          documentId: params.documentId,
+          skillId: params.skillId,
+        });
+        return {
+          success: false,
+          data: {},
+        };
+      }
+    },
+  };
+}
 
 function resolveCursorPosition(payload: SkillRunPayload): number | undefined {
   if (payload.selection) {
@@ -1002,6 +1144,7 @@ type AiIpcDeps = {
   secretStorage?: SecretStorageAdapter;
   projectSessionBinding?: ProjectSessionBindingRegistry;
   costTracker?: CostTracker;
+  eventBus?: EventBusLike;
 };
 
 type AiIpcContext = {
@@ -1561,23 +1704,41 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
   // INV-7: Build the WritingOrchestrator's AI service adapter using factories from
   // the services layer. ai.ts must not hold bare aiService.runSkill() calls directly;
   // all AI calling logic is encapsulated in writingOrchestratorAiService + writingGenerateText.
-  const writingOrchestratorAiSvc = (() => {
-    if (deps.db === null || !deps.costTracker) {
-      return createNullWritingOrchestratorAiService();
-    }
-    const bridgeAiService = createAiServiceBridge({
-      db: deps.db,
-      logger: deps.logger,
-      costTracker: deps.costTracker,
-      env: deps.env,
-      runtimeAiTimeoutMs: runtimeGovernance.ai.timeoutMs,
-      getProxySettings: readProxySettings,
-    });
-    return createWritingOrchestratorAiService({
-      aiService,
-      bridgeAiService,
-    });
-  })();
+  const bridgeAiService =
+    deps.db === null || !deps.costTracker
+      ? undefined
+      : createAiServiceBridge({
+          db: deps.db,
+          logger: deps.logger,
+          costTracker: deps.costTracker,
+          env: deps.env,
+          runtimeAiTimeoutMs: runtimeGovernance.ai.timeoutMs,
+          getProxySettings: readProxySettings,
+        });
+  const writingOrchestratorAiSvc = bridgeAiService
+    ? createWritingOrchestratorAiService({
+        aiService,
+        bridgeAiService,
+      })
+    : createNullWritingOrchestratorAiService();
+  const p3QualityCheckExecutor =
+    bridgeAiService && deps.eventBus
+        ? createP3SkillExecutor({
+            aiService: createP3AiServiceAdapter({
+              bridgeAiService,
+            }),
+            contextEngine: createP3ContextEngineAdapter({
+              contextAssemblyService,
+              logger: deps.logger,
+            }),
+            eventBus: deps.eventBus ?? NOOP_EVENT_BUS,
+            toolRegistry: {
+              register: () => undefined,
+              get: () => undefined,
+              unregister: () => undefined,
+            },
+          })
+        : undefined;
   const generateText = createWritingGenerateText({
     aiService,
     skillExecutor,
@@ -1627,11 +1788,9 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           return;
         },
       },
-       // INV-8: Wire the post-writing hooks from the hook chain factory.
-      // kg-update and memory-extract are fully activated with real services.
-      // quality-check is omitted: P3SkillExecutor needs contextEngine +
-      // eventBus which are not yet available in the IPC scope. It will be
-      // registered once the P3 skill infrastructure is wired here.
+      // INV-8: Wire the post-writing hooks from the hook chain factory.
+      // When the main-process event bus is available we can also activate
+      // the final quality-check leg via the P3 executor bridge.
       ...buildPostWritingHookChain({
         kgUpdate: {
           scanEntities: matchEntitiesCached,
@@ -1663,10 +1822,14 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
               },
           logger: deps.logger,
         },
-        // qualityCheck intentionally omitted — P3SkillExecutor requires
-        // contextEngine + eventBus which are not yet available in the IPC
-        // scope. The quality-check hook will be registered once the P3 skill
-        // infrastructure lands. See PostWritingHookChainDeps.qualityCheck.
+        ...(p3QualityCheckExecutor
+          ? {
+              qualityCheck: {
+                skillExecutor: p3QualityCheckExecutor,
+                logger: deps.logger,
+              },
+            }
+          : {}),
       }),
     ],
     defaultTimeoutMs: 30_000,

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -43,6 +43,7 @@ import { normalizeAssembledContextPrompt } from "../services/skills/contextPromp
 import { renderPromptTemplate } from "../services/skills/promptTemplate";
 import { createContextLayerAssemblyService } from "../services/context/layerAssemblyService";
 import { createKnowledgeGraphService } from "../services/kg/kgService";
+import type { KnowledgeGraphService } from "../services/kg/types";
 import { DegradationCounter } from "../services/shared/degradationCounter";
 import { createDbNotReadyError } from "./dbError";
 import type { ProjectSessionBindingRegistry } from "./projectSessionBinding";
@@ -206,6 +207,7 @@ function createP3AiServiceAdapter(args: {
 
 function createP3ContextEngineAdapter(args: {
   contextAssemblyService: ReturnType<typeof createContextLayerAssemblyService>;
+  kgService?: Pick<KnowledgeGraphService, "entityList">;
   logger: Logger;
 }): {
   assembleContext: (params: P3ContextRequest) => Promise<{
@@ -216,29 +218,65 @@ function createP3ContextEngineAdapter(args: {
   return {
     assembleContext: async (params) => {
       try {
-        const assembled = await args.contextAssemblyService.assemble({
-          projectId: params.projectId,
-          documentId: params.documentId,
-          cursorPosition: 0,
-          skillId: params.skillId,
-          additionalInput: params.selection?.text ?? params.input,
-          ...(params.selection
-            ? { additionalInputIsSelection: true as const }
-            : {}),
-        });
+        const [assembled, settingsProbe] = await Promise.all([
+          args.contextAssemblyService.assemble({
+            projectId: params.projectId,
+            documentId: params.documentId,
+            cursorPosition: 0,
+            skillId: params.skillId,
+            additionalInput: params.selection?.text ?? params.input,
+            ...(params.selection
+              ? { additionalInputIsSelection: true as const }
+              : {}),
+          }),
+          Promise.resolve().then(() => {
+            if (!args.kgService) {
+              return {
+                hasCharacterSettings: false,
+                hasLocationSettings: false,
+              };
+            }
+
+            const listed = args.kgService.entityList({
+              projectId: params.projectId,
+              limit: 5000,
+            });
+            if (!listed.ok) {
+              args.logger.error("p3_context_engine_settings_probe_failed", {
+                code: listed.error.code,
+                message: listed.error.message,
+                projectId: params.projectId,
+                documentId: params.documentId,
+                skillId: params.skillId,
+              });
+              return {
+                hasCharacterSettings: false,
+                hasLocationSettings: false,
+              };
+            }
+
+            return {
+              hasCharacterSettings: listed.data.items.some(
+                (entity: { type: string }) => entity.type === "character",
+              ),
+              hasLocationSettings: listed.data.items.some(
+                (entity: { type: string }) => entity.type === "location",
+              ),
+            };
+          }),
+        ]);
+
         return {
           success: true,
           data: {
             prompt: assembled.prompt,
-            characterSettings: params.injectCharacterSettings
-              ? assembled.prompt
-              : "",
-            locationSettings: params.injectLocationSettings
-              ? assembled.prompt
-              : "",
-            memory: params.injectMemory
-              ? assembled.prompt
-              : "",
+            hasCharacterSettings: params.injectCharacterSettings
+              ? settingsProbe.hasCharacterSettings
+              : false,
+            hasLocationSettings: params.injectLocationSettings
+              ? settingsProbe.hasLocationSettings
+              : false,
+            hasMemory: params.injectMemory,
           },
         };
       } catch (error) {
@@ -1729,6 +1767,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
             }),
             contextEngine: createP3ContextEngineAdapter({
               contextAssemblyService,
+              kgService: kgServiceForContext ?? undefined,
               logger: deps.logger,
             }),
             eventBus: deps.eventBus ?? NOOP_EVENT_BUS,

--- a/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
@@ -371,6 +371,24 @@ System prompt.`;
   // ── consistency-check skill ─────────────────────────────────────
 
   describe("consistency-check", () => {
+    it("向 aiService.complete 透传 skillId 以保持桥接层路由语义", async () => {
+      aiService.complete.mockResolvedValue({
+        content: JSON.stringify({ passed: true, issues: [] }),
+      });
+
+      await executor.executeSkill("consistency-check", {
+        projectId: "proj-1",
+        documentId: "doc-1",
+        documentContent: "林远走进了废弃仓库",
+      });
+
+      expect(aiService.complete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skillId: "consistency-check",
+        }),
+      );
+    });
+
     it("发现矛盾时返回 ConsistencyCheckResult with issues", async () => {
       aiService.complete.mockResolvedValue({
         content: JSON.stringify({

--- a/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
@@ -315,14 +315,25 @@ System prompt.`;
   // ── SkillContextRequirement behavior ────────────────────────────
 
   describe("SkillContextRequirement", () => {
-    it("requiresProjectContext=true 时注入角色/地点设定", async () => {
+    it("requiresProjectContext=true 时按 skill-aware 入参组装上下文", async () => {
       await executor.executeSkill("consistency-check", {
         projectId: "proj-1",
         documentId: "doc-1",
         documentContent: "林远走进了废弃仓库",
       });
 
-      expect(contextEngine.assembleContext).toHaveBeenCalled();
+      expect(contextEngine.assembleContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "proj-1",
+          documentId: "doc-1",
+          skillId: "consistency-check",
+          input: "林远走进了废弃仓库",
+          selection: undefined,
+          injectCharacterSettings: true,
+          injectLocationSettings: true,
+          injectMemory: false,
+        }),
+      );
     });
 
     it("requiresSelection=true 但无选区时返回错误", async () => {
@@ -340,9 +351,9 @@ System prompt.`;
       contextEngine.assembleContext.mockResolvedValue({
         success: true,
         data: {
-          characterSettings: "",
-          locationSettings: "",
-          documentContent: "文本",
+          prompt: "文本",
+          hasCharacterSettings: false,
+          hasLocationSettings: false,
         },
       });
 
@@ -353,6 +364,28 @@ System prompt.`;
       });
 
       expect(result.success).toBe(false);
+    });
+
+    it("bridge 用布尔设定标记时仍允许 analysis skill 继续执行", async () => {
+      contextEngine.assembleContext.mockResolvedValue({
+        success: true,
+        data: {
+          prompt: "角色设定已注入到 prompt",
+          hasCharacterSettings: true,
+          hasLocationSettings: false,
+        },
+      });
+      aiService.complete.mockResolvedValue({
+        content: JSON.stringify({ passed: true, issues: [] }),
+      });
+
+      const result = await executor.executeSkill("consistency-check", {
+        projectId: "proj-1",
+        documentId: "doc-1",
+        documentContent: "林远走进了废弃仓库",
+      });
+
+      expect(result.success).toBe(true);
     });
 
     it("minInputLength 不满足时返回错误", async () => {

--- a/apps/desktop/main/src/services/skills/p3Skills.ts
+++ b/apps/desktop/main/src/services/skills/p3Skills.ts
@@ -370,6 +370,9 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
         const ctxResult = await contextEngine.assembleContext({
           projectId: input.projectId,
           documentId: input.documentId,
+          skillId,
+          input: input.documentContent,
+          selection: input.selection,
           injectCharacterSettings: manifest.contextRules.injectCharacterSettings,
           injectLocationSettings: manifest.contextRules.injectLocationSettings,
           injectMemory: manifest.contextRules.injectMemory,
@@ -378,7 +381,15 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
       }
 
       if (manifest.contextRequirement.requiresProjectContext && contextData && manifest.category === "analysis") {
-        if (!contextData.characterSettings && !contextData.locationSettings) {
+        const hasCharacterSettings =
+          (typeof contextData.characterSettings === "string" &&
+            contextData.characterSettings.trim().length > 0) ||
+          contextData.hasCharacterSettings === true;
+        const hasLocationSettings =
+          (typeof contextData.locationSettings === "string" &&
+            contextData.locationSettings.trim().length > 0) ||
+          contextData.hasLocationSettings === true;
+        if (!hasCharacterSettings && !hasLocationSettings) {
           return { success: false, error: { code: "SKILL_CONTEXT_EMPTY", message: "请先添加角色/地点设定" } };
         }
       }

--- a/apps/desktop/main/src/services/skills/p3Skills.ts
+++ b/apps/desktop/main/src/services/skills/p3Skills.ts
@@ -386,6 +386,7 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
       let aiResponse: { content: string };
       try {
         aiResponse = await aiService.complete({
+          skillId,
           systemPrompt: manifest.systemPromptTemplate,
           context: contextData,
           input: input.documentContent,

--- a/apps/desktop/main/src/services/skills/postWritingHooks.ts
+++ b/apps/desktop/main/src/services/skills/postWritingHooks.ts
@@ -354,10 +354,9 @@ export interface PostWritingHookChainDeps {
   kgUpdate: KgUpdateHookDeps;
   memoryExtract: MemoryExtractHookDeps;
   /**
-   * Optional — quality-check requires P3SkillExecutor which depends on
-   * contextEngine + eventBus (not yet available in the IPC scope).
+   * Optional — some callers only have the fast local hook dependencies and
+   * deliberately omit the LLM-backed quality-check leg.
    * When omitted the quality-check hook is simply not registered.
-   * @todo Wire when P3 skill infrastructure lands in IPC scope.
    */
   qualityCheck?: QualityCheckHookDeps;
 }


### PR DESCRIPTION
## 概述

激活 P3 post-writing hook 链中的 quality-check 最后一环，并补齐桥接层回归测试，确保主进程能经 P3 executor 触发 consistency-check Skill。

Closes #138

## 变更类型

- [x] Feature（新功能）
- [ ] Fix（修复）
- [ ] Docs（文档）
- [ ] Refactor（重构）
- [x] Test（测试）
- [ ] CI/Infra（工程）

## 影响范围

- apps/desktop/main/src/ipc/ai.ts
- apps/desktop/main/src/index.ts
- apps/desktop/main/src/services/skills/p3Skills.ts
- apps/desktop/main/src/services/skills/postWritingHooks.ts
- apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
- apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts

---

## 阶段 A：设计文档

### 涉及的 Invariants

- INV-6 一切皆 Skill：quality-check 继续通过 P3SkillExecutor -> consistency-check 路径执行，没有裸调 LLM。
- INV-8 Hook 链：Stage 8 在具备 bridgeAiService 和 eventBus 时补齐 quality-check leg。
- INV-9 成本追踪：quality-check 走主进程 AI bridge，沿用既有 usage/cost 记录路径。
- INV-10 错误不丢上下文：桥接失败与 hook 失败继续记录结构化错误日志，不静默吞掉。

### 模块边界图

index.ts -> registerAiIpcHandlers(ai.ts) -> buildPostWritingHookChain(postWritingHooks.ts) -> createP3SkillExecutor(p3Skills.ts)

依赖方向保持主进程编排层向 service 层单向注入；IPC 未直接裸调底层 AI service。

### Definition of Done

- 主进程在具备 eventBus 时注册 quality-check post-writing hook。
- quality-check hook 触发后，能经 P3 executor 调用 consistency-check。
- P3 Skill 桥接调用继续向下透传 skillId、input、selection。
- 设定存在性判定不再伪造 character/location strings，而是单独探测布尔语义。
- 相关 focused tests 与 typecheck 通过。

---

## 阶段 B：Invariant Checklist

- [x] INV-1 原稿保护 — 不涉及新的写回路径
- [x] INV-2 并发安全 — 不新增并发执行面，hook 仍按既有顺序与隔离规则运行
- [x] INV-3 CJK Token — 不涉及 token 估算逻辑
- [x] INV-4 Memory-First — 未新增额外向量存储
- [x] INV-5 叙事压缩 — 不涉及 AutoCompact 行为变更
- [x] INV-6 一切皆 Skill — quality-check 经 Skill executor 执行
- [x] INV-7 统一入口 — 仍由 orchestrator/post-writing hooks 编排，未引入 IPC handler 直调 service
- [x] INV-8 Hook 链 — 写作后 quality-check hook 现可被注册并触发
- [x] INV-9 成本追踪 — quality-check 使用带 cost tracker 的 AI bridge
- [x] INV-10 错误不丢上下文 — 失败继续记录结构化错误日志

---

## Validation Evidence

- pnpm --filter @creonow/desktop test -- main/src/ipc/__tests__/ai-handlers-delegation.test.ts main/src/services/skills/__tests__/postWritingHooks.test.ts main/src/services/skills/__tests__/p3-skills.test.ts
  - 100 passed
- pnpm --filter @creonow/desktop typecheck
  - pass
- bash scripts/agent_pr_preflight.sh
  - 当前已通过 repo、branch、issue、open PR 识别；此前失败点为 PR 正文审计模板缺失固定模型行，本次已补齐

## Visual Evidence

### Embedded Screenshots

N/A

### Storybook Artifact / Link

- Link: N/A
- Visual acceptance note: N/A

- [x] N/A（非前端改动）

## Risk & Rollback

- 风险：低。主要风险是额外的 post-writing LLM 调用在 eventBus 存在时被启用；若未来 bridgeAiService 的流式协议改变，仍需更靠近真实 streamChat 的集成测试兜底。
- 回滚：回滚提交 c7ab42d 与 d4eca78 即可撤销本次接线。

## 审计门禁

**审计模型配置（1+1+1+Duck）：**
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)

- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT ___
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT ___
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT ___

实际执行（当前任务按用户指令采用 2-subagent 交叉审计）：
- [x] 审计 A：gpt-5.3-codex xhigh — FINAL-VERDICT: ACCEPT
- [x] 审计 B：GPT-5.4 high — FINAL-VERDICT: ACCEPT
- 残余风险：仍缺一条真实 bridgeAiService.streamChat + onComplete/chunk 行为的端到端断言，后续更适合集成测试补位。

---

## Final Checklist

- [x] 全程在 .worktrees/issue-146-layout-alignment/.worktrees/preflight-146 中完成
- [x] pnpm typecheck 通过
- [x] 相关测试通过
- [x] 无 any 类型
- [x] 前端改动：Storybook 可构建、无硬编码颜色/间距、新组件有 Story（N/A）
