### PR TITLE
feat(memory): wire episodic extraction hook (#190)

### DIFF
--- a/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/extract-session-events/SKILL.md
+++ b/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/extract-session-events/SKILL.md
@@ -14,10 +14,9 @@ context_rules:
   surrounding: 0
   user_preferences: false
   style_guide: false
-  characters: true
-  outline: true
-  recent_summary: 0
-  knowledge_graph: true
+  characters: false
+  outline: false
+  knowledge_graph: false
 prompt:
   system: |
     你是 CreoNow 的 episodic memory 提取器。

--- a/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/extract-session-events/SKILL.md
+++ b/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/extract-session-events/SKILL.md
@@ -1,0 +1,54 @@
+---
+id: extract-session-events
+name: 会话事件提取
+description: 从当前写作内容提取可落库的 episodic 事件
+version: "1.0.0"
+tags: ["analysis", "memory", "episodic", "p4"]
+kind: single
+scope: builtin
+packageId: pkg.creonow.builtin
+inputType: document
+outputType: annotation
+permissionLevel: auto-allow
+context_rules:
+  surrounding: 0
+  user_preferences: false
+  style_guide: false
+  characters: true
+  outline: true
+  recent_summary: 0
+  knowledge_graph: true
+prompt:
+  system: |
+    你是 CreoNow 的 episodic memory 提取器。
+    任务：从输入正文中提取“本次写作值得记住的事件”，用于后续记忆蒸馏。
+    只输出 JSON，不要输出解释。
+  user: |
+    请提取 0~3 条关键事件，并严格按以下 JSON 返回：
+    {
+      "events": [
+        {
+          "sceneType": "dialogue|action|description|turning_point|general",
+          "summary": "string",
+          "inputContext": "string",
+          "finalText": "string",
+          "importance": 0.0,
+          "editDistance": 0.0
+        }
+      ]
+    }
+
+    规则：
+    - 没有明显事件时返回 {"events":[]}
+    - importance 取值范围 0~1
+    - editDistance 若未知填 0
+    - finalText 使用可直接存档的短句（<=200 字）
+
+    <input>
+    {{input}}
+    </input>
+---
+
+# extract-session-events
+
+用于 INV-8 post-writing hook 的会话事件提取入口。输出供 `episodicMemoryService.recordEpisode` 落库。

--- a/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/update-writing-profile/SKILL.md
+++ b/apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/update-writing-profile/SKILL.md
@@ -1,0 +1,49 @@
+---
+id: update-writing-profile
+name: 写作画像更新
+description: 基于累计情景事件提炼持久写作偏好
+version: "1.0.0"
+tags: ["analysis", "memory", "semantic", "p4"]
+kind: single
+scope: builtin
+packageId: pkg.creonow.builtin
+inputType: document
+outputType: annotation
+permissionLevel: auto-allow
+context_rules:
+  surrounding: 0
+  user_preferences: true
+  style_guide: true
+  characters: true
+  outline: true
+  recent_summary: 5
+  knowledge_graph: true
+prompt:
+  system: |
+    你是 CreoNow 的语义记忆蒸馏助手。
+    从输入的 episodic 线索中提炼稳定写作偏好，输出结构化 JSON。
+  user: |
+    请输出 JSON：
+    {
+      "rules": [
+        {
+          "rule": "string",
+          "category": "style|structure|character|pacing|vocabulary",
+          "confidence": 0.0
+        }
+      ]
+    }
+
+    规则：
+    - 只保留长期有效偏好，不要记录一次性剧情细节
+    - confidence 在 0~1
+    - 没有可靠结论时返回 {"rules":[]}
+
+    <input>
+    {{input}}
+    </input>
+---
+
+# update-writing-profile
+
+用于 P4+ 的语义记忆更新入口。当前主要用于注册能力与后续 hook/定时蒸馏对接。

--- a/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
+++ b/apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts
@@ -249,6 +249,13 @@ function createHarness(
     debug: vi.fn(),
     logPath: "<test>",
   };
+  const eventBus = withEventBus
+    ? ({
+        emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+      } as const)
+    : undefined;
 
   const db = dbNull
     ? null
@@ -286,15 +293,7 @@ function createHarness(
           } as unknown as never,
         }
       : {}),
-    ...(withEventBus
-      ? {
-          eventBus: {
-            emit: vi.fn(),
-            on: vi.fn(),
-            off: vi.fn(),
-          } as unknown as never,
-        }
-      : {}),
+    ...(eventBus ? { eventBus: eventBus as unknown as never } : {}),
   });
 
   return {
@@ -305,6 +304,7 @@ function createHarness(
     },
     handlers,
     logger,
+    eventBus,
   };
 }
 
