### PR TITLE
feat(skills): normalize P3 skill IDs for builtin alias compatibility

### DIFF
--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -399,7 +399,7 @@ describe("AI IPC channel registration", () => {
     expect(hookNames).toContain("quality-check");
   });
 
-  it("触发 quality-check hook 时经 P3 executor 执行 consistency-check", async () => {
+  it("触发 quality-check hook 时经 P3 executor 执行 builtin:consistency-check", async () => {
     createHarness(false, true, true);
     const firstCall =
       mocks.createWritingOrchestratorMock.mock.calls[0] as unknown[] | undefined;
@@ -436,7 +436,7 @@ describe("AI IPC channel registration", () => {
     });
 
     expect(executorInstance?.executeSkill).toHaveBeenCalledWith(
-      "consistency-check",
+      "builtin:consistency-check",
       expect.objectContaining({
         projectId: "proj-001",
         documentId: "doc-001",

--- a/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
@@ -159,10 +159,16 @@ describe("P3 runtime skill chain", () => {
       const consistency = svc.resolveForRun({ id: "consistency-check" });
       const dialogue = svc.resolveForRun({ id: "dialogue-gen" });
       const outline = svc.resolveForRun({ id: "outline-expand" });
+      const prefixedConsistency = svc.resolveForRun({ id: "builtin:consistency-check" });
+      const prefixedDialogue = svc.resolveForRun({ id: "builtin:dialogue-gen" });
+      const prefixedOutline = svc.resolveForRun({ id: "builtin:outline-expand" });
 
       expect(consistency.ok && consistency.data.inputType).toBe("document");
       expect(dialogue.ok && dialogue.data.inputType).toBe("selection");
       expect(outline.ok && outline.data.inputType).toBe("selection");
+      expect(prefixedConsistency.ok && prefixedConsistency.data.inputType).toBe("document");
+      expect(prefixedDialogue.ok && prefixedDialogue.data.inputType).toBe("selection");
+      expect(prefixedOutline.ok && prefixedOutline.data.inputType).toBe("selection");
     } finally {
       db.close();
     }

--- a/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-runtime.execution.test.ts
@@ -162,6 +162,7 @@ describe("P3 runtime skill chain", () => {
       const prefixedConsistency = svc.resolveForRun({ id: "builtin:consistency-check" });
       const prefixedDialogue = svc.resolveForRun({ id: "builtin:dialogue-gen" });
       const prefixedOutline = svc.resolveForRun({ id: "builtin:outline-expand" });
+      const plainChat = svc.resolveForRun({ id: "chat" });
 
       expect(consistency.ok && consistency.data.inputType).toBe("document");
       expect(dialogue.ok && dialogue.data.inputType).toBe("selection");
@@ -169,6 +170,7 @@ describe("P3 runtime skill chain", () => {
       expect(prefixedConsistency.ok && prefixedConsistency.data.inputType).toBe("document");
       expect(prefixedDialogue.ok && prefixedDialogue.data.inputType).toBe("selection");
       expect(prefixedOutline.ok && prefixedOutline.data.inputType).toBe("selection");
+      expect(plainChat.ok).toBe(false);
     } finally {
       db.close();
     }

--- a/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
@@ -840,6 +840,25 @@ System prompt.`;
       });
       expect(validResult.success).toBe(true);
     });
+
+    it("支持 builtin: 前缀别名调用 consistency-check", async () => {
+      aiService.complete.mockResolvedValue({
+        content: JSON.stringify({ passed: true, issues: [] }),
+      });
+
+      const result = await executor.executeSkill("builtin:consistency-check", {
+        projectId: "proj-1",
+        documentId: "doc-1",
+        documentContent: "文本",
+      });
+
+      expect(result.success).toBe(true);
+      expect(aiService.complete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skillId: "builtin:consistency-check",
+        }),
+      );
+    });
   });
 
   // ── Skill registration ─────────────────────────────────────────
@@ -851,15 +870,18 @@ System prompt.`;
       expect(toolRegistry.register).toHaveBeenCalled();
     });
 
-    it("注册三个 P3 技能", () => {
+    it("同时注册 canonical 与 builtin 前缀技能 ID", () => {
       executor.registerSkills();
 
       const registeredIds = toolRegistry.register.mock.calls.map(
         (call: any) => call[0]?.id || call[0]?.name,
       );
       expect(registeredIds).toContain("consistency-check");
+      expect(registeredIds).toContain("builtin:consistency-check");
       expect(registeredIds).toContain("dialogue-gen");
+      expect(registeredIds).toContain("builtin:dialogue-gen");
       expect(registeredIds).toContain("outline-expand");
+      expect(registeredIds).toContain("builtin:outline-expand");
     });
   });
 

--- a/apps/desktop/main/src/services/skills/__tests__/postWritingHooks.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/postWritingHooks.test.ts
@@ -407,7 +407,7 @@ describe("createQualityCheckHook", () => {
     expect(hook.priority).toBe(QUALITY_CHECK_PRIORITY);
   });
 
-  it("calls consistency-check skill with correct args (fire-and-forget)", async () => {
+  it("calls builtin:consistency-check skill with correct args (fire-and-forget)", async () => {
     const deps = makeQualityCheckDeps();
     const hook = createQualityCheckHook(deps);
     const ctx = makeContext();
@@ -415,7 +415,7 @@ describe("createQualityCheckHook", () => {
     await hook.execute(ctx);
     // executeSkill is called immediately (fire-and-forget)
     expect(deps.skillExecutor.executeSkill).toHaveBeenCalledWith(
-      "consistency-check",
+      "builtin:consistency-check",
       {
         projectId: "proj-001",
         documentId: "doc-001",

--- a/apps/desktop/main/src/services/skills/p3Skills.ts
+++ b/apps/desktop/main/src/services/skills/p3Skills.ts
@@ -40,6 +40,14 @@ export interface SkillManifest {
 
 type JsonObject = Record<string, unknown>;
 
+const P3_SKILL_CANONICAL_IDS = [
+  "consistency-check",
+  "dialogue-gen",
+  "outline-expand",
+] as const;
+
+const P3_SKILL_CANONICAL_ID_SET = new Set<string>(P3_SKILL_CANONICAL_IDS);
+
 // L1: severity union type instead of string
 export interface ConsistencyIssue {
   location: string;
@@ -294,11 +302,7 @@ export function loadP3SkillManifestRegistry(options?: {
 }): SkillManifestRegistry {
   const manifests: Record<string, SkillManifest> = {};
   const errors: SkillManifestRegistry["errors"] = {};
-  const skillDirs = options?.skillDirs ?? [
-    "consistency-check",
-    "dialogue-gen",
-    "outline-expand",
-  ];
+  const skillDirs = options?.skillDirs ?? [...P3_SKILL_CANONICAL_IDS];
 
   for (const skillDir of skillDirs) {
     try {
@@ -317,6 +321,21 @@ export function loadP3SkillManifestRegistry(options?: {
 }
 
 const DEFAULT_MANIFEST_REGISTRY = loadP3SkillManifestRegistry();
+
+function normalizeP3SkillId(skillId: string): string {
+  const trimmed = skillId.trim();
+  if (trimmed.startsWith("builtin:")) {
+    const leaf = trimmed.slice("builtin:".length);
+    if (P3_SKILL_CANONICAL_ID_SET.has(leaf)) {
+      return leaf;
+    }
+  }
+  return trimmed;
+}
+
+function runtimeP3SkillIds(canonicalId: string): string[] {
+  return [`builtin:${canonicalId}`, canonicalId];
+}
 
 // ─── Implementation ─────────────────────────────────────────────────
 
@@ -345,9 +364,10 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
         return { success: false, error: { code: "SKILL_DISPOSED", message: "技能执行器已销毁" } };
       }
 
-      const manifest = skillManifests[skillId];
+      const canonicalSkillId = normalizeP3SkillId(skillId);
+      const manifest = skillManifests[canonicalSkillId];
       if (!manifest) {
-        const manifestError = manifestErrors[skillId];
+        const manifestError = manifestErrors[canonicalSkillId];
         if (manifestError) {
           return {
             success: false,
@@ -415,7 +435,7 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
         return { success: false, error: { code: "SKILL_OUTPUT_INVALID", message: "AI 返回格式错误" } };
       }
 
-      if (skillId === "consistency-check") {
+      if (canonicalSkillId === "consistency-check") {
         const rawIssues = (parsed.issues as Array<Record<string, unknown>>) || [];
         const result: ConsistencyCheckResult = {
           passed: (parsed.passed as boolean) ?? true,
@@ -439,7 +459,7 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
         return { success: true, data: result };
       }
 
-      if (skillId === "dialogue-gen") {
+      if (canonicalSkillId === "dialogue-gen") {
         const result: DialogueGenResult = {
           dialogue: parsed.dialogue as string,
           characterId: parsed.characterId as string | undefined,
@@ -447,7 +467,7 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
         return { success: true, data: result };
       }
 
-      if (skillId === "outline-expand") {
+      if (canonicalSkillId === "outline-expand") {
         const result: OutlineExpandResult = {
           expandedContent: parsed.expandedContent as string,
           paragraphCount: parsed.paragraphCount as number | undefined,
@@ -459,21 +479,25 @@ export function createP3SkillExecutor(deps: Deps): P3SkillExecutor {
     },
 
     registerSkills(): void {
-      for (const [id, manifest] of Object.entries(skillManifests)) {
-        toolRegistry.register({
-          id,
-          name: id,
-          description: manifest.description,
-          category: manifest.category,
-          execute: (input: SkillInput) => executor.executeSkill(id, input),
-        });
+      for (const [canonicalId, manifest] of Object.entries(skillManifests)) {
+        for (const runtimeId of runtimeP3SkillIds(canonicalId)) {
+          toolRegistry.register({
+            id: runtimeId,
+            name: runtimeId,
+            description: manifest.description,
+            category: manifest.category,
+            execute: (input: SkillInput) => executor.executeSkill(runtimeId, input),
+          });
+        }
       }
     },
 
     dispose(): void {
       disposed = true;
-      for (const id of Object.keys(skillManifests)) {
-        toolRegistry.unregister?.(id);
+      for (const canonicalId of Object.keys(skillManifests)) {
+        for (const runtimeId of runtimeP3SkillIds(canonicalId)) {
+          toolRegistry.unregister?.(runtimeId);
+        }
       }
     },
   };

--- a/apps/desktop/main/src/services/skills/postWritingHooks.ts
+++ b/apps/desktop/main/src/services/skills/postWritingHooks.ts
@@ -312,7 +312,7 @@ export function createQualityCheckHook(
 
       // Fire-and-forget: don't await — avoids blocking Stage 8 on an LLM call.
       void deps.skillExecutor
-        .executeSkill("consistency-check", {
+        .executeSkill("builtin:consistency-check", {
           projectId: ctx.projectId,
           documentId: ctx.documentId,
           documentContent: ctx.fullText,

--- a/apps/desktop/main/src/services/skills/skillService.ts
+++ b/apps/desktop/main/src/services/skills/skillService.ts
@@ -153,6 +153,12 @@ type SkillRegistryCacheEntry = {
   skills: LoadedSkill[];
 };
 
+const P3_SKILL_ALIAS_LEAF_IDS = new Set<string>([
+  "consistency-check",
+  "dialogue-gen",
+  "outline-expand",
+]);
+
 function normalizeCustomSkillId(id: string): string {
   if (id.startsWith("custom:")) {
     return id.slice("custom:".length);
@@ -163,6 +169,24 @@ function normalizeCustomSkillId(id: string): string {
 function leafSkillId(id: string): string {
   const parts = id.split(":");
   return parts[parts.length - 1] ?? id;
+}
+
+function resolveRunSkillIdCandidates(id: string): string[] {
+  const trimmed = id.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+  if (trimmed.startsWith("builtin:")) {
+    const leaf = trimmed.slice("builtin:".length);
+    if (P3_SKILL_ALIAS_LEAF_IDS.has(leaf)) {
+      return [trimmed, leaf];
+    }
+    return [trimmed];
+  }
+  if (P3_SKILL_ALIAS_LEAF_IDS.has(trimmed)) {
+    return [trimmed, `builtin:${trimmed}`];
+  }
+  return [trimmed];
 }
 
 function encodeCustomListId(id: string): string {
@@ -1453,10 +1477,10 @@ function executeResolveForRun(
     );
   }
 
-  const requestedLeafId = leafSkillId(id);
+  const skillIdCandidates = resolveRunSkillIdCandidates(id);
   const skill =
     loaded.data.skills.find(
-      (s) => s.id === id || leafSkillId(s.id) === requestedLeafId,
+      (s) => skillIdCandidates.includes(s.id),
     ) ?? null;
   if (!skill) {
     return ipcError("NOT_FOUND", "Skill not found", { id });

--- a/apps/desktop/main/src/services/skills/skillService.ts
+++ b/apps/desktop/main/src/services/skills/skillService.ts
@@ -1453,12 +1453,16 @@ function executeResolveForRun(
     );
   }
 
-  const skill = loaded.data.skills.find((s) => s.id === id) ?? null;
+  const requestedLeafId = leafSkillId(id);
+  const skill =
+    loaded.data.skills.find(
+      (s) => s.id === id || leafSkillId(s.id) === requestedLeafId,
+    ) ?? null;
   if (!skill) {
     return ipcError("NOT_FOUND", "Skill not found", { id });
   }
 
-  const enabled = loaded.data.enabledMap.get(id) ?? true;
+  const enabled = loaded.data.enabledMap.get(skill.id) ?? true;
   return {
     ok: true,
     data: {


### PR DESCRIPTION
## Summary
- normalize P3 skill execution IDs so builtin-prefixed and leaf IDs are both accepted by P3SkillExecutor
- register both canonical and builtin-prefixed IDs for P3 tools, and move quality-check hook invocation to builtin:consistency-check
- make SkillService.resolveForRun resolve by leaf ID, so prefixed P3 IDs map to the same loaded manifest
- add and adjust runtime and hook tests to lock alias behavior and prevent regression

Closes #173

## Invariant Checklist
- [x] INV-1 原稿保护：本改动不新增写回路径，仍走现有 orchestrator/tooling
- [x] INV-2 并发安全：未改并发模型
- [x] INV-3 CJK Token：不涉及
- [x] INV-4 Memory-First：不涉及检索存储策略变更
- [x] INV-5 叙事压缩：不涉及
- [x] INV-6 一切皆 Skill：P3 quality-check 改为显式 builtin:consistency-check，并保证 alias 兼容
- [x] INV-7 统一入口：未绕开现有 Skill/IPC 边界
- [x] INV-8 Hook 链：quality-check hook 语义保持 fire-and-forget
- [x] INV-9 成本追踪：不涉及
- [x] INV-10 错误不丢上下文：错误分支保持结构化返回与日志

## Validation Evidence
- pnpm -C apps/desktop test -- src/services/skills/__tests__/p3-skills.test.ts src/services/skills/__tests__/postWritingHooks.test.ts src/services/skills/__tests__/p3-runtime.execution.test.ts src/ipc/__tests__/ai-handlers-delegation.test.ts
- pnpm --filter @creonow/desktop typecheck

## Visual Evidence
### Embedded Screenshots
![Backend-only change placeholder](https://dummyimage.com/1200x675/0f172a/e2e8f0.png&text=P3+Skill+ID+Alias+Compatibility)

### Storybook Artifact / Link
- Link: https://github.com/Leeky1017/CreoNow/blob/task/173-p3-07-core-skills/apps/desktop/storybook-static/index.html
- Visual acceptance note: backend-only change; no renderer visual delta expected.

## Risk & Rollback
- Risk: low（ID 归一化与别名注册改动，主要影响 P3 技能路由）
- Rollback: git revert 1c64cf4

## Audit Gate
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)
- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT pending
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT pending
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT waived in-thread

Actual in-thread audit policy for this task:
- 审计 A：gpt-5.3-codex xhigh subagent — pending
- 审计 B：gpt-5.4 high subagent — pending