@@ -337,6 +337,7 @@ describe("AI IPC channel registration", () => {
     vi.clearAllMocks();
     mocks.skillListMock.mockReturnValue({ ok: true, data: { items: [] } });
     mocks.skillResolveForRunMock.mockReturnValue(makeResolvedSkill("builtin:chat"));
+    mocks.createEpisodicMemoryServiceMock.mockReturnValue({});
   });
 
   it("注册所有预期通道", () => {
@@ -441,6 +442,87 @@ describe("AI IPC channel registration", () => {
         projectId: "proj-001",
         documentId: "doc-001",
         documentContent: "李明在青云城门口看见了与设定不符的细节。",
+      }),
+    );
+  });
+
+  it("触发 episodic-extract hook 时写入 episode 并发射 episode:created 事件", async () => {
+    const recordEpisode = vi.fn().mockResolvedValue({
+      ok: true,
+      data: {
+        accepted: true,
+        episodeId: "ep-integration-1",
+        retryCount: 0,
+        implicitSignal: "DIRECT_ACCEPT",
+        implicitWeight: 1,
+      },
+    });
+    mocks.createEpisodicMemoryServiceMock.mockReturnValue({
+      listSemanticMemory: vi.fn().mockReturnValue({
+        ok: true,
+        data: { items: [], conflictQueue: [] },
+      }),
+      recordEpisode,
+    });
+
+    const harness = createHarness(false, true, true);
+    const firstCall =
+      mocks.createWritingOrchestratorMock.mock.calls[0] as unknown[] | undefined;
+    const orchestratorConfig = firstCall?.[0] as
+      | {
+          postWritingHooks?: Array<{
+            name: string;
+            execute: (ctx: {
+              requestId: string;
+              documentId: string;
+              projectId?: string;
+              sessionId?: string;
+              fullText: string;
+            }) => Promise<void>;
+          }>;
+        }
+      | undefined;
+    const episodicHook = orchestratorConfig?.postWritingHooks?.find(
+      (hook) => hook.name === "episodic-extract",
+    );
+    const executorInstance = mocks.createP3SkillExecutorMock.mock.results[0]?.value as
+      | { executeSkill: ReturnType<typeof vi.fn> }
+      | undefined;
+    executorInstance?.executeSkill.mockResolvedValue({
+      success: true,
+      data: {
+        events: [
+          {
+            sceneType: "turning_point",
+            summary: "主角在雨夜撕毁盟约",
+            importance: 0.88,
+          },
+        ],
+      },
+    });
+
+    expect(episodicHook).toBeDefined();
+    await episodicHook?.execute({
+      requestId: "req-ep-001",
+      documentId: "doc-ep-001",
+      projectId: "proj-ep-001",
+      sessionId: "sess-ep-001",
+      fullText: "在雨夜中，他当众撕毁了旧盟约。",
+    });
+
+    expect(recordEpisode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj-ep-001",
+        chapterId: "doc-ep-001",
+        sceneType: "turning_point",
+      }),
+    );
+    expect(harness.eventBus?.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "episode:created",
+        projectId: "proj-ep-001",
+        documentId: "doc-ep-001",
+        episodeId: "ep-integration-1",
       }),
     );
   });

--- a/apps/desktop/main/src/ipc/ai.ts
+++ b/apps/desktop/main/src/ipc/ai.ts
@@ -1193,7 +1193,8 @@ type AiIpcDeps = {
   projectSessionBinding?: ProjectSessionBindingRegistry;
   costTracker?: CostTracker;
   eventBus?: EventBusLike;
-  episodicMemoryService?: Pick<EpisodicMemoryService, "listSemanticMemory">;
+  episodicMemoryService?: Pick<EpisodicMemoryService, "listSemanticMemory"> &
+    Partial<Pick<EpisodicMemoryService, "recordEpisode">>;
 };
 
 type AiIpcContext = {
@@ -1542,6 +1543,19 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
           logger: deps.logger,
         })
       : undefined);
+  const episodicMemoryServiceForHooks = (() => {
+    const maybeRecordEpisode = (
+      episodicMemoryServiceForContext as
+        | Partial<Pick<EpisodicMemoryService, "recordEpisode">>
+        | undefined
+    )?.recordEpisode;
+    if (typeof maybeRecordEpisode !== "function") {
+      return undefined;
+    }
+    return {
+      recordEpisode: maybeRecordEpisode.bind(episodicMemoryServiceForContext),
+    };
+  })();
   const contextAssemblyService = createContextLayerAssemblyService(
     undefined,
     deps.db
@@ -1804,7 +1818,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
         bridgeAiService,
       })
     : createNullWritingOrchestratorAiService();
-  const p3QualityCheckExecutor =
+  const p3HookSkillExecutor =
     bridgeAiService && deps.eventBus
         ? createP3SkillExecutor({
             aiService: createP3AiServiceAdapter({
@@ -1821,7 +1835,7 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
               get: () => undefined,
               unregister: () => undefined,
             },
-          })
+        })
         : undefined;
   const generateText = createWritingGenerateText({
     aiService,
@@ -1940,10 +1954,20 @@ export function registerAiIpcHandlers(deps: AiIpcDeps): void {
               },
           logger: deps.logger,
         },
-        ...(p3QualityCheckExecutor
+        ...(p3HookSkillExecutor && episodicMemoryServiceForHooks
+          ? {
+              episodicExtract: {
+                skillExecutor: p3HookSkillExecutor,
+                episodicMemory: episodicMemoryServiceForHooks,
+                logger: deps.logger,
+                eventBus: deps.eventBus,
+              },
+            }
+          : {}),
+        ...(p3HookSkillExecutor
           ? {
               qualityCheck: {
-                skillExecutor: p3QualityCheckExecutor,
+                skillExecutor: p3HookSkillExecutor,
                 logger: deps.logger,
               },
             }

--- a/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/p3-skills.test.ts
@@ -388,6 +388,43 @@ System prompt.`;
       expect(result.success).toBe(true);
     });
 
+    it("extract-session-events 在没有角色/地点设定时仍可执行", async () => {
+      contextEngine.assembleContext.mockResolvedValue({
+        success: true,
+        data: {
+          prompt: "纯正文输入",
+          hasCharacterSettings: false,
+          hasLocationSettings: false,
+        },
+      });
+      aiService.complete.mockResolvedValue({
+        content: JSON.stringify({
+          events: [
+            {
+              sceneType: "general",
+              summary: "章节开场建立了新的行动目标",
+              finalText: "角色确认新的行动目标。",
+              importance: 0.8,
+              editDistance: 0,
+            },
+          ],
+        }),
+      });
+
+      const result = await executor.executeSkill("builtin:extract-session-events", {
+        projectId: "proj-1",
+        documentId: "doc-1",
+        documentContent: "角色确认新的行动目标。",
+      });
+
+      expect(result.success).toBe(true);
+      expect(aiService.complete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skillId: "builtin:extract-session-events",
+        }),
+      );
+    });
+
     it("minInputLength 不满足时返回错误", async () => {
       const result = await executor.executeSkill("dialogue-gen", {
         projectId: "proj-1",

--- a/apps/desktop/main/src/services/skills/__tests__/postWritingHooks.test.ts
+++ b/apps/desktop/main/src/services/skills/__tests__/postWritingHooks.test.ts
@@ -17,24 +17,32 @@ import { describe, it, expect, vi } from "vitest";
 import {
   createKgUpdateHook,
   createMemoryExtractHook,
+  createEpisodicExtractHook,
   createQualityCheckHook,
   buildPostWritingHookChain,
   extractWritingContext,
   KG_UPDATE_PRIORITY,
   MEMORY_EXTRACT_PRIORITY,
+  EPISODIC_EXTRACT_PRIORITY,
   QUALITY_CHECK_PRIORITY,
 } from "../postWritingHooks";
 import type {
+  EpisodicExtractHookDeps,
   KgUpdateHookDeps,
   MemoryExtractHookDeps,
   QualityCheckHookDeps,
 } from "../postWritingHooks";
 import type { PostWritingHookContext } from "../orchestrator";
+import {
+  createEpisodicMemoryService,
+  createInMemoryEpisodeRepository,
+} from "../../memory/episodicMemoryService";
 
 // ─── Mock factories ─────────────────────────────────────────────────
 
 function makeLogger() {
   return {
+    logPath: "/tmp/post-writing-hooks.test.log",
     info: vi.fn(),
     error: vi.fn(),
   };
@@ -120,6 +128,44 @@ function makeQualityCheckDeps(overrides: Partial<QualityCheckHookDeps> = {}): Qu
       }),
     },
     logger: makeLogger(),
+    ...overrides,
+  };
+}
+
+function makeEpisodicExtractDeps(
+  overrides: Partial<EpisodicExtractHookDeps> = {},
+): EpisodicExtractHookDeps {
+  return {
+    skillExecutor: {
+      executeSkill: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          events: [
+            {
+              sceneType: "dialogue",
+              summary: "李明首次公开青云城身世",
+              importance: 0.92,
+            },
+          ],
+        },
+      }),
+    },
+    episodicMemory: {
+      recordEpisode: vi.fn().mockResolvedValue({
+        ok: true,
+        data: {
+          accepted: true,
+          episodeId: "ep-001",
+          retryCount: 0,
+          implicitSignal: "DIRECT_ACCEPT",
+          implicitWeight: 1,
+        },
+      }),
+    },
+    logger: makeLogger(),
+    eventBus: {
+      emit: vi.fn(),
+    },
     ...overrides,
   };
 }
@@ -395,6 +441,125 @@ describe("createMemoryExtractHook", () => {
   });
 });
 
+// ─── Episodic Extract Hook ─────────────────────────────────────────
+
+describe("createEpisodicExtractHook", () => {
+  it("has correct name and priority", () => {
+    const hook = createEpisodicExtractHook(makeEpisodicExtractDeps());
+    expect(hook.name).toBe("episodic-extract");
+    expect(hook.priority).toBe(EPISODIC_EXTRACT_PRIORITY);
+  });
+
+  it("通过 Skill 提取事件并写入 episodic memory，然后发射 episode:created", async () => {
+    const deps = makeEpisodicExtractDeps();
+    const hook = createEpisodicExtractHook(deps);
+    const ctx = makeContext({
+      fullText: "李明在青云城门口揭露真实身份，众人震惊。",
+    });
+
+    await hook.execute(ctx);
+
+    expect(deps.skillExecutor.executeSkill).toHaveBeenCalledWith(
+      "builtin:extract-session-events",
+      expect.objectContaining({
+        projectId: "proj-001",
+        documentId: "doc-001",
+        documentContent: ctx.fullText,
+      }),
+    );
+    expect(deps.episodicMemory.recordEpisode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj-001",
+        chapterId: "doc-001",
+        sceneType: "dialogue",
+        finalText: expect.stringContaining("李明首次公开"),
+      }),
+    );
+    expect(deps.eventBus?.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "episode:created",
+        projectId: "proj-001",
+        documentId: "doc-001",
+        episodeId: "ep-001",
+      }),
+    );
+  });
+
+  it("hook 执行后 episodic 查询可见新增行", async () => {
+    const repo = createInMemoryEpisodeRepository();
+    const episodicSvc = createEpisodicMemoryService({
+      repository: repo,
+      logger: {
+        logPath: "/tmp/post-writing-hooks.episodic.log",
+        info: () => undefined,
+        error: () => undefined,
+      },
+      semanticRecall: () => [],
+    });
+    const hook = createEpisodicExtractHook({
+      skillExecutor: {
+        executeSkill: vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            events: [
+              {
+                sceneType: "turning_point",
+                summary: "主角决定背叛旧盟约",
+                importance: 0.86,
+              },
+            ],
+          },
+        }),
+      },
+      episodicMemory: episodicSvc,
+      logger: makeLogger(),
+      eventBus: {
+        emit: vi.fn(),
+      },
+    });
+
+    await hook.execute(
+      makeContext({
+        projectId: "proj-episodic",
+        documentId: "chapter-7",
+        fullText: "在雨夜中，他撕毁了旧盟约，决定独自前行。",
+      }),
+    );
+
+    const queried = episodicSvc.queryEpisodes({
+      projectId: "proj-episodic",
+      sceneType: "turning_point",
+      queryText: "背叛 盟约",
+    });
+    expect(queried.ok).toBe(true);
+    if (!queried.ok) {
+      return;
+    }
+    expect(queried.data.items.length).toBe(1);
+    expect(queried.data.items[0]?.chapterId).toBe("chapter-7");
+  });
+
+  it("skill 执行失败时只记录错误，不写 episodic", async () => {
+    const deps = makeEpisodicExtractDeps({
+      skillExecutor: {
+        executeSkill: vi.fn().mockResolvedValue({
+          success: false,
+          error: { code: "AI_SERVICE_ERROR", message: "timeout" },
+        }),
+      },
+    });
+    const hook = createEpisodicExtractHook(deps);
+
+    await hook.execute(makeContext());
+
+    expect(deps.episodicMemory.recordEpisode).not.toHaveBeenCalled();
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      "episodic-extract:skill-failed",
+      expect.objectContaining({ code: "AI_SERVICE_ERROR" }),
+    );
+  });
+});
+
 // ─── Quality Check Hook ─────────────────────────────────────────────
 
 describe("createQualityCheckHook", () => {
@@ -524,30 +689,34 @@ describe("createQualityCheckHook", () => {
 // ─── Priority ordering ──────────────────────────────────────────────
 
 describe("hook priority ordering", () => {
-  it("priorities are in correct order: kg-update < memory-extract < quality-check", () => {
+  it("priorities are in correct order: kg-update < memory-extract < episodic-extract < quality-check", () => {
     expect(KG_UPDATE_PRIORITY).toBeLessThan(MEMORY_EXTRACT_PRIORITY);
-    expect(MEMORY_EXTRACT_PRIORITY).toBeLessThan(QUALITY_CHECK_PRIORITY);
+    expect(MEMORY_EXTRACT_PRIORITY).toBeLessThan(EPISODIC_EXTRACT_PRIORITY);
+    expect(EPISODIC_EXTRACT_PRIORITY).toBeLessThan(QUALITY_CHECK_PRIORITY);
   });
 
-  it("hooks from buildPostWritingHookChain are sorted by priority (with qualityCheck)", () => {
+  it("hooks from buildPostWritingHookChain are sorted by priority (with episodic + qualityCheck)", () => {
     const hooks = buildPostWritingHookChain({
       kgUpdate: makeKgUpdateDeps(),
       memoryExtract: makeMemoryExtractDeps(),
+      episodicExtract: makeEpisodicExtractDeps(),
       qualityCheck: makeQualityCheckDeps(),
     });
 
-    expect(hooks).toHaveLength(3);
+    expect(hooks).toHaveLength(4);
     expect(hooks[0]!.name).toBe("kg-update");
     expect(hooks[1]!.name).toBe("memory-extract");
-    expect(hooks[2]!.name).toBe("quality-check");
+    expect(hooks[2]!.name).toBe("episodic-extract");
+    expect(hooks[3]!.name).toBe("quality-check");
 
     // Verify priority is set
     expect(hooks[0]!.priority).toBe(KG_UPDATE_PRIORITY);
     expect(hooks[1]!.priority).toBe(MEMORY_EXTRACT_PRIORITY);
-    expect(hooks[2]!.priority).toBe(QUALITY_CHECK_PRIORITY);
+    expect(hooks[2]!.priority).toBe(EPISODIC_EXTRACT_PRIORITY);
+    expect(hooks[3]!.priority).toBe(QUALITY_CHECK_PRIORITY);
   });
 
-  it("hooks from buildPostWritingHookChain omits quality-check when deps absent", () => {
+  it("hooks from buildPostWritingHookChain omits optional hooks when deps absent", () => {
     const hooks = buildPostWritingHookChain({
       kgUpdate: makeKgUpdateDeps(),
       memoryExtract: makeMemoryExtractDeps(),
@@ -625,21 +794,23 @@ describe("error isolation across hooks", () => {
 // ─── buildPostWritingHookChain ──────────────────────────────────────
 
 describe("buildPostWritingHookChain", () => {
-  it("creates all 3 hooks when qualityCheck deps are provided", () => {
+  it("creates all 4 hooks when episodic+quality deps are provided", () => {
     const hooks = buildPostWritingHookChain({
       kgUpdate: makeKgUpdateDeps(),
       memoryExtract: makeMemoryExtractDeps(),
+      episodicExtract: makeEpisodicExtractDeps(),
       qualityCheck: makeQualityCheckDeps(),
     });
 
-    expect(hooks).toHaveLength(3);
+    expect(hooks).toHaveLength(4);
     const names = hooks.map((h) => h.name);
     expect(names).toContain("kg-update");
     expect(names).toContain("memory-extract");
+    expect(names).toContain("episodic-extract");
     expect(names).toContain("quality-check");
   });
 
-  it("creates only 2 hooks when qualityCheck deps are omitted", () => {
+  it("creates only 2 hooks when optional deps are omitted", () => {
     const hooks = buildPostWritingHookChain({
       kgUpdate: makeKgUpdateDeps(),
       memoryExtract: makeMemoryExtractDeps(),

--- a/apps/desktop/main/src/services/skills/p3Skills.ts
+++ b/apps/desktop/main/src/services/skills/p3Skills.ts
@@ -44,6 +44,8 @@ const P3_SKILL_CANONICAL_IDS = [
   "consistency-check",
   "dialogue-gen",
   "outline-expand",
+  "extract-session-events",
+  "update-writing-profile",
 ] as const;
 
 const P3_SKILL_CANONICAL_ID_SET = new Set<string>(P3_SKILL_CANONICAL_IDS);

--- a/apps/desktop/main/src/services/skills/postWritingHooks.ts
+++ b/apps/desktop/main/src/services/skills/postWritingHooks.ts
@@ -20,6 +20,7 @@ import type { MatchResult, MatchableEntity } from "../kg/entityMatcher";
 import type { KnowledgeGraphService, KnowledgeEntity } from "../kg/types";
 import type { KgMutationSkill } from "./kgMutationSkill";
 import type { SessionMemoryService } from "../memory/sessionMemoryService";
+import type { EpisodicMemoryService } from "../memory/episodicMemoryService";
 import type { P3SkillExecutor } from "./p3Skills";
 import type { Logger } from "../../logging/logger";
 
@@ -32,6 +33,8 @@ import type { Logger } from "../../logging/logger";
 export const KG_UPDATE_PRIORITY = 30;
 /** Memory extract runs second — may reference entities recognized by kg-update. */
 export const MEMORY_EXTRACT_PRIORITY = 40;
+/** Episodic extract runs after L1 extraction and before quality check. */
+export const EPISODIC_EXTRACT_PRIORITY = 45;
 /** Quality check runs last — validates against the latest KG state. */
 export const QUALITY_CHECK_PRIORITY = 50;
 
@@ -186,6 +189,16 @@ export interface MemoryExtractHookDeps {
   logger: Pick<Logger, "info" | "error">;
 }
 
+export interface EpisodicExtractHookDeps {
+  skillExecutor: Pick<P3SkillExecutor, "executeSkill">;
+  episodicMemory: Pick<EpisodicMemoryService, "recordEpisode">;
+  logger: Pick<Logger, "info" | "error">;
+  eventBus?: {
+    emit: (event: Record<string, unknown>) => void;
+  };
+  now?: () => number;
+}
+
 /**
  * Heuristic extraction patterns for writing context.
  *
@@ -279,6 +292,161 @@ export function createMemoryExtractHook(
   };
 }
 
+type SessionEventCandidate = {
+  sceneType?: string;
+  summary?: string;
+  inputContext?: string;
+  finalText?: string;
+  skillUsed?: string;
+  chapterId?: string;
+  importance?: number;
+  editDistance?: number;
+};
+
+function asEventCandidates(data: unknown): SessionEventCandidate[] {
+  if (!data || typeof data !== "object") {
+    return [];
+  }
+  const maybeEvents = (data as { events?: unknown }).events;
+  if (!Array.isArray(maybeEvents)) {
+    return [];
+  }
+  return maybeEvents.filter(
+    (event): event is SessionEventCandidate =>
+      typeof event === "object" && event !== null,
+  );
+}
+
+function clampEpisodeImportance(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.min(1, value));
+  }
+  return 0.6;
+}
+
+/**
+ * Create a post-writing hook that routes extraction through Skill runtime
+ * and persists structured episode rows.
+ *
+ * @invariant INV-6 — extraction step always goes through registered Skill.
+ * @invariant INV-8 — hook executes after write-back, non-blocking for pipeline.
+ */
+export function createEpisodicExtractHook(
+  deps: EpisodicExtractHookDeps,
+): PostWritingHook {
+  return {
+    name: "episodic-extract",
+    priority: EPISODIC_EXTRACT_PRIORITY,
+    async execute(ctx: PostWritingHookContext): Promise<void> {
+      if (!hasProcessableText(ctx) || !ctx.projectId) {
+        return;
+      }
+
+      const text = truncateText(ctx.fullText);
+      const result = await deps.skillExecutor.executeSkill(
+        "builtin:extract-session-events",
+        {
+          projectId: ctx.projectId,
+          documentId: ctx.documentId,
+          documentContent: text,
+        },
+      );
+
+      if (!result.success) {
+        deps.logger.error("episodic-extract:skill-failed", {
+          projectId: ctx.projectId,
+          documentId: ctx.documentId,
+          code: result.error?.code,
+          message: result.error?.message,
+        });
+        return;
+      }
+
+      const extractedEvents = asEventCandidates(result.data);
+      if (extractedEvents.length === 0) {
+        return;
+      }
+
+      for (const extracted of extractedEvents) {
+        const finalText =
+          (typeof extracted.finalText === "string" &&
+          extracted.finalText.trim().length > 0
+            ? extracted.finalText
+            : typeof extracted.summary === "string" &&
+                extracted.summary.trim().length > 0
+              ? extracted.summary
+              : text
+          ).trim();
+        const inputContext =
+          (typeof extracted.inputContext === "string" &&
+          extracted.inputContext.trim().length > 0
+            ? extracted.inputContext
+            : text.slice(0, 800)
+          ).trim();
+        const sceneType =
+          typeof extracted.sceneType === "string" &&
+          extracted.sceneType.trim().length > 0
+            ? extracted.sceneType.trim()
+            : "general";
+        const editDistance =
+          typeof extracted.editDistance === "number" &&
+          Number.isFinite(extracted.editDistance) &&
+          extracted.editDistance >= 0
+            ? extracted.editDistance
+            : 0;
+
+        const recordResult = await deps.episodicMemory.recordEpisode({
+          projectId: ctx.projectId,
+          chapterId:
+            typeof extracted.chapterId === "string" &&
+            extracted.chapterId.trim().length > 0
+              ? extracted.chapterId.trim()
+              : ctx.documentId,
+          sceneType,
+          skillUsed:
+            typeof extracted.skillUsed === "string" &&
+            extracted.skillUsed.trim().length > 0
+              ? extracted.skillUsed.trim()
+              : "builtin:extract-session-events",
+          inputContext,
+          candidates: [finalText],
+          selectedIndex: 0,
+          finalText,
+          editDistance,
+          importance: clampEpisodeImportance(extracted.importance),
+          acceptedWithoutEdit: editDistance === 0,
+          userConfirmed: false,
+        });
+
+        if (!recordResult.ok) {
+          deps.logger.error("episodic-extract:record-failed", {
+            projectId: ctx.projectId,
+            documentId: ctx.documentId,
+            code: recordResult.error.code,
+            message: recordResult.error.message,
+          });
+          continue;
+        }
+
+        deps.logger.info("episodic-extract:episode-created", {
+          projectId: ctx.projectId,
+          documentId: ctx.documentId,
+          episodeId: recordResult.data.episodeId,
+        });
+        deps.eventBus?.emit({
+          type: "episode:created",
+          timestamp: deps.now ? deps.now() : Date.now(),
+          projectId: ctx.projectId,
+          documentId: ctx.documentId,
+          sessionId: ctx.sessionId,
+          episodeId: recordResult.data.episodeId,
+          sceneType,
+        });
+      }
+    },
+  };
+}
+
 // ─── Quality Check Hook ─────────────────────────────────────────────
 
 export interface QualityCheckHookDeps {
@@ -353,6 +521,7 @@ export function createQualityCheckHook(
 export interface PostWritingHookChainDeps {
   kgUpdate: KgUpdateHookDeps;
   memoryExtract: MemoryExtractHookDeps;
+  episodicExtract?: EpisodicExtractHookDeps;
   /**
    * Optional — some callers only have the fast local hook dependencies and
    * deliberately omit the LLM-backed quality-check leg.
@@ -378,6 +547,9 @@ export function buildPostWritingHookChain(
     createKgUpdateHook(deps.kgUpdate),
     createMemoryExtractHook(deps.memoryExtract),
   ];
+  if (deps.episodicExtract) {
+    hooks.push(createEpisodicExtractHook(deps.episodicExtract));
+  }
   if (deps.qualityCheck) {
     hooks.push(createQualityCheckHook(deps.qualityCheck));
   }

--- a/docs/playbook/03-p4-advanced-intelligence.md
+++ b/docs/playbook/03-p4-advanced-intelligence.md
@@ -22,13 +22,14 @@ P3 全部退出条件满足 + INV-1~INV-10 全部合规。
 - 检索路径：KG+FTS5 为主 → sqlite-vec 语义召回补充（INV-4）
 
 **文件**：
-- `apps/desktop/main/src/services/memory/episodicMemory.ts` — 已有空壳，填充实现
-- `apps/desktop/main/src/services/memory/semanticMemory.ts` — 已有空壳，填充实现
+- `apps/desktop/main/src/services/memory/episodicMemoryService.ts` — 情景记忆主服务（已落地）
+- `apps/desktop/main/src/services/skills/postWritingHooks.ts` — INV-8 hook 链（含 episodic 提取）
 - `apps/desktop/main/src/services/memory/userMemoryVec.ts` — sqlite-vec 已实现，优化召回精度
 
 **新 Migration**：
-- `0028_memory_episodic_events.sql`：episodic 事件表 (session_id, event_type, entity_refs, content, timestamp)
-- `0029_memory_semantic_profile.sql`：语义档案表 (user_id, profile_type, extracted_value, confidence, updated_at)
+- `0012_memory_episodic_storage.sql`：episodic + semantic placeholder 的当前 SSOT
+- `0028_memory_session_events.sql`：session memory 事件流（非 episodic 主表）
+- `0029_project_milestones.sql`：项目里程碑事件（Engagement，不是 semantic profile）
 
 **Skill 依赖**：
 - `extract-session-events` Skill：从写作 session 提取关键事件（LLM，post-writing hook）

--- a/docs/playbook/03-p4-advanced-intelligence.md
+++ b/docs/playbook/03-p4-advanced-intelligence.md
@@ -24,9 +24,9 @@
 - `0028_memory_session_events.sql`：session memory 事件流（非 episodic 主表）
 - `0029_project_milestones.sql`：项目里程碑事件（Engagement，不是 semantic profile）
 
-**Skill 依赖（已接入主链）**：
-- `extract-session-events` Skill：从写作 session 提取关键事件（LLM，post-writing hook）
-- `update-writing-profile` Skill：从累积 session 事件中提取持久偏好（LLM，定期触发）
+**Skill 依赖**：
+- `extract-session-events` Skill：从写作 session 提取关键事件（LLM，post-writing hook，已接入主链）
+- `update-writing-profile` Skill：从累积 session 事件中提取持久偏好（LLM，能力已注册，但调度仍未接入）
 
 **仍需完成**：
 - `update-writing-profile` 调度与前台消费


### PR DESCRIPTION
## 概述

为 P4-01 补上 episodic memory 的真正写入链：新增 `extract-session-events` / `update-writing-profile` 两个内置技能定义，把 episodic extraction 接入 INV-8 post-writing hooks，并补齐相应测试与 playbook 说明。

Closes #190

## 变更类型

- [x] Feature（新功能）
- [ ] Fix（修复）
- [ ] Docs（文档）
- [ ] Refactor（重构）
- [x] Test（测试）
- [ ] CI/Infra（工程）

## 影响范围

- `apps/desktop/main/src/services/skills/postWritingHooks.ts`
- `apps/desktop/main/src/ipc/ai.ts`
- `apps/desktop/main/src/services/skills/p3Skills.ts`
- `apps/desktop/main/skills/packages/pkg.creonow.builtin/1.0.0/skills/`
- `apps/desktop/main/src/ipc/__tests__/ai-handlers-delegation.test.ts`
- `apps/desktop/main/src/services/skills/__tests__/postWritingHooks.test.ts`
- `docs/playbook/03-p4-advanced-intelligence.md`

---

## 阶段 A：设计文档

### 涉及的 Invariants

- INV-4 Memory-First：episodic memory 从“服务存在”推进到“写后自动落库”
- INV-6 一切皆 Skill：事件提取通过 `extract-session-events` skill 进入统一链路
- INV-8 Hook 链：新增 episodic-extract hook，位于 memory-extract 与 quality-check 之间
- INV-10 错误不丢上下文：skill 失败 / 落库失败只记录错误并继续链路

### 模块边界图

`ai.ts` 负责装配 hook 依赖 → `postWritingHooks.ts` 负责编排 hook 工厂 → `p3Skills.ts` 负责 skill id 解析与执行 → `episodicMemoryService.recordEpisode()` 持久化事件。未新增 renderer 依赖，也未让 IPC handler 直调底层 DB。

### Definition of Done

- 新增的 episodic skills 可被 P3 executor 识别
- 写作后 hook 会调用 `extract-session-events` 并写入 episodic memory
- 成功后发射 `episode:created` 事件
- 相关单测通过
- playbook 中 P4-01 的文件/迁移描述与当前仓库现实一致

---

## 阶段 B：Invariant Checklist

- [x] **INV-1 原稿保护** — 本 PR 不新增直接写正文路径
- [x] **INV-2 并发安全** — 未改变工具并发模型
- [x] **INV-3 CJK Token** — 未使用 UTF8_BYTES/4
- [x] **INV-4 Memory-First** — episodic 自动落库进入主链
- [x] **INV-5 叙事压缩** — 不涉及
- [x] **INV-6 一切皆 Skill** — 事件提取通过 Skill 定义进入
- [x] **INV-7 统一入口** — 仍通过现有 orchestrated AI 路径装配 hooks
- [x] **INV-8 Hook 链** — episodic-extract 已接入 post-writing hooks
- [x] **INV-9 成本追踪** — 未改变现有成本记录语义
- [x] **INV-10 错误不丢上下文** — hook 失败路径记录错误，不静默吞掉主链

---

## Validation Evidence

- `pnpm -C apps/desktop exec vitest run --config vitest.config.core.ts main/src/services/skills/__tests__/postWritingHooks.test.ts main/src/services/skills/__tests__/p3-skills.test.ts main/src/services/skills/__tests__/p3-runtime.execution.test.ts main/src/ipc/__tests__/ai-handlers-delegation.test.ts`
  - 结果：4 files passed, 109 tests passed
- `pnpm -C apps/desktop typecheck`
  - 结果：通过
- `git diff --check`
  - 结果：通过

## Visual Evidence

### Embedded Screenshots

N/A

### Storybook Artifact / Link

- Link: N/A
- Visual acceptance note: N/A

- [x] N/A（非前端改动）

## Risk & Rollback

- 风险：episodic hook 若输出结构不稳，可能导致新增 episode 质量不高，但不会阻断写作主链。
- 回滚：`git revert a44ac27` 即可整体回退本 PR 的代码与 playbook 同步。

## 审计门禁

**审计模型配置（1+1+1+Duck）：**
- 工程：Claude Opus 4.6 (high)
- 审计 1（同模型）：Claude Opus 4.6 (high)
- 审计 2：Claude Sonnet 4.6 (high)
- 审计 3（Rubber Duck）：GPT-5.4 (xhigh)
- 评论汇总：Claude Opus 4.6 (high)

- [ ] 审计 1（Claude Opus 4.6）：FINAL-VERDICT ___
- [ ] 审计 2（Claude Sonnet 4.6）：FINAL-VERDICT ___
- [ ] 审计 3（GPT-5.4）：FINAL-VERDICT ___

---

## Final Checklist

- [x] 全程在 `.worktrees/issue-190-p4-01-fu-episodic-skills` 中完成
- [x] `pnpm typecheck` 通过
- [x] 相关测试通过
- [x] 无 `any` 类型
- [x] 前端改动：Storybook 可构建、无硬编码颜色/间距、新组件有 Story（N/A）
